### PR TITLE
Daemonize broker quote engine

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,15 @@ broker quote query ``rate`` with ``-r``::
     piker watch indexes -l info -r 10
 
 
+It is also possible to run the broker-client micro service as a daemon::
+
+    pikerd -l info
+
+Then start the client app as normal::
+
+    piker watch indexes -l info
+
+
 .. _trio: https://github.com/python-trio/trio
 .. _pipenv: https://docs.pipenv.org/
 

--- a/piker/brokers/__init__.py
+++ b/piker/brokers/__init__.py
@@ -13,7 +13,10 @@ __brokers__ = [
 def get_brokermod(brokername: str) -> ModuleType:
     """Return the imported broker module by name.
     """
-    return import_module('.' + brokername, 'piker.brokers')
+    module = import_module('.' + brokername, 'piker.brokers')
+    # we only allows monkeys because it's for internal keying
+    module.name =  module.__name__.split('.')[-1]
+    return module
 
 
 def iter_brokermods():

--- a/piker/brokers/core.py
+++ b/piker/brokers/core.py
@@ -12,6 +12,7 @@ from typing import AsyncContextManager
 import trio
 
 from ..log import get_logger
+from . import get_brokermod
 log = get_logger('broker.core')
 
 
@@ -126,10 +127,8 @@ class StreamQueue:
 
 
 async def poll_tickers(
-    client: 'Client',
-    quoter: AsyncContextManager,
-    tickers: [str],
-    queue: StreamQueue,
+    brokermod: ModuleType,
+    tickers2qs: {str: StreamQueue},
     rate: int = 5,  # delay between quote requests
     diff_cached: bool = True,  # only deliver "new" quotes to the queue
 ) -> None:
@@ -142,107 +141,129 @@ async def poll_tickers(
     sleeptime = round(1. / rate, 3)
     _cache = {}  # ticker to quote caching
 
-    async with quoter(client, tickers) as get_quotes:
-        # run a first quote smoke test filtering out any bad tickers
-        first_quotes_dict = await get_quotes(tickers)
-        # FIXME: oh god it's so hideous
-        tickers[:] = list(first_quotes_dict.keys())[:]
-
-        while True:  # use an event here to trigger exit?
-            prequote_start = time.time()
-
-            with trio.move_on_after(3) as cancel_scope:
-                quotes = await get_quotes(tickers)
-
-            cancelled = cancel_scope.cancelled_caught
-            if cancelled:
-                log.warn("Quote query timed out after 3 seconds, retrying...")
-                # handle network outages by idling until response is received
-                quotes = await wait_for_network(partial(get_quotes, tickers))
-
-            postquote_start = time.time()
-            payload = {}
-            for symbol, quote in quotes.items():
-                # FIXME: None is returned if a symbol can't be found.
-                # Consider filtering out such symbols before starting poll loop
-                if quote is None:
-                    continue
-
-                if diff_cached:
-                    # if cache is enabled then only deliver "new" changes
-                    last = _cache.setdefault(symbol, {})
-                    new = set(quote.items()) - set(last.items())
-                    if new:
-                        log.info(
-                            f"New quote {quote['symbol']}:\n{new}")
-                        _cache[symbol] = quote
-                        payload[symbol] = quote
-                else:
-                    payload[symbol] = quote
-
-            if payload:
-                await queue.put(payload)
-
-            req_time = round(postquote_start - prequote_start, 3)
-            proc_time = round(time.time() - postquote_start, 3)
-            tot = req_time + proc_time
-            log.debug(f"Request + processing took {tot}")
-            delay = sleeptime - tot
-            if delay <= 0:
-                log.warn(
-                    f"Took {req_time} (request) + {proc_time} (processing) "
-                    f"= {tot} secs (> {sleeptime}) for processing quotes?")
-            else:
-                log.debug(f"Sleeping for {delay}")
-                await trio.sleep(delay)
-
-
-async def _handle_subs(
-    queue,
-    stream2tickers,
-    nursery,
-    task_status=trio.TASK_STATUS_IGNORED
-):
-    """Handle quote stream subscriptions.
-    """
-    async with queue.stream:
-        async for tickers in queue:
-            task_status.started(tickers)
-            log.info(f"{queue.peer} subscribed for tickers {tickers}")
-            stream2tickers[queue.peer] = tickers
-        else:
-            log.info(f"{queue.peer} was disconnected")
-            nursery.cancel_scope.cancel()
-
-
-async def _daemon_main(brokermod):
-    """Main entry point for the piker daemon.
-    """
-    rate = 5
     broker_limit = getattr(brokermod, '_rate_limit', float('inf'))
     if broker_limit < rate:
         rate = broker_limit
         log.warn(f"Limiting {brokermod.__name__} query rate to {rate}/sec")
 
-    stream2tickers = {}
+    tickers = list(tickers2qs.keys())
+
     async with brokermod.get_client() as client:
+        async with brokermod.quoter(client, tickers) as get_quotes:
+            # run a first quote smoke test filtering out any bad tickers
+            first_quotes_dict = await get_quotes(tickers)
+            valid_symbols = list(first_quotes_dict.keys())[:]
 
-        async def start_quoter(stream):
-            queue = StreamQueue(stream)  # wrap in a shabby queue-like api
-            log.debug(f"Accepted new connection from {queue.peer}")
+            for ticker in set(tickers) - set(valid_symbols):
+                tickers2qs.pop(ticker)
 
-            # spawn request handler
-            async with trio.open_nursery() as nursery:
-                await nursery.start(
-                    _handle_subs, queue, stream2tickers, nursery)
-                nursery.start_soon(
-                    partial(
-                        poll_tickers, client, brokermod.quoter,
-                        stream2tickers[queue.peer], queue, rate=rate)
-                )
+            # push intial quotes
+            q_payloads = {}
+            for symbol, quote in first_quotes_dict.items():
+                if quote is None:
+                    tickers2qs.pop(symbol)
+                    continue
+                for queue in tickers2qs[symbol]:
+                    q_payloads.setdefault(queue, {})[symbol] = quote
 
-        async with trio.open_nursery() as nursery:
-            listeners = await nursery.start(
-                partial(trio.serve_tcp, start_quoter, 1616, host='127.0.0.1')
-            )
-            log.debug(f"Spawned {listeners}")
+            if q_payloads:
+                for queue, payload in q_payloads.items():
+                    await queue.put(payload)
+
+            # assign valid symbol set
+            tickers = list(tickers2qs.keys())
+
+            while True:  # use an event here to trigger exit?
+                prequote_start = time.time()
+
+                with trio.move_on_after(3) as cancel_scope:
+                    quotes = await get_quotes(valid_symbols)
+
+                cancelled = cancel_scope.cancelled_caught
+                if cancelled:
+                    log.warn("Quote query timed out after 3 seconds, retrying...")
+                    # handle network outages by idling until response is received
+                    quotes = await wait_for_network(partial(get_quotes, tickers))
+
+                postquote_start = time.time()
+                q_payloads = {}
+                for symbol, quote in quotes.items():
+                    # FIXME: None is returned if a symbol can't be found.
+                    # Consider filtering out such symbols before starting poll loop
+                    if quote is None:
+                        continue
+
+                    if diff_cached:
+                        # if cache is enabled then only deliver "new" changes
+                        last = _cache.setdefault(symbol, {})
+                        new = set(quote.items()) - set(last.items())
+                        if new:
+                            log.info(
+                                f"New quote {quote['symbol']}:\n{new}")
+                            _cache[symbol] = quote
+                            for queue in tickers2qs[symbol]:
+                                q_payloads.setdefault(queue, {})[symbol] = quote
+                    else:
+                        for queue in tickers2qs[symbol]:
+                            q_payloads[queue] = {symbol: quote}
+
+                # deliver to each subscriber
+                if q_payloads:
+                    for queue, payload in q_payloads.items():
+                        await queue.put(payload)
+
+                req_time = round(postquote_start - prequote_start, 3)
+                proc_time = round(time.time() - postquote_start, 3)
+                tot = req_time + proc_time
+                log.debug(f"Request + processing took {tot}")
+                delay = sleeptime - tot
+                if delay <= 0:
+                    log.warn(
+                        f"Took {req_time} (request) + {proc_time} (processing) "
+                        f"= {tot} secs (> {sleeptime}) for processing quotes?")
+                else:
+                    log.debug(f"Sleeping for {delay}")
+                    await trio.sleep(delay)
+
+
+async def start_quoter(stream):
+    """Handle per-broker quote stream subscriptions.
+    """
+    broker2tickersubs = {}
+    tickers2qs = {}
+
+    queue = StreamQueue(stream)  # wrap in a shabby queue-like api
+    log.debug(f"Accepted new connection from {queue.peer}")
+    async with trio.open_nursery() as nursery:
+        async with queue.stream:
+            async for (broker, tickers) in queue:
+                log.info(
+                    f"{queue.peer} subscribed to {broker} for tickers {tickers}")
+
+                if broker not in broker2tickersubs:  # spawn quote streamer
+                    tickers2qs = broker2tickersubs.setdefault(broker, {})
+                    brokermod = get_brokermod(broker)
+                    log.info(f"Spawning quote streamer for broker {broker}")
+                    # task should begin on the next checkpoint/iteration
+                    nursery.start_soon(poll_tickers, brokermod, tickers2qs)
+
+                # create map from each symbol to consuming client queues
+                for ticker in tickers:
+                    tickers2qs.setdefault(ticker, set()).add(queue)
+
+                # remove queue from any ticker subscriptions it no longer wants
+                for ticker in set(tickers2qs) - set(tickers):
+                    tickers2qs[ticker].remove(queue)
+            else:
+                log.info(f"{queue.peer} was disconnected")
+                nursery.cancel_scope.cancel()
+
+
+async def _daemon_main(brokermod):
+    """Entry point for the piker daemon.
+    """
+    async with trio.open_nursery() as nursery:
+        listeners = await nursery.start(
+            partial(trio.serve_tcp, start_quoter, 1616, host='127.0.0.1')
+        )
+        log.debug(f"Spawned {listeners}")

--- a/piker/brokers/core.py
+++ b/piker/brokers/core.py
@@ -139,13 +139,13 @@ async def poll_tickers(
     A broker-client ``quoter`` async context manager must be provided which
     returns an async quote function.
     """
-    sleeptime = round(1. / rate, 3)
-    _cache = {}  # ticker to quote caching
-
     broker_limit = getattr(brokermod, '_rate_limit', float('inf'))
     if broker_limit < rate:
         rate = broker_limit
         log.warn(f"Limiting {brokermod.__name__} query rate to {rate}/sec")
+
+    sleeptime = round(1. / rate, 3)
+    _cache = {}  # ticker to quote caching
 
     while True:  # use an event here to trigger exit?
         prequote_start = time.time()

--- a/piker/brokers/core.py
+++ b/piker/brokers/core.py
@@ -333,8 +333,9 @@ async def start_quoter(stream: trio.SocketStream) -> None:
                 await client.__aexit__()
 
 
-async def _daemon_main(brokermod: ModuleType) -> None:
-    """Entry point for the broker daemon.
+async def _daemon_main() -> None:
+    """Entry point for the broker daemon which waits for connections
+    before spawning micro-services.
     """
     async with trio.open_nursery() as nursery:
         listeners = await nursery.start(

--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -284,7 +284,6 @@ async def get_client() -> Client:
         write_conf(client)
 
 
-@asynccontextmanager
 async def quoter(client: Client, tickers: [str]):
     """Quoter context.
     """
@@ -328,7 +327,7 @@ async def quoter(client: Client, tickers: [str]):
             quotes[quote['symbol']] = quote
 
             if quote.get('delay', 0) > 0:
-                log.warning(f"Delayed quote:\n{quote}")
+                log.warn(f"Delayed quote:\n{quote}")
 
         return quotes
 
@@ -338,7 +337,7 @@ async def quoter(client: Client, tickers: [str]):
     # re-save symbol ids cache
     ids = ','.join(map(str, t2ids.values()))
 
-    yield get_quote
+    return get_quote
 
 
 # Questrade key conversion / column order

--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -307,7 +307,7 @@ async def quoter(client: Client, tickers: [str]):
         new, current = set(tickers), set(t2ids.keys())
         if new != current:
             # update ticker ids cache
-            log.info(f"Tickers set changed {new - current}")
+            log.debug(f"Tickers set changed {new - current}")
             t2ids = await client.tickers2ids(tickers)
             ids = ','.join(map(str, t2ids.values()))
 

--- a/piker/brokers/robinhood.py
+++ b/piker/brokers/robinhood.py
@@ -72,11 +72,10 @@ async def get_client() -> Client:
     yield Client()
 
 
-@asynccontextmanager
 async def quoter(client: Client, tickers: [str]):
     """Quoter context.
     """
-    yield client.quote
+    return client.quote
 
 
 # Robinhood key conversion / column order

--- a/piker/cli.py
+++ b/piker/cli.py
@@ -134,12 +134,6 @@ def watch(loglevel, broker, rate, name):
     brokermod = get_brokermod(broker)
     watchlist_from_file = wl.ensure_watchlists(_watchlists_data_path)
     watchlists = wl.merge_watchlist(watchlist_from_file, wl._builtins)
-    broker_limit = getattr(brokermod, '_rate_limit', float('inf'))
-
-    if broker_limit < rate:
-        rate = broker_limit
-        log.warn(f"Limiting {brokermod.__name__} query rate to {rate}/sec")
-
     trio.run(_async_main, name, watchlists[name], brokermod, rate)
 
 

--- a/piker/cli.py
+++ b/piker/cli.py
@@ -35,6 +35,18 @@ def run(main, loglevel='info'):
         log.debug("Exiting piker")
 
 
+@click.command()
+@click.option('--broker', '-b', default=DEFAULT_BROKER,
+              help='Broker backend to use')
+@click.option('--loglevel', '-l', default='warning', help='Logging level')
+def pikerd(broker, loglevel):
+    """Spawn the piker daemon.
+    """
+    from piker.brokers.core import _daemon_main
+    brokermod = get_brokermod(broker)
+    run(partial(_daemon_main, brokermod), loglevel)
+
+
 @click.group()
 def cli():
     pass

--- a/piker/cli.py
+++ b/piker/cli.py
@@ -171,7 +171,7 @@ def watch(loglevel, broker, rate, name):
     try:
         trio.run(main)
     except OSError as oserr:
-        log.error(oserr)
+        log.warn(oserr)
         log.info("Spawning local broker-daemon...")
         child = Process(
             target=run,

--- a/piker/ui/watchlist.py
+++ b/piker/ui/watchlist.py
@@ -382,86 +382,77 @@ async def run_kivy(root, nursery):
     nursery.cancel_scope.cancel()  # cancel all other tasks that may be running
 
 
-async def _async_main(name, tickers, brokermod, rate):
+async def _async_main(name, client, tickers, brokermod, rate):
     '''Launch kivy app + all other related tasks.
 
     This is started with cli command `piker watch`.
     '''
-    # setup ticker stream
-    from ..brokers.core import Client
+    # get initial symbol data
+    async with brokermod.get_client() as bclient:
+        # get long term data including last days close price
+        sd = await bclient.symbol_data(tickers)
 
-    async def subscribe(client):
-        # initial request for symbols price streams
-        await client.send((brokermod.name, tickers))
+    async with trio.open_nursery() as nursery:
+        # get first quotes response
+        quotes = await client.recv()
+        first_quotes = [
+            brokermod.format_quote(quote, symbol_data=sd)[0]
+            for quote in quotes.values()]
 
-    async with Client(('127.0.0.1', 1616), subscribe) as client:
+        if first_quotes[0].get('last') is None:
+            log.error("Broker API is down temporarily")
+            nursery.cancel_scope.cancel()
+            return
 
-        # get initial symbol data
-        async with brokermod.get_client() as bclient:
-            # get long term data including last days close price
-            sd = await bclient.symbol_data(tickers)
+        # build out UI
+        Window.set_title(f"watchlist: {name}\t(press ? for help)")
+        Builder.load_string(_kv)
+        box = BoxLayout(orientation='vertical', padding=5, spacing=5)
 
-        async with trio.open_nursery() as nursery:
-            # get first quotes response
-            quotes = await client.recv()
-            first_quotes = [
-                brokermod.format_quote(quote, symbol_data=sd)[0]
-                for quote in quotes.values()]
+        # define bid-ask "stacked" cells
+        # (TODO: needs some rethinking and renaming for sure)
+        bidasks = brokermod._bidasks
 
-            if first_quotes[0].get('last') is None:
-                log.error("Broker API is down temporarily")
-                nursery.cancel_scope.cancel()
-                return
+        # add header row
+        headers = first_quotes[0].keys()
+        header = Row(
+            {key: key for key in headers},
+            headers=headers,
+            bidasks=bidasks,
+            is_header_row=True,
+            size_hint=(1, None),
+        )
+        box.add_widget(header)
 
-            # build out UI
-            Window.set_title(f"watchlist: {name}\t(press ? for help)")
-            Builder.load_string(_kv)
-            box = BoxLayout(orientation='vertical', padding=5, spacing=5)
+        # build grid
+        grid = TickerTable(
+            cols=1,
+            size_hint=(1, None),
+        )
+        for ticker_record in first_quotes:
+            grid.append_row(ticker_record, bidasks=bidasks)
+        # associate the col headers row with the ticker table even though
+        # they're technically wrapped separately in containing BoxLayout
+        header.table = grid
 
-            # define bid-ask "stacked" cells
-            # (TODO: needs some rethinking and renaming for sure)
-            bidasks = brokermod._bidasks
+        # mark the initial sorted column header as bold and underlined
+        sort_cell = header.get_cell(grid.sort_key)
+        sort_cell.bold = sort_cell.underline = True
+        grid.last_clicked_col_cell = sort_cell
 
-            # add header row
-            headers = first_quotes[0].keys()
-            header = Row(
-                {key: key for key in headers},
-                headers=headers,
-                bidasks=bidasks,
-                is_header_row=True,
-                size_hint=(1, None),
-            )
-            box.add_widget(header)
+        # set up a pager view for large ticker lists
+        grid.bind(minimum_height=grid.setter('height'))
+        pager = PagerView(box, grid, nursery)
+        box.add_widget(pager)
 
-            # build grid
-            grid = TickerTable(
-                cols=1,
-                size_hint=(1, None),
-            )
-            for ticker_record in first_quotes:
-                grid.append_row(ticker_record, bidasks=bidasks)
-            # associate the col headers row with the ticker table even though
-            # they're technically wrapped separately in containing BoxLayout
-            header.table = grid
-
-            # mark the initial sorted column header as bold and underlined
-            sort_cell = header.get_cell(grid.sort_key)
-            sort_cell.bold = sort_cell.underline = True
-            grid.last_clicked_col_cell = sort_cell
-
-            # set up a pager view for large ticker lists
-            grid.bind(minimum_height=grid.setter('height'))
-            pager = PagerView(box, grid, nursery)
-            box.add_widget(pager)
-
-            widgets = {
-                # 'anchor': anchor,
-                'root': box,
-                'grid': grid,
-                'box': box,
-                'header': header,
-                'pager': pager,
-            }
-            nursery.start_soon(run_kivy, widgets['root'], nursery)
-            nursery.start_soon(
-                update_quotes, nursery, brokermod, widgets, client, sd, quotes)
+        widgets = {
+            # 'anchor': anchor,
+            'root': box,
+            'grid': grid,
+            'box': box,
+            'header': header,
+            'pager': pager,
+        }
+        nursery.start_soon(run_kivy, widgets['root'], nursery)
+        nursery.start_soon(
+            update_quotes, nursery, brokermod, widgets, client, sd, quotes)

--- a/piker/ui/watchlist.py
+++ b/piker/ui/watchlist.py
@@ -7,7 +7,6 @@ Launch with ``piker watch <watchlist name>``.
 """
 from itertools import chain
 from types import ModuleType
-from functools import partial
 
 import trio
 from kivy.uix.boxlayout import BoxLayout
@@ -21,7 +20,6 @@ from kivy.core.window import Window
 
 from ..log import get_logger
 from .pager import PagerView
-from ..brokers.core import poll_tickers
 
 log = get_logger('watchlist')
 
@@ -49,7 +47,7 @@ _kv = (f'''
 #:kivy 1.10.0
 
 <Cell>
-    font_size: 18
+    font_size: 20
     # text_size: self.size
     size: self.texture_size
     color: {colorcode('gray')}
@@ -386,77 +384,77 @@ async def _async_main(name, tickers, brokermod, rate):
 
     This is started with cli command `piker watch`.
     '''
-    queue = trio.Queue(1000)
+    # setup ticker stream
+    from ..brokers.core import StreamQueue
+    queue = StreamQueue(await trio.open_tcp_stream('127.0.0.1', 1616))
+    await queue.put(tickers)  # initial request for symbols price streams
+
+    # get initial symbol data
     async with brokermod.get_client() as client:
-        async with trio.open_nursery() as nursery:
-            # get long term data including last days close price
-            sd = await client.symbol_data(tickers)
+        # get long term data including last days close price
+        sd = await client.symbol_data(tickers)
 
-            nursery.start_soon(
-                partial(poll_tickers, client, brokermod.quoter, tickers, queue,
-                        rate=rate)
-            )
+    async with trio.open_nursery() as nursery:
+        # get first quotes response
+        quotes = await queue.get()
+        first_quotes = [
+            brokermod.format_quote(quote, symbol_data=sd)[0]
+            for quote in quotes.values()]
 
-            # get first quotes response
-            quotes = await queue.get()
-            first_quotes = [
-                brokermod.format_quote(quote, symbol_data=sd)[0]
-                for quote in quotes.values()]
+        if first_quotes[0].get('last') is None:
+            log.error("Broker API is down temporarily")
+            nursery.cancel_scope.cancel()
+            return
 
-            if first_quotes[0].get('last') is None:
-                log.error("Broker API is down temporarily")
-                nursery.cancel_scope.cancel()
-                return
+        # build out UI
+        Window.set_title(f"watchlist: {name}\t(press ? for help)")
+        Builder.load_string(_kv)
+        box = BoxLayout(orientation='vertical', padding=5, spacing=5)
 
-            # build out UI
-            Window.set_title(f"watchlist: {name}\t(press ? for help)")
-            Builder.load_string(_kv)
-            box = BoxLayout(orientation='vertical', padding=5, spacing=5)
+        # define bid-ask "stacked" cells
+        # (TODO: needs some rethinking and renaming for sure)
+        bidasks = brokermod._bidasks
 
-            # define bid-ask "stacked" cells
-            # (TODO: needs some rethinking and renaming for sure)
-            bidasks = brokermod._bidasks
+        # add header row
+        headers = first_quotes[0].keys()
+        header = Row(
+            {key: key for key in headers},
+            headers=headers,
+            bidasks=bidasks,
+            is_header_row=True,
+            size_hint=(1, None),
+        )
+        box.add_widget(header)
 
-            # add header row
-            headers = first_quotes[0].keys()
-            header = Row(
-                {key: key for key in headers},
-                headers=headers,
-                bidasks=bidasks,
-                is_header_row=True,
-                size_hint=(1, None),
-            )
-            box.add_widget(header)
+        # build grid
+        grid = TickerTable(
+            cols=1,
+            size_hint=(1, None),
+        )
+        for ticker_record in first_quotes:
+            grid.append_row(ticker_record, bidasks=bidasks)
+        # associate the col headers row with the ticker table even though
+        # they're technically wrapped separately in containing BoxLayout
+        header.table = grid
 
-            # build grid
-            grid = TickerTable(
-                cols=1,
-                size_hint=(1, None),
-            )
-            for ticker_record in first_quotes:
-                grid.append_row(ticker_record, bidasks=bidasks)
-            # associate the col headers row with the ticker table even though
-            # they're technically wrapped separately in containing BoxLayout
-            header.table = grid
+        # mark the initial sorted column header as bold and underlined
+        sort_cell = header.get_cell(grid.sort_key)
+        sort_cell.bold = sort_cell.underline = True
+        grid.last_clicked_col_cell = sort_cell
 
-            # mark the initial sorted column header as bold and underlined
-            sort_cell = header.get_cell(grid.sort_key)
-            sort_cell.bold = sort_cell.underline = True
-            grid.last_clicked_col_cell = sort_cell
+        # set up a pager view for large ticker lists
+        grid.bind(minimum_height=grid.setter('height'))
+        pager = PagerView(box, grid, nursery)
+        box.add_widget(pager)
 
-            # set up a pager view for large ticker lists
-            grid.bind(minimum_height=grid.setter('height'))
-            pager = PagerView(box, grid, nursery)
-            box.add_widget(pager)
-
-            widgets = {
-                # 'anchor': anchor,
-                'root': box,
-                'grid': grid,
-                'box': box,
-                'header': header,
-                'pager': pager,
-            }
-            nursery.start_soon(run_kivy, widgets['root'], nursery)
-            nursery.start_soon(
-                update_quotes, brokermod, widgets, queue, sd, quotes)
+        widgets = {
+            # 'anchor': anchor,
+            'root': box,
+            'grid': grid,
+            'box': box,
+            'header': header,
+            'pager': pager,
+        }
+        nursery.start_soon(run_kivy, widgets['root'], nursery)
+        nursery.start_soon(
+            update_quotes, brokermod, widgets, queue, sd, quotes)

--- a/piker/ui/watchlist.py
+++ b/piker/ui/watchlist.py
@@ -394,6 +394,7 @@ async def _async_main(name, client, tickers, brokermod, rate):
 
     async with trio.open_nursery() as nursery:
         # get first quotes response
+        log.debug("Waiting on first quote...")
         quotes = await client.recv()
         first_quotes = [
             brokermod.format_quote(quote, symbol_data=sd)[0]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     },
     install_requires=[
         'click', 'colorlog', 'trio', 'attrs', 'async_generator',
-        'pygments', 'cython', 'asks', 'pandas',
+        'pygments', 'cython', 'asks', 'pandas', 'msgpack',
         #'kivy',  see requirement.txt; using a custom branch atm
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     entry_points={
         'console_scripts': [
             'piker = piker.cli:cli',
+            'pikerd = piker.cli:pikerd',
         ]
     },
     install_requires=[


### PR DESCRIPTION
Enables running the broker backends quote engine in a separate process and having clients subscribe for price streams wrapped in a queue api.

Still a WIP and I'll likely iterate on this a bit more but I wanted to get some eyes on it including:
- [x] making subscriptions per-broker (i.e. ticker lists should be broker specific for now)
- [x] using [`msgpack`](https://github.com/msgpack/msgpack-python) instead of `json`
- [x] spin up the daemon in a `multiprocessing.Process` if one is not already running and a client is launched? Maybe the same if the daemon crashes?
- [x] update docs showing how to launch the daemon and possibly print quotes to the console
- ~[ ] add a IPC way to tear down `trio.run()` launched in a subprocess~

Leave the last one. I think it's sensible to leave the child process daemon up when an app is torn down in case other apps still have live connections. Still need to figure out why the `SIGINT` isn't graceful in the subproc though...

Resolves #35

@Konstantine00 hint hint 