### PR TITLE
Unleash the kraken

### DIFF
--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -1,44 +1,73 @@
 """
 Kraken backend.
 """
+from dataclasses import dataclass, asdict
 from typing import List
 import json
 
-import trio
 import tractor
 from trio_websocket import open_websocket_url
 
 
+async def stream_quotes(
+    pairs: List[str] = ['BTC/USD', 'XRP/USD'],
+    sub_type: str = 'ohlc',
+) -> None:
+    """Subscribe for ohlc stream of quotes for ``pairs``.
+
+    ``pairs`` must be formatted <crypto_symbol>/<fiat_symbol>.
+    """
+    async with open_websocket_url(
+        'wss://ws.kraken.com',
+    ) as ws:
+        # setup subs
+        # see: https://docs.kraken.com/websockets/#message-subscribe
+        subs = {
+            'pair': pairs,
+            'event': 'subscribe',
+            'subscription': {
+                'name': sub_type,
+                'interval': 1,  # 1 min
+                # 'name': 'ticker',
+                # 'name': 'openOrders',
+                # 'depth': '25',
+            },
+        }
+        await ws.send_message(json.dumps(subs))
+
+        async def recv():
+            return json.loads(await ws.get_message())
+
+        @dataclass
+        class OHLC:
+            chan_id: int  # internal kraken id
+            chan_name: str  # eg. ohlc-1  (name-interval)
+            pair: str  # fx pair
+            time: float  # Begin time of interval, in seconds since epoch
+            etime: float  # End time of interval, in seconds since epoch
+            open: float  # Open price of interval
+            high: float  # High price within interval
+            low: float  # Low price within interval
+            close: float  # Close price of interval
+            vwap: float  # Volume weighted average price within interval
+            volume: int  # Accumulated volume within interval
+            count: int  # Number of trades within interval
+
+        while True:
+            msg = await recv()
+            if isinstance(msg, dict):
+                if msg.get('event') == 'heartbeat':
+                    continue
+            else:
+                chan_id, ohlc_array, chan_name, pair = msg
+                ohlc = OHLC(chan_id, chan_name, pair, *ohlc_array)
+                yield ohlc
+
+
 if __name__ == '__main__':
 
-    async def stream_quotes(
-        pairs: List[str] = ['BTC/USD'],
-    ) -> None:
-        """Subscribe ohlc quotes for ``pairs``.
+    async def stream_ohlc():
+        async for msg in stream_quotes():
+            print(asdict(msg))
 
-        ``pairs`` must be formatted like `crypto/fiat`.
-        """
-        async with open_websocket_url(
-            'wss://ws.kraken.com',
-        ) as ws:
-            # setup subs
-            subs = {
-                'event': 'subscribe',
-                'pair': pairs,
-                'subscription': {
-                    'name': 'ohlc',
-                    # 'name': 'ticker',
-                    # 'name': 'openOrders',
-                    # 'depth': '25',
-                },
-            }
-            await ws.send_message(json.dumps(subs))
-
-            while True:
-                msg = json.loads(await ws.get_message())
-                if isinstance(msg, dict) and msg.get('event') == 'heartbeat':
-                    continue
-
-                print(msg)
-
-    trio.run(stream_quotes)
+    tractor.run(stream_ohlc)

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -1,29 +1,137 @@
 """
 Kraken backend.
 """
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, asdict
-from typing import List
+from itertools import starmap
+from typing import List, Dict, Any
 import json
 
-import tractor
 from trio_websocket import open_websocket_url
+import arrow
+import asks
+import numpy as np
+import tractor
+
+from ._util import resproc, SymbolNotFound, BrokerError
+from ..log import get_logger
+
+log = get_logger(__name__)
+
+
+# <uri>/<version>/
+_url = 'https://api.kraken.com/0'
+
+
+# conversion to numpy worthy types
+ohlc_dtype = [
+    ('index', int),
+    ('time', int),
+    ('open', float),
+    ('high', float),
+    ('low', float),
+    ('close', float),
+    ('vwap', float),
+    ('volume', float),
+    ('count', int)
+]
+
+
+class Client:
+
+    def __init__(self) -> None:
+        self._sesh = asks.Session(connections=4)
+        self._sesh.base_location = _url
+        self._sesh.headers.update({
+            'User-Agent':
+                'krakenex/2.1.0 (+https://github.com/veox/python3-krakenex)'
+        })
+
+    async def _public(
+        self,
+        method: str,
+        data: dict,
+    ) -> Dict[str, Any]:
+        resp = await self._sesh.post(
+            path=f'/public/{method}',
+            json=data,
+            timeout=float('inf')
+        )
+        return resproc(resp, log)
+
+    async def symbol_info(
+        self,
+        pair: str = 'all',
+    ):
+        resp = await self._public('AssetPairs', {'pair': pair})
+        assert not resp['error']
+        true_pair_key, data = next(iter(resp['result'].items()))
+        return data
+
+    async def bars(
+        self,
+        symbol: str = 'XBTUSD',
+        # UTC 2017-07-02 12:53:20
+        since: int = None,
+        count: int = 720,  # <- max allowed per query
+        as_np: bool = True,
+    ) -> dict:
+        if since is None:
+            since = arrow.utcnow().floor('minute').shift(
+                minutes=-count).timestamp
+        # UTC 2017-07-02 12:53:20 is oldest seconds value
+        since = str(max(1499000000, since))
+        json = await self._public(
+            'OHLC',
+            data={
+                'pair': symbol,
+                'since': since,
+            },
+        )
+        try:
+            res = json['result']
+            res.pop('last')
+            bars = next(iter(res.values()))
+
+            # convert all fields to native types
+            bars = list(starmap(
+                lambda i, bar:
+                    (i,) + tuple(
+                        ftype(bar[i]) for i, (name, ftype)
+                        in enumerate(ohlc_dtype[1:])
+                    ),
+                enumerate(bars))
+            )
+            return np.array(bars, dtype=ohlc_dtype) if as_np else bars
+        except KeyError:
+            raise SymbolNotFound(json['error'][0] + f': {symbol}')
+
+
+@asynccontextmanager
+async def get_client() -> Client:
+    yield Client()
 
 
 async def stream_quotes(
-    pairs: List[str] = ['BTC/USD', 'XRP/USD'],
+    symbols: List[str] = ['BTC/USD', 'XRP/USD'],
     sub_type: str = 'ohlc',
 ) -> None:
     """Subscribe for ohlc stream of quotes for ``pairs``.
 
     ``pairs`` must be formatted <crypto_symbol>/<fiat_symbol>.
     """
+    ws_pairs = {}
+    async with get_client() as client:
+        for sym in symbols:
+            ws_pairs[sym] = (await client.symbol_info(sym))['wsname']
+
     async with open_websocket_url(
         'wss://ws.kraken.com',
     ) as ws:
         # setup subs
         # see: https://docs.kraken.com/websockets/#message-subscribe
         subs = {
-            'pair': pairs,
+            'pair': list(ws_pairs.values()),
             'event': 'subscribe',
             'subscription': {
                 'name': sub_type,
@@ -50,18 +158,27 @@ async def stream_quotes(
             low: float  # Low price within interval
             close: float  # Close price of interval
             vwap: float  # Volume weighted average price within interval
-            volume: int  # Accumulated volume within interval
+            volume: float  # Accumulated volume within interval
             count: int  # Number of trades within interval
+
+            # XXX: ugh, super hideous.. why doesn't
+            def __post_init__(self):
+                for field, val in self.__dataclass_fields__.items():
+                    setattr(self, field, val.type(getattr(self, field)))
 
         while True:
             msg = await recv()
             if isinstance(msg, dict):
                 if msg.get('event') == 'heartbeat':
                     continue
+                err = msg.get('errorMessage')
+                if err:
+                    raise BrokerError(err)
             else:
                 chan_id, ohlc_array, chan_name, pair = msg
                 ohlc = OHLC(chan_id, chan_name, pair, *ohlc_array)
-                yield ohlc
+                print(ohlc)
+                yield asdict(ohlc)
 
 
 if __name__ == '__main__':

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -64,7 +64,9 @@ class Client:
         pair: str = 'all',
     ):
         resp = await self._public('AssetPairs', {'pair': pair})
-        assert not resp['error']
+        err = resp['error']
+        if err:
+            raise BrokerError(err)
         true_pair_key, data = next(iter(resp['result'].items()))
         return data
 
@@ -113,7 +115,9 @@ async def get_client() -> Client:
 
 
 async def stream_quotes(
-    symbols: List[str] = ['BTC/USD', 'XRP/USD'],
+    # These are the symbols not expected by the ws api
+    # they are looked up inside this routine.
+    symbols: List[str] = ['XBTUSD', 'XMRUSD'],
     sub_type: str = 'ohlc',
 ) -> None:
     """Subscribe for ohlc stream of quotes for ``pairs``.
@@ -185,6 +189,6 @@ if __name__ == '__main__':
 
     async def stream_ohlc():
         async for msg in stream_quotes():
-            print(asdict(msg))
+            print(msg)
 
     tractor.run(stream_ohlc)

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -1,0 +1,44 @@
+"""
+Kraken backend.
+"""
+from typing import List
+import json
+
+import trio
+import tractor
+from trio_websocket import open_websocket_url
+
+
+if __name__ == '__main__':
+
+    async def stream_quotes(
+        pairs: List[str] = ['BTC/USD'],
+    ) -> None:
+        """Subscribe ohlc quotes for ``pairs``.
+
+        ``pairs`` must be formatted like `crypto/fiat`.
+        """
+        async with open_websocket_url(
+            'wss://ws.kraken.com',
+        ) as ws:
+            # setup subs
+            subs = {
+                'event': 'subscribe',
+                'pair': pairs,
+                'subscription': {
+                    'name': 'ohlc',
+                    # 'name': 'ticker',
+                    # 'name': 'openOrders',
+                    # 'depth': '25',
+                },
+            }
+            await ws.send_message(json.dumps(subs))
+
+            while True:
+                msg = json.loads(await ws.get_message())
+                if isinstance(msg, dict) and msg.get('event') == 'heartbeat':
+                    continue
+
+                print(msg)
+
+    trio.run(stream_quotes)

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -181,11 +181,20 @@ async def stream_quotes(
                 async def recv():
                     return json.loads(await ws.get_message())
 
+                import time
+
                 async def recv_ohlc():
+                    last_hb = 0
                     while True:
                         msg = await recv()
                         if isinstance(msg, dict):
                             if msg.get('event') == 'heartbeat':
+                                log.trace(
+                                    f"Heartbeat after {time.time() - last_hb}")
+                                last_hb = time.time()
+                                # TODO: hmm i guess we should use this
+                                # for determining when to do connection
+                                # resets eh?
                                 continue
                             err = msg.get('errorMessage')
                             if err:

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -165,7 +165,7 @@ async def stream_quotes(
             volume: float  # Accumulated volume within interval
             count: int  # Number of trades within interval
 
-            # XXX: ugh, super hideous.. why doesn't
+            # XXX: ugh, super hideous.. needs built-in converters.
             def __post_init__(self):
                 for field, val in self.__dataclass_fields__.items():
                     setattr(self, field, val.type(getattr(self, field)))

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -27,7 +27,7 @@ _url = 'https://api.kraken.com/0'
 
 
 # conversion to numpy worthy types
-ohlc_dtype = [
+_ohlc_dtype = [
     ('index', int),
     ('time', int),
     ('open', float),
@@ -38,6 +38,10 @@ ohlc_dtype = [
     ('volume', float),
     ('count', int)
 ]
+
+# UI components allow this to be declared such that additional
+# (historical) fields can be exposed.
+ohlc_dtype = np.dtype(_ohlc_dtype)
 
 
 class Client:
@@ -103,11 +107,11 @@ class Client:
                 lambda i, bar:
                     (i,) + tuple(
                         ftype(bar[i]) for i, (name, ftype)
-                        in enumerate(ohlc_dtype[1:])
+                        in enumerate(_ohlc_dtype[1:])
                     ),
                 enumerate(bars))
             )
-            return np.array(bars, dtype=ohlc_dtype) if as_np else bars
+            return np.array(bars, dtype=_ohlc_dtype) if as_np else bars
         except KeyError:
             raise SymbolNotFound(json['error'][0] + f': {symbol}')
 
@@ -193,7 +197,7 @@ def normalize(
     # in subscription systems...
     topic = quote['pair'].replace('/', '')
 
-    print(quote)
+    # print(quote)
     return topic, quote
 
 

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -9,6 +9,7 @@ import json
 import time
 
 import trio_websocket
+from trio_websocket._impl import ConnectionClosed, DisconnectionTimeout
 import arrow
 import asks
 import numpy as np
@@ -247,7 +248,7 @@ async def stream_quotes(
                         })
                     yield asdict(ohlc)
                     ohlc_last = ohlc
-        except trio_websocket._impl.ConnectionClosed:
+        except (ConnectionClosed, DisconnectionTimeout):
             log.exception("Good job kraken...reconnecting")
 
 

--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -1164,10 +1164,10 @@ async def stream_quotes(
             packetizer=partial(
                 packetizer,
                 formatter=formatter,
-                symboal_data=sd,
+                symbol_data=sd,
             ),
 
-            # actual func args
+            # actual target "streaming func" args
             get_quotes=get_quotes,
             diff_cached=diff_cached,
             rate=rate,


### PR DESCRIPTION
Initial draft of rt-feed support but only using the [ohlc](https://docs.kraken.com/websockets/#message-ohlc) endpoint.

We still need to get:
- [L1 bid/ask](https://docs.kraken.com/websockets/#message-spread) feed 
- [L2 book feed](https://docs.kraken.com/websockets/#message-book), afaict on the web GUI they only do about 3-4Hz update rate.
- maybe the [trade data feed](https://docs.kraken.com/websockets/#message-trade), though we might already mostly getting that doing the "tick parsing" that's done in this patch.

Ping @guilledk