### PR TITLE
Multi ticker add

### DIFF
--- a/piker/cli.py
+++ b/piker/cli.py
@@ -206,11 +206,12 @@ def load(ctx, data):
 
 @watchlists.command(help='add ticker to watchlist')
 @click.argument('name', nargs=1, required=True)
-@click.argument('ticker_name', nargs=1, required=True)
+@click.argument('ticker_names', nargs=-1, required=True)
 @click.pass_context
-def add(ctx, name, ticker_name):
-    watchlist = wl.add_ticker(name, ticker_name,
-                              ctx.obj['watchlist'])
+def add(ctx, name, ticker_names):
+    for ticker in ticker_names:
+        watchlist = wl.add_ticker(
+            name, ticker, ctx.obj['watchlist'])
     wl.write_to_file(watchlist, ctx.obj['path'])
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,9 +150,15 @@ def test_dump_watchlists(capfd, piker_dir, ex_watchlists):
     assert out.strip() == expected_out
 
 
-def test_ticker_added_to_watchlists(capfd, piker_dir, ex_watchlists):
-    ex_watchlists['pharma'].append('CRACK')
-    run(f"piker watchlists -d {piker_dir} add pharma CRACK")
+@pytest.mark.parametrize(
+    'tickers', [('CRACK',), ('CRACK', 'SUIT',)]
+)
+def test_ticker_added_to_watchlists(capfd, piker_dir, ex_watchlists, tickers):
+    """Verify that single or multi-ticker lists can be added.
+    """
+    for ticker in tickers:
+        ex_watchlists['pharma'].append(ticker)
+    run(f"piker watchlists -d {piker_dir} add pharma {' '.join(tickers)}")
     out = wl.ensure_watchlists(piker_dir)
     assert out == ex_watchlists
 


### PR DESCRIPTION
@Konstantine00 just a very quick one to allow adding multiple tickers (delimited by spaces) using `piker watchlists <wl_name> add <ticker1> ticker2> ... <tickerN>`.