### PR TITLE
use >1 asks session connections

### DIFF
--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -212,7 +212,10 @@ class Client:
         self,
         config: dict,
     ):
-        self._sess = asks.Session()
+        # use 2 connections per streaming endpoint (stocks, opts)
+        # TODO: when we have more then one account key then this should scale
+        # linearly with that.
+        self._sess = asks.Session(connections=4)
         self.api = _API(self)
         self._conf = config
         self._is_practice = _use_practice_account or (


### PR DESCRIPTION
Gets us better throughput when polling multiple endpoints (eg. option
and stock quotes simultaneously) since slower round trip request won't
block faster ones when using multiple connections.