### PR TITLE
To qpainterpath and beyond

### DIFF
--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -57,12 +57,14 @@ _ohlc_dtype = [
     ('close', float),
     ('volume', float),
     ('count', int),
-    ('vwap', float),
+    ('bar_wap', float),
 ]
 
 # UI components allow this to be declared such that additional
 # (historical) fields can be exposed.
 ohlc_dtype = np.dtype(_ohlc_dtype)
+
+_show_wap_in_history = True
 
 
 class Client:
@@ -341,7 +343,7 @@ async def stream_quotes(
         while True:
             try:
                 async with trio_websocket.open_websocket_url(
-                    'wss://ws.kraken.com',
+                    'wss://ws.kraken.com/',
                 ) as ws:
 
                     # XXX: setup subs
@@ -433,7 +435,7 @@ async def stream_quotes(
                                      'high',
                                      'low',
                                      'close',
-                                     'vwap',
+                                     'bar_wap',  # in this case vwap of bar
                                      'volume']
                                 ][-1] = (
                                     o,

--- a/piker/data/__init__.py
+++ b/piker/data/__init__.py
@@ -42,7 +42,7 @@ from ._sharedmem import (
     ShmArray,
     get_shm_token,
 )
-from ._source import base_ohlc_dtype
+from ._source import base_iohlc_dtype
 from ._buffer import (
     increment_ohlc_buffer,
     subscribe_ohlc_for_increment
@@ -139,6 +139,7 @@ class Feed:
     name: str
     stream: AsyncIterator[Dict[str, Any]]
     shm: ShmArray
+    # ticks: ShmArray
     _broker_portal: tractor._portal.Portal
     _index_stream: Optional[AsyncIterator[Dict[str, Any]]] = None
 
@@ -188,7 +189,7 @@ async def open_feed(
         key=sym_to_shm_key(name, symbols[0]),
 
         # use any broker defined ohlc dtype:
-        dtype=getattr(mod, '_ohlc_dtype', base_ohlc_dtype),
+        dtype=getattr(mod, '_ohlc_dtype', base_iohlc_dtype),
 
         # we expect the sub-actor to write
         readonly=True,

--- a/piker/data/_buffer.py
+++ b/piker/data/_buffer.py
@@ -91,19 +91,20 @@ async def increment_ohlc_buffer(
 
                 # append new entry to buffer thus "incrementing" the bar
                 array = shm.array
-                last = array[-1:].copy()
-                (index, t, close) = last[0][['index', 'time', 'close']]
+                last = array[-1:][shm._write_fields].copy()
+                # (index, t, close) = last[0][['index', 'time', 'close']]
+                (t, close) = last[0][['time', 'close']]
 
                 # this copies non-std fields (eg. vwap) from the last datum
                 last[
-                    ['index', 'time', 'volume', 'open', 'high', 'low', 'close']
-                ][0] = (index + 1, t + delay_s, 0, close, close, close, close)
+                    ['time', 'volume', 'open', 'high', 'low', 'close']
+                ][0] = (t + delay_s, 0, close, close, close, close)
 
                 # write to the buffer
                 shm.push(last)
 
         # broadcast the buffer index step
-        yield {'index': shm._i.value}
+        yield {'index': shm._last.value}
 
 
 def subscribe_ohlc_for_increment(

--- a/piker/data/_normalize.py
+++ b/piker/data/_normalize.py
@@ -33,6 +33,6 @@ def iterticks(
     ticks = quote.get('ticks', ())
     if ticks:
         for tick in ticks:
-            print(f"{quote['symbol']}: {tick}")
+            # print(f"{quote['symbol']}: {tick}")
             if tick.get('type') in types:
                 yield tick

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -17,11 +17,10 @@
 """
 NumPy compatible shared memory buffers for real-time FSP.
 """
-from typing import List
 from dataclasses import dataclass, asdict
 from sys import byteorder
-from typing import Tuple, Optional
-from multiprocessing import shared_memory
+from typing import List, Tuple, Optional
+from multiprocessing.shared_memory import SharedMemory, _USE_POSIX
 from multiprocessing import resource_tracker as mantracker
 from _posixshmem import shm_unlink
 
@@ -29,7 +28,7 @@ import tractor
 import numpy as np
 
 from ..log import get_logger
-from ._source import base_ohlc_dtype
+from ._source import base_ohlc_dtype, base_iohlc_dtype
 
 
 log = get_logger(__name__)
@@ -58,17 +57,15 @@ mantracker.getfd = mantracker._resource_tracker.getfd
 
 
 class SharedInt:
+    """Wrapper around a single entry shared memory array which
+    holds an ``int`` value used as an index counter.
+
+    """
     def __init__(
         self,
-        token: str,
-        create: bool = False,
+        shm: SharedMemory,
     ) -> None:
-        # create a single entry array for storing an index counter
-        self._shm = shared_memory.SharedMemory(
-            name=token,
-            create=create,
-            size=4,  # std int
-        )
+        self._shm = shm
 
     @property
     def value(self) -> int:
@@ -79,7 +76,7 @@ class SharedInt:
         self._shm.buf[:] = value.to_bytes(4, byteorder)
 
     def destroy(self) -> None:
-        if shared_memory._USE_POSIX:
+        if _USE_POSIX:
             # We manually unlink to bypass all the "resource tracker"
             # nonsense meant for non-SC systems.
             shm_unlink(self._shm.name)
@@ -91,7 +88,8 @@ class _Token:
     which can be used to key a system wide post shm entry.
     """
     shm_name: str  # this servers as a "key" value
-    shm_counter_name: str
+    shm_first_index_name: str
+    shm_last_index_name: str
     dtype_descr: List[Tuple[str]]
 
     def __post_init__(self):
@@ -130,27 +128,47 @@ def _make_token(
     """Create a serializable token that can be used
     to access a shared array.
     """
-    dtype = base_ohlc_dtype if dtype is None else dtype
+    dtype = base_iohlc_dtype if dtype is None else dtype
     return _Token(
         key,
-        key + "_counter",
+        key + "_first",
+        key + "_last",
         np.dtype(dtype).descr
     )
 
 
 class ShmArray:
+    """A shared memory ``numpy`` (compatible) array API.
+
+    An underlying shared memory buffer is allocated based on
+    a user specified ``numpy.ndarray``. This fixed size array
+    can be read and written to by pushing data both onto the "front"
+    or "back" of a set index range. The indexes for the "first" and
+    "last" index are themselves stored in shared memory (accessed via
+    ``SharedInt`` interfaces) values such that multiple processes can
+    interact with the same array using a synchronized-index.
+
+    """
     def __init__(
         self,
         shmarr: np.ndarray,
-        counter: SharedInt,
-        shm: shared_memory.SharedMemory,
-        readonly: bool = True,
+        first: SharedInt,
+        last: SharedInt,
+        shm: SharedMemory,
+        # readonly: bool = True,
     ) -> None:
         self._array = shmarr
-        self._i = counter
+
+        # indexes for first and last indices corresponding
+        # to fille data
+        self._first = first
+        self._last = last
+
         self._len = len(shmarr)
         self._shm = shm
-        self._readonly = readonly
+
+        # pushing data does not write the index (aka primary key)
+        self._write_fields = list(shmarr.dtype.fields.keys())[1:]
 
     # TODO: ringbuf api?
 
@@ -158,24 +176,25 @@ class ShmArray:
     def _token(self) -> _Token:
         return _Token(
             self._shm.name,
-            self._i._shm.name,
+            self._first._shm.name,
+            self._last._shm.name,
             self._array.dtype.descr,
         )
 
     @property
     def token(self) -> dict:
-        """Shared memory token that can be serialized
-        and used by another process to attach to this array.
+        """Shared memory token that can be serialized and used by
+        another process to attach to this array.
         """
         return self._token.as_msg()
 
     @property
     def index(self) -> int:
-        return self._i.value % self._len
+        return self._last.value % self._len
 
     @property
     def array(self) -> np.ndarray:
-        return self._array[:self._i.value]
+        return self._array[self._first.value:self._last.value]
 
     def last(
         self,
@@ -186,62 +205,90 @@ class ShmArray:
     def push(
         self,
         data: np.ndarray,
+        prepend: bool = False,
     ) -> int:
         """Ring buffer like "push" to append data
-        into the buffer and return updated index.
+        into the buffer and return updated "last" index.
         """
         length = len(data)
-        # TODO: use .index for actual ring logic?
-        index = self._i.value
+
+        if prepend:
+            index = self._first.value - length
+        else:
+            index = self._last.value
+
         end = index + length
+
+        fields = self._write_fields
+
         try:
-            self._array[index:end] = data[:]
-            self._i.value = end
+            self._array[fields][index:end] = data[fields][:]
+            if prepend:
+                self._first.value = index
+            else:
+                self._last.value = end
             return end
         except ValueError as err:
-            # reraise with any field discrepancy
-            our_fields, their_fields = (
-                set(self._array.dtype.fields),
-                set(data.dtype.fields),
+            # shoudl raise if diff detected
+            self.diff_err_fields(data)
+
+            raise err
+
+    def diff_err_fields(
+        self,
+        data: np.ndarray,
+    ) -> None:
+        # reraise with any field discrepancy
+        our_fields, their_fields = (
+            set(self._array.dtype.fields),
+            set(data.dtype.fields),
+        )
+
+        only_in_ours = our_fields - their_fields
+        only_in_theirs = their_fields - our_fields
+
+        if only_in_ours:
+            raise TypeError(
+                f"Input array is missing field(s): {only_in_ours}"
+            )
+        elif only_in_theirs:
+            raise TypeError(
+                f"Input array has unknown field(s): {only_in_theirs}"
             )
 
-            only_in_ours = our_fields - their_fields
-            only_in_theirs = their_fields - our_fields
-
-            if only_in_ours:
-                raise TypeError(
-                    f"Input array is missing field(s): {only_in_ours}"
-                )
-            elif only_in_theirs:
-                raise TypeError(
-                    f"Input array has unknown field(s): {only_in_theirs}"
-                )
-            else:
-                raise err
+    def prepend(
+        self,
+        data: np.ndarray,
+    ) -> int:
+        end = self.push(data, prepend=True)
+        assert end
 
     def close(self) -> None:
-        self._i._shm.close()
+        self._first._shm.close()
+        self._last._shm.close()
         self._shm.close()
 
     def destroy(self) -> None:
-        if shared_memory._USE_POSIX:
+        if _USE_POSIX:
             # We manually unlink to bypass all the "resource tracker"
             # nonsense meant for non-SC systems.
             shm_unlink(self._shm.name)
-        self._i.destroy()
+
+        self._first.destroy()
+        self._last.destroy()
 
     def flush(self) -> None:
         # TODO: flush to storage backend like markestore?
         ...
 
 
-_lotsa_5s = int(5 * 60 * 60 * 10 / 5)
-
+# how  much is probably dependent on lifestyle
+_secs_in_day = int(60 * 60 * 12)
+_default_size = 2 * _secs_in_day
 
 def open_shm_array(
     key: Optional[str] = None,
-    # approx number of 5s bars in a "day" x2
-    size: int = _lotsa_5s,
+    size: int = _default_size,
     dtype: Optional[np.dtype] = None,
     readonly: bool = False,
 ) -> ShmArray:
@@ -253,7 +300,9 @@ def open_shm_array(
     # create new shared mem segment for which we
     # have write permission
     a = np.zeros(size, dtype=dtype)
-    shm = shared_memory.SharedMemory(
+    a['index'] = np.arange(len(a))
+
+    shm = SharedMemory(
         name=key,
         create=True,
         size=a.nbytes
@@ -267,17 +316,30 @@ def open_shm_array(
         dtype=dtype
     )
 
-    counter = SharedInt(
-        token=token.shm_counter_name,
-        create=True,
+    # create single entry arrays for storing an first and last indices
+    first = SharedInt(
+        shm=SharedMemory(
+            name=token.shm_first_index_name,
+            create=True,
+            size=4,  # std int
+        )
     )
-    counter.value = 0
+
+    last = SharedInt(
+        shm=SharedMemory(
+            name=token.shm_last_index_name,
+            create=True,
+            size=4,  # std int
+        )
+    )
+
+    last.value = first.value = int(_secs_in_day)
 
     shmarr = ShmArray(
         array,
-        counter,
+        first,
+        last,
         shm,
-        readonly=readonly,
     )
 
     assert shmarr._token == token
@@ -293,18 +355,23 @@ def open_shm_array(
 
 def attach_shm_array(
     token: Tuple[str, str, Tuple[str, str]],
-    size: int = _lotsa_5s,
+    size: int = _default_size,
     readonly: bool = True,
 ) -> ShmArray:
-    """Load and attach to an existing shared memory array previously
+    """Attach to an existing shared memory array previously
     created by another process using ``open_shared_array``.
+
+    No new shared mem is allocated but wrapper types for read/write
+    access are constructed.
     """
     token = _Token.from_msg(token)
     key = token.shm_name
+
     if key in _known_tokens:
         assert _known_tokens[key] == token, "WTF"
 
-    shm = shared_memory.SharedMemory(name=key)
+    # attach to array buffer and view as per dtype
+    shm = SharedMemory(name=key)
     shmarr = np.ndarray(
         (size,),
         dtype=token.dtype_descr,
@@ -312,15 +379,29 @@ def attach_shm_array(
     )
     shmarr.setflags(write=int(not readonly))
 
-    counter = SharedInt(token=token.shm_counter_name)
+    first = SharedInt(
+        shm=SharedMemory(
+            name=token.shm_first_index_name,
+            create=False,
+            size=4,  # std int
+        ),
+    )
+    last = SharedInt(
+        shm=SharedMemory(
+            name=token.shm_last_index_name,
+            create=False,
+            size=4,  # std int
+        ),
+    )
+
     # make sure we can read
-    counter.value
+    first.value
 
     sha = ShmArray(
         shmarr,
-        counter,
+        first,
+        last,
         shm,
-        readonly=readonly,
     )
     # read test
     sha.array

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -342,21 +342,20 @@ def maybe_open_shm_array(
     dtype: Optional[np.dtype] = None,
     **kwargs,
 ) -> Tuple[ShmArray, bool]:
-    """Attempt to attach to a shared memory block by a
-    "key" determined by the users overall "system"
+    """Attempt to attach to a shared memory block using a "key" lookup
+    to registered blocks in the users overall "system" registryt
     (presumes you don't have the block's explicit token).
 
-    This function is meant to solve the problem of
-    discovering whether a shared array token has been
-    allocated or discovered by the actor running in
-    **this** process. Systems where multiple actors
-    may seek to access a common block can use this
-    function to attempt to acquire a token as discovered
-    by the actors who have previously stored a
-    "key" -> ``_Token`` map in an actor local variable.
+    This function is meant to solve the problem of discovering whether
+    a shared array token has been allocated or discovered by the actor
+    running in **this** process. Systems where multiple actors may seek
+    to access a common block can use this function to attempt to acquire
+    a token as discovered by the actors who have previously stored
+    a "key" -> ``_Token`` map in an actor local (aka python global)
+    variable.
 
-    If you know the explicit ``_Token`` for your memory
-    instead use ``attach_shm_array``.
+    If you know the explicit ``_Token`` for your memory segment instead
+    use ``attach_shm_array``.
     """
     try:
         # see if we already know this key

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -214,10 +214,12 @@ class ShmArray:
         ...
 
 
+_lotsa_5s = int(5*60*60*10/5)
+
 def open_shm_array(
     key: Optional[str] = None,
     # approx number of 5s bars in a "day" x2
-    size: int = int(2*60*60*10/5),
+    size: int = _lotsa_5s,
     dtype: Optional[np.dtype] = None,
     readonly: bool = False,
 ) -> ShmArray:
@@ -269,7 +271,7 @@ def open_shm_array(
 
 def attach_shm_array(
     token: Tuple[str, str, Tuple[str, str]],
-    size: int = int(60*60*10/5),
+    size: int = _lotsa_5s,
     readonly: bool = True,
 ) -> ShmArray:
     """Load and attach to an existing shared memory array previously

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -216,6 +216,7 @@ class ShmArray:
 
 _lotsa_5s = int(5*60*60*10/5)
 
+
 def open_shm_array(
     key: Optional[str] = None,
     # approx number of 5s bars in a "day" x2
@@ -263,9 +264,9 @@ def open_shm_array(
 
     # "unlink" created shm on process teardown by
     # pushing teardown calls onto actor context stack
-    actor = tractor.current_actor()
-    actor._lifetime_stack.callback(shmarr.close)
-    actor._lifetime_stack.callback(shmarr.destroy)
+    tractor._actor._lifetime_stack.callback(shmarr.close)
+    tractor._actor._lifetime_stack.callback(shmarr.destroy)
+
     return shmarr
 
 
@@ -310,8 +311,8 @@ def attach_shm_array(
         _known_tokens[key] = token
 
     # "close" attached shm on process teardown
-    actor = tractor.current_actor()
-    actor._lifetime_stack.callback(sha.close)
+    tractor._actor._lifetime_stack.callback(sha.close)
+
     return sha
 
 

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -116,13 +116,25 @@ class DynamicDateAxis(Axis):
         indexes: List[int],
     ) -> List[str]:
 
-        bars = self.linked_charts.chart._ohlc
+        # try:
+        chart = self.linked_charts.chart
+        bars = chart._ohlc
+        shm = self.linked_charts.chart._shm
+        first = shm._first.value
+
         bars_len = len(bars)
         times = bars['time']
 
         epochs = times[list(
-            map(int, filter(lambda i: i < bars_len, indexes))
+            map(
+                int,
+                filter(
+                    lambda i: i > 0 and i < bars_len,
+                    (i-first for i in indexes)
+                )
+            )
         )]
+
         # TODO: **don't** have this hard coded shift to EST
         dts = pd.to_datetime(epochs, unit='s')  # - 4*pd.offsets.Hour()
 

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -38,7 +38,7 @@ class Axis(pg.AxisItem):
     def __init__(
         self,
         linked_charts,
-        typical_max_str: str = '100 000.00',
+        typical_max_str: str = '100 000.000',
         min_tick: int = 2,
         **kwargs
     ) -> None:
@@ -116,7 +116,7 @@ class DynamicDateAxis(Axis):
         indexes: List[int],
     ) -> List[str]:
 
-        bars = self.linked_charts.chart._array
+        bars = self.linked_charts.chart._ohlc
         bars_len = len(bars)
         times = bars['time']
 
@@ -267,8 +267,8 @@ class YAxisLabel(AxisLabel):
     _h_margin = 2
 
     text_flags = (
-        # QtCore.Qt.AlignLeft
-        QtCore.Qt.AlignHCenter
+        QtCore.Qt.AlignLeft
+        # QtCore.Qt.AlignHCenter
         | QtCore.Qt.AlignVCenter
         | QtCore.Qt.TextDontClip
     )
@@ -285,7 +285,7 @@ class YAxisLabel(AxisLabel):
     ) -> None:
 
         # this is read inside ``.paint()``
-        self.label_str = '{value:,.{digits}f}'.format(
+        self.label_str = ' {value:,.{digits}f}'.format(
             digits=self.digits, value=value).replace(',', ' ')
 
         br = self.boundingRect()

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -51,6 +51,8 @@ class Axis(pg.AxisItem):
         self.setStyle(**{
             'textFillLimits': [(0, 0.666)],
             'tickFont': _font.font,
+            # offset of text *away from* axis line in px
+            'tickTextOffset': 2,
         })
 
         self.setTickFont(_font.font)
@@ -88,11 +90,10 @@ class PriceAxis(Axis):
         # print(f'digits: {digits}')
 
         return [
-            ('{value:,.{digits}f}')
-                .format(
-                    digits=digits,
-                    value=v,
-                ).replace(',', ' ') for v in vals
+            ('{value:,.{digits}f}').format(
+                digits=digits,
+                value=v,
+            ).replace(',', ' ') for v in vals
         ]
 
 
@@ -104,10 +105,11 @@ class DynamicDateAxis(Axis):
         60: '%H:%M',
         30: '%H:%M:%S',
         5: '%H:%M:%S',
+        1: '%H:%M:%S',
     }
 
     def resize(self) -> None:
-        self.setHeight(self.typical_br.height() + 3)
+        self.setHeight(self.typical_br.height() + 1)
 
     def _indexes_to_timestrs(
         self,
@@ -228,6 +230,7 @@ class AxisLabel(pg.GraphicsObject):
 
 
 class XAxisLabel(AxisLabel):
+    _w_margin = 4
 
     text_flags = (
         QtCore.Qt.TextDontClip
@@ -255,14 +258,13 @@ class XAxisLabel(AxisLabel):
         w = self.boundingRect().width()
         self.setPos(QPointF(
             abs_pos.x() - w / 2 - offset,
-            0,
+            1,
         ))
         self.update()
 
 
 class YAxisLabel(AxisLabel):
-    _h_margin = 3
-    # _w_margin = 1
+    _h_margin = 2
 
     text_flags = (
         # QtCore.Qt.AlignLeft
@@ -289,7 +291,7 @@ class YAxisLabel(AxisLabel):
         br = self.boundingRect()
         h = br.height()
         self.setPos(QPointF(
-            0,
+            1,
             abs_pos.y() - h / 2 - offset
         ))
         self.update()

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -123,6 +123,7 @@ class ChartSpace(QtGui.QWidget):
         self,
         symbol: str,
         data: np.ndarray,
+        ohlc: bool = True,
     ) -> None:
         """Load a new contract into the charting app.
         """
@@ -147,7 +148,7 @@ class ChartSpace(QtGui.QWidget):
         if not self.v_layout.isEmpty():
             self.v_layout.removeWidget(linkedcharts)
 
-        main_chart = linkedcharts.plot_main(s, data)
+        main_chart = linkedcharts.plot_main(s, data, ohlc=ohlc)
         self.v_layout.addWidget(linkedcharts)
 
         return linkedcharts, main_chart
@@ -234,7 +235,7 @@ class LinkedSplitCharts(QtGui.QWidget):
             name=symbol.key,
             array=array,
             xaxis=self.xaxis,
-            ohlc=True,
+            ohlc=ohlc,
             _is_main=True,
         )
         # add crosshair graphic
@@ -746,6 +747,15 @@ async def _async_main(
         ohlcv = feed.shm
         bars = ohlcv.array
 
+        # TODO: when we start messing with line charts
+        # c = np.zeros(len(bars), dtype=[
+        #     (sym, bars.dtype.fields['close'][0]),
+        #     ('index', 'i4'),
+        # ])
+        # c[sym] = bars['close']
+        # c['index'] = bars['index']
+        # linked_charts, chart = chart_app.load_symbol(sym, c, ohlc=False)
+
         # load in symbol's ohlc data
         linked_charts, chart = chart_app.load_symbol(sym, bars)
 
@@ -849,6 +859,11 @@ async def chart_from_quotes(
         l, lbar, rbar, r = last_bars_range
         in_view = array[lbar:rbar]
         mx, mn = np.nanmax(in_view['high']), np.nanmin(in_view['low'])
+
+        # TODO: when we start using line charts
+        # sym = chart.name
+        # mx, mn = np.nanmax(in_view[sym]), np.nanmin(in_view[sym])
+
         return last_bars_range, mx, mn
 
     last_bars_range, last_mx, last_mn = maxmin()
@@ -897,6 +912,11 @@ async def chart_from_quotes(
                         chart.name,
                         array,
                     )
+
+                    # chart.update_curve_from_array(
+                        # chart.name,
+                        # TODO: when we start using line charts
+                        # np.array(array['close'], dtype=[(chart.name, 'f8')])
 
                     # if vwap_in_history:
                     #     # update vwap overlay line

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -17,7 +17,7 @@
 """
 High level Qt chart widgets.
 """
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple, Dict, Any, Optional, Callable
 from functools import partial
 
 from PyQt5 import QtCore, QtGui
@@ -105,6 +105,7 @@ class ChartSpace(QtGui.QWidget):
         self.tf_layout.setContentsMargins(0, 12, 0, 0)
         time_frames = ('1M', '5M', '15M', '30M', '1H', '1D', '1W', 'MN')
         btn_prefix = 'TF'
+
         for tf in time_frames:
             btn_name = ''.join([btn_prefix, tf])
             btn = QtGui.QPushButton(tf)
@@ -112,6 +113,7 @@ class ChartSpace(QtGui.QWidget):
             btn.setEnabled(False)
             setattr(self, btn_name, btn)
             self.tf_layout.addWidget(btn)
+
         self.toolbar_layout.addLayout(self.tf_layout)
 
     # XXX: strat loader/saver that we don't need yet.
@@ -126,6 +128,8 @@ class ChartSpace(QtGui.QWidget):
         ohlc: bool = True,
     ) -> None:
         """Load a new contract into the charting app.
+
+        Expects a ``numpy`` structured array containing all the ohlcv fields.
         """
         # XXX: let's see if this causes mem problems
         self.window.setWindowTitle(f'piker chart {symbol}')
@@ -148,7 +152,8 @@ class ChartSpace(QtGui.QWidget):
         if not self.v_layout.isEmpty():
             self.v_layout.removeWidget(linkedcharts)
 
-        main_chart = linkedcharts.plot_main(s, data, ohlc=ohlc)
+        main_chart = linkedcharts.plot_ohlc_main(s, data)
+
         self.v_layout.addWidget(linkedcharts)
 
         return linkedcharts, main_chart
@@ -176,7 +181,6 @@ class LinkedSplitCharts(QtGui.QWidget):
     def __init__(self):
         super().__init__()
         self.signals_visible: bool = False
-        self._array: np.ndarray = None  # main data source
         self._ch: CrossHair = None  # crosshair graphics
         self.chart: ChartPlotWidget = None  # main (ohlc) chart
         self.subplots: Dict[Tuple[str, ...], ChartPlotWidget] = {}
@@ -212,19 +216,17 @@ class LinkedSplitCharts(QtGui.QWidget):
         sizes.extend([min_h_ind] * len(self.subplots))
         self.splitter.setSizes(sizes)  # , int(self.height()*0.2)
 
-    def plot_main(
+    def plot_ohlc_main(
         self,
         symbol: Symbol,
         array: np.ndarray,
-        ohlc: bool = True,
+        style: str = 'bar',
     ) -> 'ChartPlotWidget':
         """Start up and show main (price) chart and all linked subcharts.
+
+        The data input struct array must include OHLC fields.
         """
         self.digits = symbol.digits()
-
-        # TODO: this should eventually be a view onto shared mem or some
-        # higher level type / API
-        self._array = array
 
         # add crosshairs
         self._ch = CrossHair(
@@ -235,11 +237,13 @@ class LinkedSplitCharts(QtGui.QWidget):
             name=symbol.key,
             array=array,
             xaxis=self.xaxis,
-            ohlc=ohlc,
+            style=style,
             _is_main=True,
         )
         # add crosshair graphic
         self.chart.addItem(self._ch)
+
+        # axis placement
         if _xaxis_at == 'bottom':
             self.chart.hideAxis('bottom')
 
@@ -253,7 +257,7 @@ class LinkedSplitCharts(QtGui.QWidget):
         name: str,
         array: np.ndarray,
         xaxis: DynamicDateAxis = None,
-        ohlc: bool = False,
+        style: str = 'line',
         _is_main: bool = False,
         **cpw_kwargs,
     ) -> 'ChartPlotWidget':
@@ -263,7 +267,7 @@ class LinkedSplitCharts(QtGui.QWidget):
         """
         if self.chart is None and not _is_main:
             raise RuntimeError(
-                "A main plot must be created first with `.plot_main()`")
+                "A main plot must be created first with `.plot_ohlc_main()`")
 
         # source of our custom interactions
         cv = ChartView()
@@ -277,6 +281,11 @@ class LinkedSplitCharts(QtGui.QWidget):
             )
 
         cpw = ChartPlotWidget(
+
+            # this name will be used to register the primary
+            # graphics curve managed by the subchart
+            name=name,
+
             array=array,
             parent=self.splitter,
             axisItems={
@@ -287,11 +296,12 @@ class LinkedSplitCharts(QtGui.QWidget):
             cursor=self._ch,
             **cpw_kwargs,
         )
+
+        # give viewbox a reference to primary chart
+        # allowing for kb controls and interactions
+        # (see our custom view in `._interactions.py`)
         cv.chart = cpw
 
-        # this name will be used to register the primary
-        # graphics curve managed by the subchart
-        cpw.name = name
         cpw.plotItem.vb.linked_charts = self
         cpw.setFrameStyle(QtGui.QFrame.StyledPanel)  # | QtGui.QFrame.Plain)
         cpw.hideButtons()
@@ -305,10 +315,14 @@ class LinkedSplitCharts(QtGui.QWidget):
         self._ch.add_plot(cpw)
 
         # draw curve graphics
-        if ohlc:
+        if style == 'bar':
             cpw.draw_ohlc(name, array)
-        else:
+
+        elif style == 'line':
             cpw.draw_curve(name, array)
+
+        else:
+            raise ValueError(f"Chart style {style} is currently unsupported")
 
         if not _is_main:
             # track by name
@@ -319,6 +333,8 @@ class LinkedSplitCharts(QtGui.QWidget):
 
             # XXX: we need this right?
             # self.splitter.addWidget(cpw)
+        else:
+            assert style == 'bar', 'main chart must be OHLC'
 
         return cpw
 
@@ -344,6 +360,7 @@ class ChartPlotWidget(pg.PlotWidget):
     def __init__(
         self,
         # the data view we generate graphics from
+        name: str,
         array: np.ndarray,
         static_yrange: Optional[Tuple[float, float]] = None,
         cursor: Optional[CrossHair] = None,
@@ -356,17 +373,26 @@ class ChartPlotWidget(pg.PlotWidget):
             # parent=None,
             # plotItem=None,
             # antialias=True,
+            useOpenGL=True,
             **kwargs
         )
+
+        self.name = name
+
         # self.setViewportMargins(0, 0, 0, 0)
-        self._array = array  # readonly view of data
+        self._ohlc = array  # readonly view of ohlc data
+        self.default_view()
+
         self._arrays = {}  # readonly view of overlays
         self._graphics = {}  # registry of underlying graphics
-        self._overlays = {}  # registry of overlay curves
+        self._overlays = set()  # registry of overlay curve names
+
         self._labels = {}  # registry of underlying graphics
         self._ysticks = {}  # registry of underlying graphics
+
         self._vb = self.plotItem.vb
         self._static_yrange = static_yrange  # for "known y-range style"
+
         self._view_mode: str = 'follow'
         self._cursor = cursor  # placehold for mouse
 
@@ -377,6 +403,7 @@ class ChartPlotWidget(pg.PlotWidget):
         # show background grid
         self.showGrid(x=True, y=True, alpha=0.5)
 
+        # TODO: stick in config
         # use cross-hair for cursor?
         # self.setCursor(QtCore.Qt.CrossCursor)
 
@@ -391,22 +418,25 @@ class ChartPlotWidget(pg.PlotWidget):
         self._vb.sigResized.connect(self._set_yrange)
 
     def last_bar_in_view(self) -> bool:
-        self._array[-1]['index']
+        self._ohlc[-1]['index']
 
     def update_contents_labels(
         self,
         index: int,
         # array_name: str,
     ) -> None:
-        if index >= 0 and index < len(self._array):
+        if index >= 0 and index < self._ohlc[-1]['index']:
             for name, (label, update) in self._labels.items():
 
-                if name is self.name :
-                    array = self._array
+                if name is self.name:
+                    array = self._ohlc
                 else:
                     array = self._arrays[name]
 
-                update(index, array)
+                try:
+                    update(index, array)
+                except IndexError:
+                    log.exception(f"Failed to update label: {name}")
 
     def _set_xlimits(
         self,
@@ -430,8 +460,11 @@ class ChartPlotWidget(pg.PlotWidget):
         """Return a range tuple for the bars present in view.
         """
         l, r = self.view_range()
-        lbar = max(l, 0)
-        rbar = min(r, len(self._array))
+        a = self._ohlc
+        lbar = max(l, a[0]['index'])
+        rbar = min(r, a[-1]['index'])
+        # lbar = max(l, 0)
+        # rbar = min(r, len(self._ohlc))
         return l, lbar, rbar, r
 
     def default_view(
@@ -441,7 +474,8 @@ class ChartPlotWidget(pg.PlotWidget):
         """Set the view box to the "default" startup view of the scene.
 
         """
-        xlast = self._array[index]['index']
+        xlast = self._ohlc[index]['index']
+        print(xlast)
         begin = xlast - _bars_to_left_in_follow_mode
         end = xlast + _bars_from_right_in_follow_mode
 
@@ -462,7 +496,7 @@ class ChartPlotWidget(pg.PlotWidget):
         self._vb.setXRange(
             min=l + 1,
             max=r + 1,
-            # holy shit, wtf dude... why tf would this not be 0 by
+            # TODO: holy shit, wtf dude... why tf would this not be 0 by
             # default... speechless.
             padding=0,
         )
@@ -477,6 +511,7 @@ class ChartPlotWidget(pg.PlotWidget):
         """Draw OHLC datums to chart.
         """
         graphics = style(self.plotItem)
+
         # adds all bar/candle graphics objects for each data point in
         # the np array buffer to be drawn on next render cycle
         self.addItem(graphics)
@@ -486,10 +521,12 @@ class ChartPlotWidget(pg.PlotWidget):
 
         self._graphics[name] = graphics
 
-        label = ContentsLabel(chart=self, anchor_at=('top', 'left'))
-        self._labels[name] = (label, partial(label.update_from_ohlc, name))
-        label.show()
-        self.update_contents_labels(len(data) - 1) #, name)
+        self.add_contents_label(
+            name,
+            anchor_at=('top', 'left'),
+            update_func=ContentsLabel.update_from_ohlc,
+        )
+        self.update_contents_labels(len(data) - 1)
 
         self._add_sticky(name)
 
@@ -500,48 +537,73 @@ class ChartPlotWidget(pg.PlotWidget):
         name: str,
         data: np.ndarray,
         overlay: bool = False,
+        color: str = 'default_light',
+        add_label: bool = True,
         **pdi_kwargs,
     ) -> pg.PlotDataItem:
-        # draw the indicator as a plain curve
+        """Draw a "curve" (line plot graphics) for the provided data in
+        the input array ``data``.
+
+        """
         _pdi_defaults = {
-            'pen': pg.mkPen(hcolor('default_light')),
+            'pen': pg.mkPen(hcolor(color)),
         }
         pdi_kwargs.update(_pdi_defaults)
 
         curve = pg.PlotDataItem(
-            data[name],
+            y=data[name],
+            x=data['index'],
             # antialias=True,
             name=name,
+
             # TODO: see how this handles with custom ohlcv bars graphics
+            # and/or if we can implement something similar for OHLC graphics
             clipToView=True,
+
             **pdi_kwargs,
         )
         self.addItem(curve)
 
-        # register overlay curve with name
+        # register curve graphics and backing array for name
         self._graphics[name] = curve
+        self._arrays[name] = data
 
         if overlay:
-            anchor_at = ('bottom', 'right')
-            self._overlays[name] = curve
-            self._arrays[name] = data
+            anchor_at = ('bottom', 'left')
+            self._overlays.add(name)
 
         else:
-            anchor_at = ('top', 'right')
+            anchor_at = ('top', 'left')
 
             # TODO: something instead of stickies for overlays
             # (we need something that avoids clutter on x-axis).
             self._add_sticky(name, bg_color='default_light')
 
-        label = ContentsLabel(chart=self, anchor_at=anchor_at)
-        self._labels[name] = (label, partial(label.update_from_value, name))
-        label.show()
-        self.update_contents_labels(len(data) - 1) #, name)
+        if add_label:
+            self.add_contents_label(name, anchor_at=anchor_at)
+            self.update_contents_labels(len(data) - 1)
 
         if self._cursor:
             self._cursor.add_curve_cursor(self, curve)
 
         return curve
+
+    def add_contents_label(
+        self,
+        name: str,
+        anchor_at: Tuple[str, str] = ('top', 'left'),
+        update_func: Callable = ContentsLabel.update_from_value,
+    ) -> ContentsLabel:
+
+        label = ContentsLabel(chart=self, anchor_at=anchor_at)
+        self._labels[name] = (
+            # calls class method on instance
+            label,
+            partial(update_func, label, name)
+        )
+        label.show()
+
+        return label
 
     def _add_sticky(
         self,
@@ -569,7 +631,7 @@ class ChartPlotWidget(pg.PlotWidget):
         """Update the named internal graphics from ``array``.
 
         """
-        self._array = array
+        self._ohlc = array
         graphics = self._graphics[name]
         graphics.update_from_array(array, **kwargs)
         return graphics
@@ -584,14 +646,18 @@ class ChartPlotWidget(pg.PlotWidget):
 
         """
         if name not in self._overlays:
-            self._array = array
+            self._ohlc = array
         else:
             self._arrays[name] = array
 
         curve = self._graphics[name]
+
         # TODO: we should instead implement a diff based
-        # "only update with new items" on the pg.PlotDataItem
-        curve.setData(array[name], **kwargs)
+        # "only update with new items" on the pg.PlotCurveItem
+        # one place to dig around this might be the `QBackingStore`
+        # https://doc.qt.io/qt-5/qbackingstore.html
+        curve.setData(y=array[name], x=array['index'], **kwargs)
+
         return curve
 
     def _set_yrange(
@@ -625,8 +691,9 @@ class ChartPlotWidget(pg.PlotWidget):
 
             # TODO: logic to check if end of bars in view
             extra = view_len - _min_points_to_show
-            begin = 0 - extra
-            end = len(self._array) - 1 + extra
+            begin = self._ohlc[0]['index'] - extra
+            # end = len(self._ohlc) - 1 + extra
+            end = self._ohlc[-1]['index'] - 1 + extra
 
             # XXX: test code for only rendering lines for the bars in view.
             # This turns out to be very very poor perf when scaling out to
@@ -642,10 +709,15 @@ class ChartPlotWidget(pg.PlotWidget):
             #     f"view_len: {view_len}, bars_len: {bars_len}\n"
             #     f"begin: {begin}, end: {end}, extra: {extra}"
             # )
-            self._set_xlimits(begin, end)
+            # self._set_xlimits(begin, end)
 
             # TODO: this should be some kind of numpy view api
-            bars = self._array[lbar:rbar]
+            # bars = self._ohlc[lbar:rbar]
+
+            a = self._ohlc
+            ifirst = a[0]['index']
+            bars = a[lbar - ifirst:rbar - ifirst]
+
             if not len(bars):
                 # likely no data loaded yet or extreme scrolling?
                 log.error(f"WTF bars_range = {lbar}:{rbar}")
@@ -731,10 +803,6 @@ async def _async_main(
 
     # chart_app.init_search()
 
-    # XXX: bug zone if you try to ctl-c after this we get hangs again?
-    # wtf...
-    # await tractor.breakpoint()
-
     # historical data fetch
     brokermod = brokers.get_brokermod(brokername)
 
@@ -747,29 +815,27 @@ async def _async_main(
         ohlcv = feed.shm
         bars = ohlcv.array
 
-        # TODO: when we start messing with line charts
-        # c = np.zeros(len(bars), dtype=[
-        #     (sym, bars.dtype.fields['close'][0]),
-        #     ('index', 'i4'),
-        # ])
-        # c[sym] = bars['close']
-        # c['index'] = bars['index']
-        # linked_charts, chart = chart_app.load_symbol(sym, c, ohlc=False)
-
         # load in symbol's ohlc data
+        # await tractor.breakpoint()
         linked_charts, chart = chart_app.load_symbol(sym, bars)
 
         # plot historical vwap if available
-        vwap_in_history = False
-        if 'vwap' in bars.dtype.fields:
-            vwap_in_history = True
-            chart.draw_curve(
-                name='vwap',
-                data=bars,
-                overlay=True,
-            )
+        wap_in_history = False
+
+        if brokermod._show_wap_in_history:
+
+            if 'bar_wap' in bars.dtype.fields:
+                wap_in_history = True
+                chart.draw_curve(
+                    name='bar_wap',
+                    data=bars,
+                    add_label=False,
+                )
 
         chart._set_yrange()
+
+        # TODO: a data view api that makes this less shit
+        chart._shm = ohlcv
 
         # eventually we'll support some kind of n-compose syntax
         fsp_conf = {
@@ -799,19 +865,13 @@ async def _async_main(
                 loglevel,
             )
 
-            # update last price sticky
-            last_price_sticky = chart._ysticks[chart.name]
-            last_price_sticky.update_from_data(
-                *ohlcv.array[-1][['index', 'close']]
-            )
-
             # start graphics update loop(s)after receiving first live quote
             n.start_soon(
                 chart_from_quotes,
                 chart,
                 feed.stream,
                 ohlcv,
-                vwap_in_history,
+                wap_in_history,
             )
 
             # wait for a first quote before we start any update tasks
@@ -834,7 +894,7 @@ async def chart_from_quotes(
     chart: ChartPlotWidget,
     stream,
     ohlcv: np.ndarray,
-    vwap_in_history: bool = False,
+    wap_in_history: bool = False,
 ) -> None:
     """The 'main' (price) chart real-time update loop.
 
@@ -847,28 +907,39 @@ async def chart_from_quotes(
     # - update last open price correctly instead
     #   of copying it from last bar's close
     # - 5 sec bar lookback-autocorrection like tws does?
+
+    # update last price sticky
     last_price_sticky = chart._ysticks[chart.name]
+    last_price_sticky.update_from_data(
+        *ohlcv.array[-1][['index', 'close']]
+    )
 
     def maxmin():
         # TODO: implement this
         # https://arxiv.org/abs/cs/0610046
         # https://github.com/lemire/pythonmaxmin
 
-        array = chart._array
+        array = chart._ohlc
+        ifirst = array[0]['index']
+
         last_bars_range = chart.bars_range()
         l, lbar, rbar, r = last_bars_range
-        in_view = array[lbar:rbar]
+        in_view = array[lbar - ifirst:rbar - ifirst]
+
+        assert in_view.size
+
         mx, mn = np.nanmax(in_view['high']), np.nanmin(in_view['low'])
 
-        # TODO: when we start using line charts
+        # TODO: when we start using line charts, probably want to make
+        # this an overloaded call on our `DataView
         # sym = chart.name
         # mx, mn = np.nanmax(in_view[sym]), np.nanmin(in_view[sym])
 
         return last_bars_range, mx, mn
 
-    last_bars_range, last_mx, last_mn = maxmin()
-
     chart.default_view()
+
+    last_bars_range, last_mx, last_mn = maxmin()
 
     last, volume = ohlcv.array[-1][['close', 'volume']]
 
@@ -889,7 +960,6 @@ async def chart_from_quotes(
 
     async for quotes in stream:
         for sym, quote in quotes.items():
-            # print(f'CHART: {quote}')
 
             for tick in quote.get('ticks', ()):
 
@@ -898,7 +968,14 @@ async def chart_from_quotes(
                 price = tick.get('price')
                 size = tick.get('size')
 
-                if ticktype in ('trade', 'utrade'):
+                # compute max and min trade values to display in view
+                # TODO: we need a streaming minmax algorithm here, see
+                # def above.
+                brange, mx_in_view, mn_in_view = maxmin()
+                l, lbar, rbar, r = brange
+
+                if ticktype in ('trade', 'utrade', 'last'):
+
                     array = ohlcv.array
 
                     # update price sticky(s)
@@ -907,25 +984,16 @@ async def chart_from_quotes(
                         *last[['index', 'close']]
                     )
 
+                    # plot bars
                     # update price bar
                     chart.update_ohlc_from_array(
                         chart.name,
                         array,
                     )
 
-                    # chart.update_curve_from_array(
-                        # chart.name,
-                        # TODO: when we start using line charts
-                        # np.array(array['close'], dtype=[(chart.name, 'f8')])
-
-                    # if vwap_in_history:
-                    #     # update vwap overlay line
-                    #     chart.update_curve_from_array('vwap', ohlcv.array)
-
-                # compute max and min trade values to display in view
-                # TODO: we need a streaming minmax algorithm here, see
-                # def above.
-                brange, mx_in_view, mn_in_view = maxmin()
+                    if wap_in_history:
+                        # update vwap overlay line
+                        chart.update_curve_from_array('bar_wap', ohlcv.array)
 
                 # XXX: prettty sure this is correct?
                 # if ticktype in ('trade', 'last'):
@@ -1021,12 +1089,14 @@ async def spawn_fsps(
 
                 # spawn closure, can probably define elsewhere
                 async def spawn_fsp_daemon(
-                    fsp_name,
-                    conf,
+                    fsp_name: str,
+                    display_name: str,
+                    conf: dict,
                 ):
                     """Start an fsp subactor async.
 
                     """
+                    print(f'FSP NAME: {fsp_name}')
                     portal = await n.run_in_actor(
 
                         # name as title of sub-chart
@@ -1057,6 +1127,7 @@ async def spawn_fsps(
                 ln.start_soon(
                     spawn_fsp_daemon,
                     fsp_func_name,
+                    display_name,
                     conf,
                 )
 
@@ -1081,6 +1152,8 @@ async def update_signals(
 ) -> None:
     """FSP stream chart update loop.
 
+    This is called once for each entry in the fsp
+    config map.
     """
     shm = conf['shm']
 
@@ -1094,6 +1167,7 @@ async def update_signals(
         last_val_sticky = None
 
     else:
+
         chart = linked_charts.add_plot(
             name=fsp_func_name,
             array=shm.array,
@@ -1112,6 +1186,7 @@ async def update_signals(
             # fsp_func_name
         )
 
+        # read last value
         array = shm.array
         value = array[fsp_func_name][-1]
 
@@ -1119,7 +1194,8 @@ async def update_signals(
         last_val_sticky.update_from_data(-1, value)
 
         chart.update_curve_from_array(fsp_func_name, array)
-        chart.default_view()
+
+        chart._shm = shm
 
     # TODO: figure out if we can roll our own `FillToThreshold` to
     # get brush filled polygons for OS/OB conditions.
@@ -1132,23 +1208,28 @@ async def update_signals(
     # graphics.curve.setFillLevel(50)
 
     # add moveable over-[sold/bought] lines
-    level_line(chart, 30)
-    level_line(chart, 70, orient_v='top')
+    # and labels only for the 70/30 lines
+    level_line(chart, 20, show_label=False)
+    level_line(chart, 30, orient_v='top')
+    level_line(chart, 70, orient_v='bottom')
+    level_line(chart, 80, orient_v='top', show_label=False)
 
-    chart._shm = shm
     chart._set_yrange()
 
     stream = conf['stream']
 
     # update chart graphics
     async for value in stream:
-        # p = pg.debug.Profiler(disabled=False, delayed=False)
+
+        # read last
         array = shm.array
         value = array[-1][fsp_func_name]
+
         if last_val_sticky:
             last_val_sticky.update_from_data(-1, value)
+
+        # update graphics
         chart.update_curve_from_array(fsp_func_name, array)
-        # p('rendered rsi datum')
 
 
 async def check_for_new_bars(feed, ohlcv, linked_charts):
@@ -1199,7 +1280,7 @@ async def check_for_new_bars(feed, ohlcv, linked_charts):
         # resize view
         # price_chart._set_yrange()
 
-        for name, curve in price_chart._overlays.items():
+        for name in price_chart._overlays:
 
             price_chart.update_curve_from_array(
                 name,
@@ -1207,15 +1288,16 @@ async def check_for_new_bars(feed, ohlcv, linked_charts):
             )
 
             # # TODO: standard api for signal lookups per plot
-            # if name in price_chart._array.dtype.fields:
+            # if name in price_chart._ohlc.dtype.fields:
 
             #     # should have already been incremented above
-            #     price_chart.update_curve_from_array(name, price_chart._array)
+            #     price_chart.update_curve_from_array(name, price_chart._ohlc)
 
         for name, chart in linked_charts.subplots.items():
             chart.update_curve_from_array(chart.name, chart._shm.array)
             # chart._set_yrange()
 
+        # shift the view if in follow mode
         price_chart.increment_view()
 
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -839,10 +839,10 @@ async def _async_main(
 
         # eventually we'll support some kind of n-compose syntax
         fsp_conf = {
-            'vwap': {
-                'overlay': True,
-                'anchor': 'session',
-            },
+            # 'vwap': {
+            #     'overlay': True,
+            #     'anchor': 'session',
+            # },
             'rsi': {
                 'period': 14,
                 'chart_kwargs': {

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -139,8 +139,8 @@ def run_qtractor(
             exc = outcome.error
 
             if isinstance(outcome.error, KeyboardInterrupt):
-                # make it look like ``trio``
-                print("Aborted!")
+                # make it kinda look like ``trio``
+                print("Terminated!")
 
             else:
                 traceback.print_exception(type(exc), exc, exc.__traceback__)

--- a/piker/ui/_graphics.py
+++ b/piker/ui/_graphics.py
@@ -481,7 +481,6 @@ class BarItems(pg.GraphicsObject):
         self.last_bar = QtGui.QPicture()
         self.history = QtGui.QPicture()
 
-        # TODO: implement updateable pixmap solution
         self._pi = plotitem
 
         # XXX: not sure this actually needs to be an array other
@@ -648,13 +647,6 @@ class BarItems(pg.GraphicsObject):
 
         p.setPen(self.bars_pen)
         p.drawPath(self.path)
-
-        # TODO: if we can ever make pixmaps work...
-        # p.drawPixmap(0, 0, self.picture)
-        # self._pmi.setPixmap(self.picture)
-        # print(self.scene())
-
-        # profiler('bars redraw:')
 
     # @timeit
     def boundingRect(self):

--- a/piker/ui/_graphics.py
+++ b/piker/ui/_graphics.py
@@ -417,7 +417,6 @@ def lines_from_ohlc(row: np.ndarray, w: float) -> Tuple[QLineF]:
     return [hl, o, c]
 
 
-@timeit
 @jit(
     # TODO: for now need to construct this manually for readonly arrays, see
     # https://github.com/numba/numba/issues/4511
@@ -489,7 +488,7 @@ def path_arrays_from_ohlc(
     return x, y, c
 
 
-@timeit
+# @timeit
 def gen_qpath(
     data,
     start,  # XXX: do we need this?
@@ -497,6 +496,8 @@ def gen_qpath(
 ) -> QtGui.QPainterPath:
 
     x, y, c = path_arrays_from_ohlc(data, start, bar_gap=w)
+
+    # TODO: numba the internals of this!
     return pg.functions.arrayToQPath(x, y, connect=c)
 
 
@@ -542,7 +543,7 @@ class BarItems(pg.GraphicsObject):
         self.start_index: int = 0
         self.stop_index: int = 0
 
-    @timeit
+    # @timeit
     def draw_from_data(
         self,
         data: np.ndarray,
@@ -717,6 +718,7 @@ class BarItems(pg.GraphicsObject):
         # lead to any perf gains other then when zoomed in to less bars
         # in view.
         p.drawPicture(0, 0, self.last_bar)
+
         p.setPen(self.bars_pen)
         p.drawPath(self.path)
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -245,7 +245,7 @@ class ChartView(ViewBox):
             log.debug("Max zoom bruh...")
             return
 
-        if ev.delta() < 0 and vl >= len(self.linked_charts._array) + 666:
+        if ev.delta() < 0 and vl >= len(self.linked_charts.chart._ohlc) + 666:
             log.debug("Min zoom bruh...")
             return
 
@@ -268,9 +268,9 @@ class ChartView(ViewBox):
         #     ).map(furthest_right_coord)
         # )
 
-        # This seems like the most "intuitive option, a hybrdid of
+        # This seems like the most "intuitive option, a hybrid of
         # tws and tv styles
-        last_bar = pg.Point(rbar)
+        last_bar = pg.Point(int(rbar))
 
         self._resetTarget()
         self.scaleBy(s, last_bar)

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -18,6 +18,7 @@
 Qt UI styling.
 """
 from typing import Optional
+import math
 
 import pyqtgraph as pg
 from PyQt5 import QtCore, QtGui
@@ -27,10 +28,9 @@ from ..log import get_logger
 
 log = get_logger(__name__)
 
-# chart-wide font
-# font size 6px / 53 dpi (3x scaled down on 4k hidpi)
-_default_font_inches_we_like = 6 / 53  # px / (px / inch) = inch
-_down_2_font_inches_we_like = 4 / 53
+# chart-wide fonts specified in inches
+_default_font_inches_we_like = 0.0666
+_down_2_font_inches_we_like = 6 / 96
 
 
 class DpiAwareFont:
@@ -66,8 +66,12 @@ class DpiAwareFont:
         listed in the script in ``snippets/qt_screen_info.py``.
 
         """
-        dpi = screen.physicalDotsPerInch()
-        font_size = round(self._iwl * dpi)
+        # take the max since scaling can make things ugly in some cases
+        pdpi = screen.physicalDotsPerInch()
+        ldpi = screen.logicalDotsPerInch()
+        dpi = max(pdpi, ldpi)
+
+        font_size = math.floor(self._iwl * dpi)
         log.info(
             f"\nscreen:{screen.name()} with DPI: {dpi}"
             f"\nbest font size is {font_size}\n"

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -29,8 +29,8 @@ from ..log import get_logger
 log = get_logger(__name__)
 
 # chart-wide fonts specified in inches
-_default_font_inches_we_like = 0.0666
-_down_2_font_inches_we_like = 6 / 96
+_default_font_inches_we_like = 6 / 96
+_down_2_font_inches_we_like = 5 / 96
 
 
 class DpiAwareFont:


### PR DESCRIPTION
This re implements OHLC sampling graphics using the much faster [`QPainterPath`](https://doc.qt.io/qt-5/qpainterpath.html#composing-a-qpainterpath) which is how `pyqtgraph` gets decent speed for curves internally.

One of the nice properties of using this API instead is being able to append to existing paths very easily and they draw much faster for way larger data sets (think 3ms to draw 30-40k datums on screen). There's probably still further speedups to get with moving some internal routines in `pyqtgraph` to use `numba`. One of the major goals with all this is to get low latency interaction with a days worth of 1s sampled futures market data in view.

I won't go into too much detail because a lot of this was fairly involved tinkering and likely not super relevant to the average maintainer/contributor.

Some further fixes:
- kill the actor stack on window close gracefully
- fix some axis and font size stuff

New internal work:
- make shared mem arrays "start" indexing in the middle of the large backing array such that they can be backfilled with historical data loaded after the initial seed
- add support for prepending to shm segments which will auto-adjust the "start" index for readers of the consumable data
- adjust a bunch of internal UI indexing logic to compute correct "relative" indexes when accessing the "filled out" data segments from shm (probably need some better abstractions and APIs here)
- allow for brokers to provide a historical weighted average price field (wap) in the OHLC array if so defined in their module
