### PR TITLE
Watchlist builtins

### DIFF
--- a/piker/cli.py
+++ b/piker/cli.py
@@ -159,7 +159,7 @@ def show(ctx, name):
 @click.pass_context
 def load(ctx, data):
     try:
-        wl.write_sorted_json(json.loads(data), ctx.obj['path'])
+        wl.write_to_file(json.loads(data), ctx.obj['path'])
     except (json.JSONDecodeError, IndexError):
         click.echo('You have passed an invalid text respresentation of a '
                    'JSON object. Try again.')
@@ -172,7 +172,7 @@ def load(ctx, data):
 def add(ctx, name, ticker_name):
     watchlist = wl.add_ticker(name, ticker_name,
                               ctx.obj['watchlist'])
-    wl.write_sorted_json(watchlist, ctx.obj['path'])
+    wl.write_to_file(watchlist, ctx.obj['path'])
 
 
 @watchlists.command(help='remove ticker from watchlist')
@@ -181,7 +181,7 @@ def add(ctx, name, ticker_name):
 @click.pass_context
 def remove(ctx, name, ticker_name):
     watchlist = wl.remove_ticker(name, ticker_name, ctx.obj['watchlist'])
-    wl.write_sorted_json(watchlist, ctx.obj['path'])
+    wl.write_to_file(watchlist, ctx.obj['path'])
 
 
 @watchlists.command(help='delete watchlist group')
@@ -189,7 +189,7 @@ def remove(ctx, name, ticker_name):
 @click.pass_context
 def delete(ctx, name):
     watchlist = wl.delete_group(name, ctx.obj['watchlist'])
-    wl.write_sorted_json(watchlist, ctx.obj['path'])
+    wl.write_to_file(watchlist, ctx.obj['path'])
 
 
 @watchlists.command(help='merge a watchlist from another user')
@@ -198,7 +198,7 @@ def delete(ctx, name):
 def merge(ctx, watchlist_to_merge):
     merged_watchlist = wl.merge_watchlist(json.loads(watchlist_to_merge),
                                           ctx.obj['watchlist'])
-    wl.write_sorted_json(merged_watchlist, ctx.obj['path'])
+    wl.write_to_file(merged_watchlist, ctx.obj['path'])
 
 
 @watchlists.command(help='dump text respresentation of a watchlist to console')

--- a/piker/cli.py
+++ b/piker/cli.py
@@ -120,35 +120,15 @@ def watch(loglevel, broker, rate, name):
     from .ui.watchlist import _async_main
     log = get_console_log(loglevel)  # activate console logging
     brokermod = get_brokermod(broker)
-
-    watchlists_base = {
-        'cannabis': [
-            'EMH.VN', 'LEAF.TO', 'HVT.VN', 'HMMJ.TO', 'APH.TO',
-            'CBW.VN', 'TRST.CN', 'VFF.TO', 'ACB.TO', 'ABCN.VN',
-            'APH.TO', 'MARI.CN', 'WMD.VN', 'LEAF.TO', 'THCX.VN',
-            'WEED.TO', 'NINE.VN', 'RTI.VN', 'SNN.CN', 'ACB.TO',
-            'OGI.VN', 'IMH.VN', 'FIRE.VN', 'EAT.CN',
-            'WMD.VN', 'HEMP.VN', 'CALI.CN', 'RQB.CN', 'MPX.CN',
-            'SEED.TO', 'HMJR.TO', 'CMED.TO', 'PAS.VN',
-            'CRON',
-        ],
-        'dad': ['GM', 'TSLA', 'DOL.TO', 'CIM', 'SPY', 'SHOP.TO'],
-        'pharma': ['ATE.VN'],
-        'indexes': ['SPY', 'DAX', 'QQQ', 'DIA'],
-    }
     watchlist_from_file = wl.ensure_watchlists(_watchlists_data_path)
-    watchlists = wl.merge_watchlist(watchlist_from_file, watchlists_base)
-    # broker_conf_path = os.path.join(
-    #     click.get_app_dir('piker'), 'watchlists.json')
-    # from piker.testing import _quote_streamer as brokermod
+    watchlists = wl.merge_watchlist(watchlist_from_file, wl._builtins)
     broker_limit = getattr(brokermod, '_rate_limit', float('inf'))
+
     if broker_limit < rate:
         rate = broker_limit
         log.warn(f"Limiting {brokermod.__name__} query rate to {rate}/sec")
+
     trio.run(_async_main, name, watchlists[name], brokermod, rate)
-    # broker_conf_path = os.path.join(
-    #     click.get_app_dir('piker'), 'watchlists.json')
-    # from piker.testing import _quote_streamer as brokermod
 
 
 @cli.group()

--- a/piker/watchlists.py
+++ b/piker/watchlists.py
@@ -36,10 +36,9 @@ def add_ticker(name, ticker_name, watchlist):
 
 
 def remove_ticker(name, ticker_name, watchlist):
-    if name in watchlist:
-        watchlist[name].remove(str(ticker_name).upper())
-        if watchlist[name] == []:
-            del watchlist[name]
+    watchlist[name].remove(str(ticker_name).upper())
+    if watchlist[name] == []:
+        del watchlist[name]
     return watchlist
 
 

--- a/piker/watchlists.py
+++ b/piker/watchlists.py
@@ -11,7 +11,7 @@ _builtins = {
 }
 
 
-def write_sorted_json(watchlist, path):
+def write_to_file(watchlist, path):
     for key in watchlist:
         watchlist[key] = sorted(list(set(watchlist[key])))
     with open(path, 'w') as f:

--- a/piker/watchlists.py
+++ b/piker/watchlists.py
@@ -6,12 +6,16 @@ from .log import get_logger
 
 log = get_logger(__name__)
 
+_builtins = {
+    'indexes': ['SPY', 'DAX', 'QQQ', 'DIA'],
+}
+
 
 def write_sorted_json(watchlist, path):
     for key in watchlist:
         watchlist[key] = sorted(list(set(watchlist[key])))
     with open(path, 'w') as f:
-        json.dump(watchlist, f, sort_keys=True)
+        json.dump(watchlist, f, sort_keys=True, indent=4)
 
 
 def make_config_dir(dir_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,7 +112,7 @@ def piker_dir(temp_dir):
         'pharma': ['ATE.VN'],
         'indexes': ['SPY', 'DAX', 'QQQ', 'DIA'],
     }
-    wl.write_sorted_json(watchlist, json_file_path)
+    wl.write_to_file(watchlist, json_file_path)
     yield json_file_path
 
 
@@ -201,7 +201,7 @@ def test_watchlists_are_merged(capfd, piker_dir):
         'pharma': ['ATE.VN', 'MALI', 'PERCOCET'],
         'drugs': ['CRACK']
     }
-    wl.write_sorted_json(orig_watchlist, piker_dir)
+    wl.write_to_file(orig_watchlist, piker_dir)
     run(f"piker watchlists -d {piker_dir} merge", list_to_merge)
     out = wl.ensure_watchlists(piker_dir)
     assert out == expected_out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,11 +6,8 @@ import subprocess
 import pytest
 import tempfile
 import os.path
-import logging
 
 import piker.watchlists as wl
-import piker.cli as cli
-from piker.log import colorize_json
 
 
 def run(cmd, *args):
@@ -104,71 +101,77 @@ def temp_dir():
 
 
 @pytest.fixture
-def piker_dir(temp_dir):
+def ex_watchlists():
+    """Made up watchlists to use for expected outputs.
+    """
+    watchlists = {
+        'dad': list(sorted(['GM', 'TSLA', 'DOL.TO', 'CIM', 'SPY', 'SHOP.TO'])),
+        'pharma': ['ATE.VN'],
+    }
+    return watchlists
+
+
+@pytest.fixture
+def ex_watchlists_wbi(ex_watchlists):
+    """Made up watchlists + built-in list(s) to use for expected outputs.
+    """
+    with_builtins = ex_watchlists.copy()
+    with_builtins.update(wl._builtins)
+    return with_builtins
+
+
+@pytest.fixture
+def piker_dir(temp_dir, ex_watchlists):
     wl.make_config_dir(temp_dir)
     json_file_path = os.path.join(temp_dir, 'watchlists.json')
-    watchlist = {
-        'dad': ['GM', 'TSLA', 'DOL.TO', 'CIM', 'SPY', 'SHOP.TO'],
-        'pharma': ['ATE.VN'],
-        'indexes': ['SPY', 'DAX', 'QQQ', 'DIA'],
-    }
-    wl.write_to_file(watchlist, json_file_path)
+    # push test watchlists to file without built-ins
+    to_write = ex_watchlists.copy()
+    wl.write_to_file(to_write, json_file_path)
     yield json_file_path
 
 
-def test_show_watchlists(capfd, piker_dir):
-    """Ensure a watchlist is printed.
+def test_show_watchlists(capfd, piker_dir, ex_watchlists_wbi):
+    """Ensure all watchlists are printed as json to stdout.
+
+    (Can't seem to get pretty formatting to work, pytest thing?)
     """
-    expected_out = json.dumps({
-        'dad': ['CIM', 'DOL.TO', 'GM', 'SHOP.TO', 'SPY', 'TSLA'],
-        'indexes': ['DAX', 'DIA', 'QQQ', 'SPY'],
-        'pharma': ['ATE.VN'],
-    }, indent=4)
+    expected_out = json.dumps(ex_watchlists_wbi, indent=4, sort_keys=True)
     run(f"piker watchlists -d {piker_dir} show")
     out, err = capfd.readouterr()
     assert out.strip() == expected_out
 
 
-def test_dump_watchlists(capfd, piker_dir):
-    """Ensure watchlist is dumped.
+def test_dump_watchlists(capfd, piker_dir, ex_watchlists):
+    """Ensure watchlist is dumped without built-in lists.
     """
-    expected_out = json.dumps({
-        'dad': ['CIM', 'DOL.TO', 'GM', 'SHOP.TO', 'SPY', 'TSLA'],
-        'indexes': ['DAX', 'DIA', 'QQQ', 'SPY'],
-        'pharma': ['ATE.VN'],
-    })
+    expected_out = json.dumps(ex_watchlists)
     run(f"piker watchlists -d {piker_dir} dump")
     out, err = capfd.readouterr()
     assert out.strip() == expected_out
 
 
-def test_ticker_added_to_watchlists(capfd, piker_dir):
-    expected_out = {
-        'dad': ['CIM', 'DOL.TO', 'GM', 'SHOP.TO', 'SPY', 'TSLA'],
-        'indexes': ['DAX', 'DIA', 'QQQ', 'SPY'],
-        'pharma': ['ATE.VN', 'CRACK'],
-    }
+def test_ticker_added_to_watchlists(capfd, piker_dir, ex_watchlists):
+    ex_watchlists['pharma'].append('CRACK')
     run(f"piker watchlists -d {piker_dir} add pharma CRACK")
     out = wl.ensure_watchlists(piker_dir)
-    assert out == expected_out
+    assert out == ex_watchlists
 
 
-def test_ticker_removed_from_watchlists(capfd, piker_dir):
-    expected_out = {
-        'dad': ['CIM', 'DOL.TO', 'GM', 'SHOP.TO', 'SPY', 'TSLA'],
-        'indexes': ['DAX', 'DIA', 'SPY'],
-        'pharma': ['ATE.VN'],
-    }
-    run(f"piker watchlists -d {piker_dir} remove indexes QQQ")
+def test_ticker_removed_from_watchlists(capfd, piker_dir, ex_watchlists):
+    expected_out = ex_watchlists.copy()
+    expected_out['dad'].remove('SPY')
+    run(f"piker watchlists -d {piker_dir} remove dad SPY")
     out = wl.ensure_watchlists(piker_dir)
     assert out == expected_out
 
+    # removing a non-entry should be a no-op
+    run(f"piker watchlists -d {piker_dir} remove dad SPY")
+    out = wl.ensure_watchlists(piker_dir)
 
-def test_group_deleted_from_watchlists(capfd, piker_dir):
-    expected_out = {
-        'dad': ['CIM', 'DOL.TO', 'GM', 'SHOP.TO', 'SPY', 'TSLA'],
-        'indexes': ['DAX', 'DIA', 'QQQ', 'SPY'],
-    }
+
+def test_group_deleted_from_watchlists(capfd, piker_dir, ex_watchlists):
+    expected_out = ex_watchlists.copy()
+    expected_out.pop('pharma')
     run(f"piker watchlists -d {piker_dir} delete pharma")
     out = wl.ensure_watchlists(piker_dir)
     assert out == expected_out

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -83,6 +83,14 @@ def test_ticker_is_removed():
     assert wl_temp == {'test': ['TEST2.CN']}
     assert not wl_temp.get('test2')
 
+    # verify trying to remove from nonexistant list
+    with pytest.raises(KeyError):
+        wl.remove_ticker('doggy', 'TEST.CN', wl_temp)
+
+    # verify trying to remove non-existing ticker
+    with pytest.raises(ValueError):
+        wl.remove_ticker('test', 'TEST.CN', wl_temp)
+
 
 def test_group_is_deleted():
     """Check that watchlist group is removed.

--- a/tests/test_watchlists.py
+++ b/tests/test_watchlists.py
@@ -30,7 +30,7 @@ def test_watchlist_is_sorted_no_dups_and_saved_to_file(piker_dir):
     wl_temp = {'test': ['TEST.CN', 'AAA'], 'AA': ['TEST.CN', 'TEST.CN'],
                'AA': ['TEST.CN']}
     wl_sort = {'AA': ['TEST.CN'], 'test': ['AAA', 'TEST.CN']}
-    wl.write_sorted_json(wl_temp, piker_dir)
+    wl.write_to_file(wl_temp, piker_dir)
     temp_sorted = wl.ensure_watchlists(piker_dir)
     assert temp_sorted == wl_sort
 
@@ -60,7 +60,7 @@ def test_watchlist_is_read_from_file(piker_dir):
     wl_temp = wl.ensure_watchlists(piker_dir)
     assert wl_temp == {}
     wl_temp2 = {"AA": ["TEST.CN"]}
-    wl.write_sorted_json(wl_temp2, piker_dir)
+    wl.write_to_file(wl_temp2, piker_dir)
     assert wl_temp2 == wl.ensure_watchlists(piker_dir)
 
 


### PR DESCRIPTION
Move the built-ins watchlists to a module variable. I also adjusted some things in `piker.watchlists` mostly to raise errors when removing non-existing entries.  Adjusted the tests to match.

Oh and I added a little extra logic to only report when the network *first* goes down and then comes back up instead of repeatedly spamming the same message to the console.

@Konstantine00 please give this a quick review if you can as it touches much of what you worked on.