### PR TITLE
Symbol search

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -18,7 +18,6 @@
 Structured, daemon tree service management.
 
 """
-from functools import partial
 from typing import Optional, Union, Callable, Any
 from contextlib import asynccontextmanager, AsyncExitStack
 from collections import defaultdict
@@ -72,7 +71,7 @@ class Services(BaseModel):
         ctx, first = await self.ctx_stack.enter_async_context(
             portal.open_context(
                 target,
-            **kwargs,
+                **kwargs,
             )
         )
         return ctx

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -142,8 +142,14 @@ async def maybe_open_runtime(
     Start the ``tractor`` runtime (a root actor) if none exists.
 
     """
+    settings = _tractor_kwargs
+    settings.update(kwargs)
+
     if not tractor.current_actor(err_on_no_runtime=False):
-        async with tractor.open_root_actor(loglevel=loglevel, **kwargs):
+        async with tractor.open_root_actor(
+            loglevel=loglevel,
+            **settings,
+        ):
             yield
     else:
         yield

--- a/piker/brokers/_util.py
+++ b/piker/brokers/_util.py
@@ -32,6 +32,10 @@ class SymbolNotFound(BrokerError):
     "Symbol not found by broker search"
 
 
+class NoData(BrokerError):
+    "Symbol data not permitted"
+
+
 def resproc(
     resp: asks.response_objects.Response,
     log: logging.Logger,

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -82,7 +82,7 @@ _ohlc_dtype = [
 ohlc_dtype = np.dtype(_ohlc_dtype)
 
 _show_wap_in_history = False
-_search_conf = {'pause_period': 0.375}
+_search_conf = {'pause_period': 0.0616}
 
 
 # https://binance-docs.github.io/apidocs/spot/en/#exchange-information
@@ -298,7 +298,7 @@ async def stream_messages(ws):
         if cs.cancelled_caught:
 
             timeouts += 1
-            if timeouts > 2:
+            if timeouts > 10:
                 raise trio.TooSlowError("binance feed seems down?")
 
             continue

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -207,6 +207,25 @@ class Client:
 
         return self._pairs
 
+    async def search_symbols(
+        self,
+        pattern: str,
+        limit: int = None,
+    ) -> Dict[str, Any]:
+        if self._pairs is not None:
+            data = self._pairs
+        else:
+            data = await self.symbol_info()
+
+        matches = fuzzy.extractBests(
+            pattern,
+            data,
+            score_cutoff=50,
+        )
+        # repack in dict form
+        return {item[0]['symbol']: item[0]
+         for item in matches}
+
     async def bars(
         self,
         symbol: str,

--- a/piker/brokers/cli.py
+++ b/piker/brokers/cli.py
@@ -50,7 +50,7 @@ def api(config, meth, kwargs, keys):
     """Make a broker-client API method call
     """
     # global opts
-    broker = config['broker']
+    broker = config['brokers'][0]
 
     _kwargs = {}
     for kwarg in kwargs:
@@ -87,7 +87,7 @@ def quote(config, tickers, df_output):
     """Print symbol quotes to the console
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
 
     quotes = trio.run(partial(core.stocks_quote, brokermod, tickers))
     if not quotes:
@@ -123,7 +123,7 @@ def bars(config, symbol, count, df_output):
     """Retreive 1m bars for symbol and print on the console
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
 
     # broker backend should return at the least a
     # list of candle dictionaries
@@ -159,7 +159,7 @@ def record(config, rate, name, dhost, filename):
     """Record client side quotes to a file on disk
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
     loglevel = config['loglevel']
     log = config['log']
 
@@ -222,7 +222,7 @@ def optsquote(config, symbol, df_output, date):
     """Retreive symbol option quotes on the console
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
 
     quotes = trio.run(
         partial(
@@ -250,7 +250,7 @@ def symbol_info(config, tickers):
     """Print symbol quotes to the console
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
 
     quotes = trio.run(partial(core.symbol_info, brokermod, tickers))
     if not quotes:
@@ -273,7 +273,7 @@ def search(config, pattern):
     """Search for symbols from broker backend(s).
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
 
     quotes = tractor.run(
         partial(core.symbol_search, brokermod, pattern),

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -158,10 +158,19 @@ _adhoc_cmdty_data_map = {
 }
 
 _adhoc_futes_set = {
+
+    # equities
     'nq.globex',
     'mnq.globex',
     'es.globex',
     'mes.globex',
+
+    # cypto$
+    'brr.cmecrypto',
+    'ethusdrr.cmecrypto',
+
+    # metals
+    'xauusd.cmdty',
 }
 
 # exchanges we don't support at the moment due to not knowing

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1286,13 +1286,12 @@ async def open_symbol_search(
                 await trio.sleep(diff)
                 try:
                     pattern = stream.receive_nowait()
-                    # if new:
-                    #     pattern = new
                 except trio.WouldBlock:
                     pass
 
-            if not pattern:
+            if not pattern or pattern.isspace():
                 log.warning('empty pattern received, skipping..')
+                await stream.send(matches)
                 continue
 
             log.debug(f'searching for {pattern}')

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -153,7 +153,7 @@ class Client:
             'User-Agent':
                 'krakenex/2.1.0 (+https://github.com/veox/python3-krakenex)'
         })
-        self._pairs = None
+        self._pairs: list[str] = []
 
     @property
     def pairs(self) -> Dict[str, Any]:
@@ -289,7 +289,7 @@ class Client:
 async def get_client() -> Client:
     client = Client()
 
-    # load all symbols locally for fast search
+    # at startup, load all symbols locally for fast search
     await client.cache_symbols()
 
     yield client

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -289,6 +289,7 @@ async def get_client() -> Client:
     yield client
 
 
+@tractor.context
 async def open_symbol_search(
     ctx: tractor.Context,
 ) -> Client:

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -207,7 +207,7 @@ class Client:
 
         return self._pairs
 
-    async def search_stocks(
+    async def search_symbols(
         self,
         pattern: str,
         limit: int = None,

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -57,6 +57,11 @@ log = get_logger(__name__)
 _url = 'https://api.kraken.com/0'
 
 
+_search_conf = {
+    'pause_period': 0.0616
+}
+
+
 # Broker specific ohlc schema which includes a vwap field
 _ohlc_dtype = [
     ('index', int),
@@ -231,6 +236,7 @@ class Client:
         if since is None:
             since = arrow.utcnow().floor('minute').shift(
                 minutes=-count).timestamp()
+
         # UTC 2017-07-02 12:53:20 is oldest seconds value
         since = str(max(1499000000, since))
         json = await self._public(
@@ -488,12 +494,12 @@ async def open_autorecon_ws(url):
 
 
 async def backfill_bars(
+
     sym: str,
     shm: ShmArray,  # type: ignore # noqa
-
     count: int = 10,  # NOTE: any more and we'll overrun the underlying buffer
-
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
+
 ) -> None:
     """Fill historical bars into shared mem / storage afap.
     """
@@ -637,7 +643,6 @@ async def stream_quotes(
                 # XXX: format required by ``tractor.msg.pub``
                 # requires a ``Dict[topic: str, quote: dict]``
                 await send_chan.send({topic: quote})
-
 
 
 @tractor.context

--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -628,7 +628,7 @@ class Client:
             f"Took {time.time() - start} seconds to retreive {len(bars)} bars")
         return bars
 
-    async def search_stocks(
+    async def search_symbols(
         self,
         pattern: str,
         # how many contracts to return

--- a/piker/clearing/_client.py
+++ b/piker/clearing/_client.py
@@ -136,7 +136,6 @@ def get_orders(
     return _orders
 
 
-# TODO: make this a ``tractor.msg.pub``
 async def send_order_cmds(symbol_key: str):
     """
     Order streaming task: deliver orders transmitted from UI

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -57,21 +57,31 @@ def pikerd(loglevel, host, tl, pdb):
 
 
 @click.group(context_settings=_context_defaults)
-@click.option('--broker', '-b', default=DEFAULT_BROKER,
-              help='Broker backend to use')
+@click.option(
+    '--brokers', '-b',
+    default=[DEFAULT_BROKER],
+    multiple=True,
+    help='Broker backend to use'
+)
 @click.option('--loglevel', '-l', default='warning', help='Logging level')
 @click.option('--tl', is_flag=True, help='Enable tractor logging')
 @click.option('--configdir', '-c', help='Configuration directory')
 @click.pass_context
-def cli(ctx, broker, loglevel, tl, configdir):
+def cli(ctx, brokers, loglevel, tl, configdir):
     if configdir is not None:
         assert os.path.isdir(configdir), f"`{configdir}` is not a valid path"
         config._override_config_dir(configdir)
 
     ctx.ensure_object(dict)
+
+    if len(brokers) == 1:
+        brokermods = [get_brokermod(brokers[0])]
+    else:
+        brokermods = [get_brokermod(broker) for broker in brokers]
+
     ctx.obj.update({
-        'broker': broker,
-        'brokermod': get_brokermod(broker),
+        'brokers': brokers,
+        'brokermods': brokermods,
         'loglevel': loglevel,
         'tractorloglevel': None,
         'log': get_console_log(loglevel),

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -227,7 +227,8 @@ async def sample_and_broadcast(
             # end up triggering backpressure which which will
             # eventually block this producer end of the feed and
             # thus other consumers still attached.
-            subs = bus._subscribers[sym]
+            subs = bus._subscribers[sym.lower()]
+
             for ctx in subs:
                 # print(f'sub is {ctx.chan.uid}')
                 try:

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -203,7 +203,10 @@ async def allocate_persistent_feed(
     # TODO: make this into a composed type which also
     # contains the backfiller cs for individual super-based
     # resspawns when needed.
-    bus.feeds[symbol] = (cs, init_msg, first_quote)
+
+    # XXX: the ``symbol`` here is put into our native piker format (i.e.
+    # lower case).
+    bus.feeds[symbol.lower()] = (cs, init_msg, first_quote)
 
     if opened:
         # start history backfill task ``backfill_bars()`` is
@@ -272,7 +275,12 @@ async def attach_feed_bus(
                     ctx=ctx,
                     bus=bus,
                     brokername=brokername,
+
+                    # here we pass through the selected symbol in native
+                    # "format" (i.e. upper vs. lowercase depending on
+                    # provider).
                     symbol=symbol,
+
                     loglevel=loglevel,
                 )
             )
@@ -411,7 +419,7 @@ async def install_brokerd_search(
 
                 provider_name=brokermod.name,
                 search_routine=search,
-                pause_period=brokermod._search_conf.get('pause_period'),
+                pause_period=brokermod._search_conf.get('pause_period', 0.0616),
 
             ):
                 yield

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -473,6 +473,7 @@ async def open_feed(
 
             if brokername in _search._searcher_cache:
                 yield feed
+
             else:
                 async with feed._brokerd_portal.open_context(
                     mod.open_symbol_search
@@ -489,5 +490,7 @@ async def open_feed(
                         async with _search.register_symbol_search(
                             provider_name=brokername,
                             search_routine=search,
+                            pause_period=mod._search_conf.get('pause_period'),
+
                         ):
                             yield feed

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -506,23 +506,3 @@ async def open_feed(
                     mod,
                 ):
                     yield feed
-
-                # async with feed._brokerd_portal.open_context(
-                #     mod.open_symbol_search
-                # ) as (ctx, cache):
-
-                #     # shield here since we expect the search rpc to be
-                #     # cancellable by the user as they see fit.
-                #     async with ctx.open_stream() as stream:
-
-                #         async def search(text: str) -> Dict[str, Any]:
-                #             await stream.send(text)
-                #             return await stream.receive()
-
-                #         async with _search.register_symbol_search(
-                #             provider_name=brokername,
-                #             search_routine=search,
-                #             pause_period=mod._search_conf.get('pause_period'),
-
-                #         ):
-                #             yield feed

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -419,8 +419,12 @@ async def install_brokerd_search(
 
                 provider_name=brokermod.name,
                 search_routine=search,
-                pause_period=brokermod._search_conf.get('pause_period', 0.0616),
 
+                # TODO: should be make this a required attr of
+                # a backend module?
+                pause_period=getattr(
+                    brokermod, '_search_conf', {}
+                    ).get('pause_period', 0.0616),
             ):
                 yield
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1563,7 +1563,7 @@ async def _async_main(
     widgets: Dict[str, Any],
 
     sym: str,
-    brokername: str,
+    brokernames: str,
     loglevel: str,
 
 ) -> None:
@@ -1617,7 +1617,7 @@ async def _async_main(
         chart_app.search = search
 
         # this internally starts a ``chart_symbol()`` task above
-        chart_app.load_symbol(brokername, sym, loglevel)
+        chart_app.load_symbol(brokernames[0], sym, loglevel)
 
         async with _search.register_symbol_search(
 
@@ -1645,7 +1645,7 @@ async def _async_main(
 
 def _main(
     sym: str,
-    brokername: str,
+    brokernames: [str],
     piker_loglevel: str,
     tractor_kwargs,
 ) -> None:
@@ -1655,7 +1655,7 @@ def _main(
     # Qt entry point
     run_qtractor(
         func=_async_main,
-        args=(sym, brokername, piker_loglevel),
+        args=(sym, brokernames, piker_loglevel),
         main_widget=ChartSpace,
         tractor_kwargs=tractor_kwargs,
     )

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1538,7 +1538,6 @@ async def chart_symbol(
                 },
             })
 
-
         async with trio.open_nursery() as n:
 
             # load initial fsp chain (otherwise known as "indicators")
@@ -1598,6 +1597,7 @@ async def load_providers(
         # search engines.
         for broker in brokernames:
 
+            log.info(f'Loading brokerd for {broker}')
             # spin up broker daemons for each provider
             portal = await stack.enter_async_context(
                 maybe_spawn_brokerd(

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1638,8 +1638,10 @@ async def _async_main(
         )
         chart_app.search = search
 
+        symbol, _, provider = sym.rpartition('.')
+
         # this internally starts a ``chart_symbol()`` task above
-        chart_app.load_symbol(brokernames[0], sym, loglevel)
+        chart_app.load_symbol(provider, symbol, loglevel)
 
         # TODO: seems like our incentive for brokerd caching lelel
         backends = {}

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1600,16 +1600,6 @@ async def _async_main(
         chart_app.vbox.addWidget(search.view)
         chart_app.search = search
 
-        search.view.set_results([
-            'ETHUSD',
-            'XMRUSD',
-            'XBTUSD',
-            'XMRXBT',
-            # 'XMRXBT',
-            # 'XDGUSD',
-            # 'ADAUSD',
-        ])
-
         # this internally starts a ``chart_symbol()`` task above
         chart_app.load_symbol(brokername, sym, loglevel)
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -309,7 +309,7 @@ class LinkedSplitCharts(QtGui.QWidget):
         self.chart = self.add_plot(
             name=symbol.key,
             array=array,
-            xaxis=self.xaxis,
+            # xaxis=self.xaxis,
             style=style,
             _is_main=True,
         )

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -172,6 +172,7 @@ class ChartSpace(QtGui.QWidget):
 
             # XXX: pretty sure we don't need this
             # remove any existing plots?
+            # XXX: ahh we might want to support cache unloading..
             # self.vbox.removeWidget(self.linkedcharts)
 
         # switching to a new viewable chart

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -94,6 +94,7 @@ class ChartSpace(QtGui.QWidget):
         # self.init_strategy_ui()
         self.vbox.addLayout(self.toolbar_layout)
         self.vbox.addLayout(self.hbox)
+
         self._chart_cache = {}
         self.linkedcharts: 'LinkedSplitCharts' = None
         self.symbol_label: Optional[QtGui.QLabel] = None
@@ -135,6 +136,9 @@ class ChartSpace(QtGui.QWidget):
         Expects a ``numpy`` structured array containing all the ohlcv fields.
 
         """
+        # our symbol key style is always lower case
+        symbol_key = symbol_key.lower()
+
         linkedcharts = self._chart_cache.get(symbol_key)
 
         if not self.vbox.isEmpty():

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -19,10 +19,11 @@ High level Qt chart widgets.
 
 """
 import time
+from collections import OrderedDict
+from contextlib import AsyncExitStack
 from typing import Tuple, Dict, Any, Optional, Callable
 from types import ModuleType
 from functools import partial
-from contextlib import AsyncExitStack
 
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtCore import Qt
@@ -104,7 +105,7 @@ class ChartSpace(QtGui.QWidget):
         self.vbox.addLayout(self.toolbar_layout)
         # self.vbox.addLayout(self.hbox)
 
-        self._chart_cache = {}
+        self._chart_cache = OrderedDict()
         self.linkedcharts: 'LinkedSplitCharts' = None
         self.symbol_label: Optional[QtGui.QLabel] = None
 
@@ -116,6 +117,8 @@ class ChartSpace(QtGui.QWidget):
         linked_charts: 'LinkedSplitCharts',  # type: ignore
     ) -> None:
         self._chart_cache[symbol_key] = linked_charts
+        # re-sort list in LIFO order
+        self._chart_cache.move_to_end(symbol_key, last=False)
 
     def get_chart_symbol(
         self,
@@ -191,7 +194,8 @@ class ChartSpace(QtGui.QWidget):
             )
 
             self.vbox.addWidget(linkedcharts)
-            self.set_chart_symbol(fqsn, linkedcharts)
+
+        self.set_chart_symbol(fqsn, linkedcharts)
 
         # chart is already in memory so just focus it
         if self.linkedcharts:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -106,8 +106,6 @@ class ChartSpace(QtGui.QWidget):
 
         self._chart_cache = {}
         self.linkedcharts: 'LinkedSplitCharts' = None
-        self.symbol_label: Optional[QtGui.QLabel] = None
-
         self._root_n: Optional[trio.Nursery] = None
 
     def set_chart_symbol(
@@ -1660,11 +1658,7 @@ async def _async_main(
         chart_app._root_n = root_n
 
         # setup search widget
-        # search.installEventFilter(self)
-
-        search = _search.SearchWidget(
-            chart_space=chart_app,
-        )
+        search = _search.SearchWidget(chart_space=chart_app)
 
         # the main chart's view is given focus at startup
         search.bar.unfocus()

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -145,6 +145,9 @@ def run_qtractor(
     # currently seem tricky..
     app.setQuitOnLastWindowClosed(False)
 
+    # XXX: lmfao, this is how you disable text edit cursor blinking..smh
+    app.setCursorFlashTime(0)
+
     # set global app singleton
     global _qt_app
     _qt_app = app

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -38,6 +38,7 @@ from PyQt5.QtCore import (
     QCoreApplication,
 )
 import qdarkstyle
+# import qdarkgraystyle
 import trio
 import tractor
 from outcome import Error

--- a/piker/ui/_graphics/_cursor.py
+++ b/piker/ui/_graphics/_cursor.py
@@ -435,7 +435,12 @@ class Cursor(pg.GraphicsObject):
         self,
         y_label_level: float = None,
     ) -> None:
-        g = self.graphics[self.active_plot]
+
+        plot = self.active_plot
+        if not plot:
+            return
+
+        g = self.graphics[plot]
         # show horiz line and y-label
         g['hl'].show()
         g['vl'].show()

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -694,7 +694,7 @@ class ChartView(ViewBox):
                 ev.accept()
                 self.mode.submit_exec()
 
-    def keyReleaseEvent(self, ev):
+    def keyReleaseEvent(self, ev: QtCore.QEvent):
         """
         Key release to normally to trigger release of input mode
 
@@ -712,6 +712,10 @@ class ChartView(ViewBox):
         if key == QtCore.Qt.Key_Shift:
             # if self.state['mouseMode'] == ViewBox.RectMode:
             self.setMouseMode(ViewBox.PanMode)
+
+        # ctlalt = False
+        # if (QtCore.Qt.AltModifier | QtCore.Qt.ControlModifier) == mods:
+        #     ctlalt = True
 
         # if self.state['mouseMode'] == ViewBox.RectMode:
         # if key == QtCore.Qt.Key_Space:
@@ -749,19 +753,20 @@ class ChartView(ViewBox):
         ctrl = False
         if mods == QtCore.Qt.ControlModifier:
             ctrl = True
-
-        if mods == QtCore.Qt.ControlModifier:
             self.mode._exec_mode = 'live'
 
         self._key_active = True
 
-        # alt
-        if mods == QtCore.Qt.AltModifier:
-            pass
+        # ctrl + alt
+        # ctlalt = False
+        # if (QtCore.Qt.AltModifier | QtCore.Qt.ControlModifier) == mods:
+        #     ctlalt = True
 
         # ctlr-<space>/<l> for "lookup", "search" -> open search tree
-        if ctrl and (key == QtCore.Qt.Key_L or key == QtCore.Qt.Key_Space):
-
+        if ctrl and key in {
+            QtCore.Qt.Key_L,
+            QtCore.Qt.Key_Space,
+        }:
             search = self._chart._lc.chart_space.search
             search.focus()
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -759,8 +759,9 @@ class ChartView(ViewBox):
         if mods == QtCore.Qt.AltModifier:
             pass
 
-        # ctlr-l for "lookup" -> open search / lists
-        if ctrl and key == QtCore.Qt.Key_L:
+        # ctlr-<space>/<l> for "lookup", "search" -> open search tree
+        if ctrl and (key == QtCore.Qt.Key_L or key == QtCore.Qt.Key_Space):
+
             search = self._chart._lc.chart_space.search
             search.focus()
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -724,7 +724,7 @@ class ChartView(ViewBox):
 
         self._key_active = False
 
-    def keyPressEvent(self, ev):
+    def keyPressEvent(self, ev: QtCore.QEvent) -> None:
         """
         This routine should capture key presses in the current view box.
 
@@ -759,10 +759,10 @@ class ChartView(ViewBox):
         if mods == QtCore.Qt.AltModifier:
             pass
 
-        # ctlr-k
-        if key == QtCore.Qt.Key_K and ctrl:
+        # ctlr-l for "lookup" -> open search / lists
+        if ctrl and key == QtCore.Qt.Key_L:
             search = self._chart._lc.chart_space.search
-            search.focus()
+            search.bar.focus()
 
         # esc
         if key == QtCore.Qt.Key_Escape or (ctrl and key == QtCore.Qt.Key_C):
@@ -809,5 +809,6 @@ class ChartView(ViewBox):
         # elif ev.key() == QtCore.Qt.Key_Backspace:
         #     self.scaleHistory(len(self.axHistory))
         else:
+            # maybe propagate to parent widget
             ev.ignore()
             self._key_active = False

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -188,7 +188,7 @@ class SelectRect(QtGui.QGraphicsRectItem):
 
         self._abs_top_right = label_anchor
         self._label_proxy.setPos(self.vb.mapFromView(label_anchor))
-        self._label.show()
+        # self._label.show()
 
     def clear(self):
         """Clear the selection box from view.
@@ -762,7 +762,7 @@ class ChartView(ViewBox):
         # ctlr-l for "lookup" -> open search / lists
         if ctrl and key == QtCore.Qt.Key_L:
             search = self._chart._lc.chart_space.search
-            search.bar.focus()
+            search.focus()
 
         # esc
         if key == QtCore.Qt.Key_Escape or (ctrl and key == QtCore.Qt.Key_C):

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -383,7 +383,6 @@ async def fill_results(
 
     # kb debouncing pauses
     min_pause_time: float = 0.0616,
-    # long_pause_time: float = 0.4,
     max_pause_time: float = 6/16,
 
 ) -> None:
@@ -674,7 +673,7 @@ def get_multi_search() -> Callable[..., Awaitable]:
 
         ) -> None:
 
-            log.debug(f'Searching {provider} for "{pattern}"')
+            log.info(f'Searching {provider} for "{pattern}"')
             results = await search(pattern)
             if results:
                 matches[provider] = results

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -825,7 +825,7 @@ async def handle_keyboard_input(
             )
         )
 
-        async for key, mods, txt in recv_chan:
+        async for event, key, mods, txt in recv_chan:
 
             log.debug(f'key: {key}, mods: {mods}, txt: {txt}')
 

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -497,7 +497,6 @@ async def fill_results(
     search: SearchBar,
     symsearch: Callable[..., Awaitable],
     recv_chan: trio.abc.ReceiveChannel,
-    # cached_symbols: Dict[str,
 
     # kb debouncing pauses
     min_pause_time: float = 0.0616,

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -735,7 +735,7 @@ async def fill_results(
             text = bar.text()
             # print(f'search: {text}')
 
-            if not text:
+            if not text or text.isspace():
                 # print('idling')
                 _search_active = trio.Event()
                 break

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -18,6 +18,19 @@
 qompleterz: embeddable search and complete using trio, Qt and fuzzywuzzy.
 
 """
+
+# link set for hackzin on this stuff:
+# https://doc.qt.io/qt-5/qheaderview.html#moving-header-sections
+# https://doc.qt.io/qt-5/model-view-programming.html
+# https://doc.qt.io/qt-5/modelview.html
+# https://doc.qt.io/qt-5/qtreeview.html#selectedIndexes
+# https://doc.qt.io/qt-5/qmodelindex.html#siblingAtColumn
+# https://doc.qt.io/qt-5/qitemselectionmodel.html#currentIndex
+# https://www.programcreek.com/python/example/108109/PyQt5.QtWidgets.QTreeView
+# https://doc.qt.io/qt-5/qsyntaxhighlighter.html
+# https://github.com/qutebrowser/qutebrowser/blob/master/qutebrowser/completion/completiondelegate.py#L243
+# https://forum.qt.io/topic/61343/highlight-matched-substrings-in-qstyleditemdelegate
+
 import sys
 from functools import partial
 from typing import (
@@ -37,6 +50,7 @@ from PyQt5.QtCore import (
     QItemSelectionModel,
 )
 from PyQt5.QtGui import (
+    # QLayout,
     QStandardItem,
     QStandardItemModel,
 )
@@ -44,7 +58,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QTreeView,
     # QListWidgetItem,
-    QAbstractScrollArea,
+    # QAbstractScrollArea,
     QStyledItemDelegate,
 )
 
@@ -91,6 +105,14 @@ class SimpleDelegate(QStyledItemDelegate):
 
 class CompleterView(QTreeView):
 
+    # XXX: relevant docs links:
+    # - simple widget version of this:
+    #   https://doc.qt.io/qt-5/qtreewidget.html#details
+    # - MVC high level instructional:
+    #   https://doc.qt.io/qt-5/model-view-programming.html
+    # - MV tut:
+    #   https://doc.qt.io/qt-5/modelview.html
+
     def __init__(
         self,
         parent=None,
@@ -106,7 +128,8 @@ class CompleterView(QTreeView):
         self.setItemDelegate(SimpleDelegate())
         self.setModel(model)
         self.setAlternatingRowColors(True)
-        self.setIndentation(1)
+        # TODO: size this based on DPI font
+        self.setIndentation(16)
 
         # self.setUniformRowHeights(True)
         # self.setColumnWidth(0, 3)
@@ -117,7 +140,8 @@ class CompleterView(QTreeView):
         self.setAnimated(False)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
-        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustIgnored)
+        # self.setVerticalBarPolicy(Qt.ScrollBarAlwaysOff)
+        # self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustIgnored)
 
         # column headers
         model.setHorizontalHeaderLabels(labels)
@@ -172,19 +196,26 @@ class CompleterView(QTreeView):
         #         # root index
         #         model.index(0, 0, QModelIndex()),
         #     )
+        root = model.invisibleRootItem()
+
         for key, values in results.items():
+
+            src = QStandardItem(key)
+            root.appendRow(src)
+            # self.expand(model.index(1, 0, QModelIndex()))
 
             # values just needs to be sequence-like
             for i, s in enumerate(values):
 
+                # blank = QStandardItem('')
                 ix = QStandardItem(str(i))
                 item = QStandardItem(s)
                 # item.setCheckable(False)
 
-                src = QStandardItem(key)
-
                 # Add the item to the model
-                model.appendRow([src, ix, item])
+                src.appendRow([ix, item])
+
+        self.expandAll()
 
     def show_matches(self) -> None:
         # print(f"SHOWING {self}")
@@ -199,8 +230,8 @@ class CompleterView(QTreeView):
             self.resizeColumnToContents(i)
 
         # inclusive of search bar and header "rows" in pixel terms
-        rows = model.rowCount() + 2
-        print(f'row count: {rows}')
+        rows = 100
+        # print(f'row count: {rows}')
         # max_rows = 8  # 6 + search and headers
         row_px = self.rowHeight(self.currentIndex())
         # print(f'font_h: {font_h}\n px_height: {px_height}')
@@ -208,6 +239,41 @@ class CompleterView(QTreeView):
         # TODO: probably make this more general / less hacky
         self.setMinimumSize(self.width(), rows * row_px)
         self.setMaximumSize(self.width(), rows * row_px)
+
+    def select_previous(self) -> QModelIndex:
+        cidx = self.currentIndex()
+        nidx = self.indexAbove(cidx)
+        if nidx.parent() is QModelIndex():
+            nidx = self.indexAbove(cidx)
+            breakpoint()
+
+        return nidx
+
+    def select_next(self) -> QModelIndex:
+        cidx = self.currentIndex()
+        nidx = self.indexBelow(cidx)
+        if nidx.parent() is QModelIndex():
+            nidx = self.indexBelow(cidx)
+            breakpoint()
+
+        return nidx
+
+    def select_from_idx(
+        self,
+        idx: QModelIndex,
+    ) -> None:
+        sel = self.selectionModel()
+        model = self.model()
+
+        # select first indented entry
+        if idx == model.index(0, 0):
+            idx = self.select_next()
+
+        sel.setCurrentIndex(
+            idx,
+            QItemSelectionModel.ClearAndSelect |
+            QItemSelectionModel.Rows
+        )
 
     # def find_matches(
     #     self,
@@ -241,6 +307,7 @@ class SearchBar(QtWidgets.QLineEdit):
         self.chart_app = parent_chart
 
         # size it as we specify
+        # https://doc.qt.io/qt-5/qsizepolicy.html#Policy-enum
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed,
             QtWidgets.QSizePolicy.Fixed,
@@ -366,12 +433,15 @@ async def fill_results(
             )
             bar.show()
 
+            # ensure we select first indented entry
+            view.select_from_idx(sel.currentIndex())
+
 
 class SearchWidget(QtGui.QWidget):
     def __init__(
         self,
         chart_space: 'ChartSpace',  # type: ignore # noqa
-        columns: List[str] = ['src', 'i', 'symbol'],
+        columns: List[str] = ['src', 'symbol'],
         parent=None,
     ):
         super().__init__(parent or chart_space)
@@ -379,13 +449,16 @@ class SearchWidget(QtGui.QWidget):
         # size it as we specify
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed,
-            QtWidgets.QSizePolicy.Fixed,
+            QtWidgets.QSizePolicy.Expanding,
         )
 
         self.chart_app = chart_space
         self.vbox = QtGui.QVBoxLayout(self)
         self.vbox.setContentsMargins(0, 0, 0, 0)
-        self.vbox.setSpacing(2)
+        self.vbox.setSpacing(4)
+
+        # https://doc.qt.io/qt-5/qlayout.html#SizeConstraint-enum
+        # self.vbox.setSizeConstraint(QLayout.SetMaximumSize)
 
         self.view = CompleterView(
             parent=self,
@@ -400,7 +473,6 @@ class SearchWidget(QtGui.QWidget):
         self.vbox.setAlignment(self.bar, Qt.AlignTop | Qt.AlignLeft)
         self.vbox.addWidget(self.bar.view)
         self.vbox.setAlignment(self.view, Qt.AlignTop | Qt.AlignLeft)
-        # self.vbox.addWidget(sel.bar.view)
 
 
 async def handle_keyboard_input(
@@ -439,7 +511,18 @@ async def handle_keyboard_input(
         async for key, mods, txt in recv_chan:
 
             log.debug(f'key: {key}, mods: {mods}, txt: {txt}')
-            nidx = cidx = view.currentIndex()
+            # parent = view.currentIndex()
+            cidx = sel.currentIndex()
+            # view.select_from_idx(nidx)
+
+            # if cidx == model.index(0, 0):
+            #     print('uhh')
+            #     cidx = view.select_next()
+            #     sel.setCurrentIndex(
+            #         cidx,
+            #         QItemSelectionModel.ClearAndSelect |
+            #         QItemSelectionModel.Rows
+            #     )
 
             ctrl = False
             if mods == Qt.ControlModifier:
@@ -447,9 +530,12 @@ async def handle_keyboard_input(
 
             if key in (Qt.Key_Enter, Qt.Key_Return):
 
-                node = model.item(nidx.row(), 2)
+                # TODO: get rid of this hard coded column -> 1
+                # https://doc.qt.io/qt-5/qstandarditemmodel.html#itemFromIndex
+                node = model.itemFromIndex(cidx.siblingAtColumn(1))
                 if node:
                     value = node.text()
+                    # print(f' value: {value}')
                 else:
                     continue
 
@@ -489,24 +575,25 @@ async def handle_keyboard_input(
                     _search_enabled = False
 
                     if key == Qt.Key_K:
-                        nidx = view.indexAbove(cidx)
+                        nidx = view.select_previous()
 
                     elif key == Qt.Key_J:
-                        nidx = view.indexBelow(cidx)
+                        nidx = view.select_next()
 
                     # select row without selecting.. :eye_rollzz:
                     # https://doc.qt.io/qt-5/qabstractitemview.html#setCurrentIndex
                     if nidx.isValid():
-                        sel.setCurrentIndex(
-                            nidx,
-                            QItemSelectionModel.ClearAndSelect |
-                            QItemSelectionModel.Rows
-                        )
+                        view.select_from_idx(nidx)
+                        # sel.setCurrentIndex(
+                        #     nidx,
+                        #     QItemSelectionModel.ClearAndSelect |
+                        #     QItemSelectionModel.Rows
+                        # )
 
                         # TODO: make this not hard coded to 2
                         # and use the ``CompleterView`` schema/settings
                         # to figure out the desired field(s)
-                        value = model.item(nidx.row(), 2).text()
+                        # value = model.item(nidx.row(), 0).text()
             else:
                 # relay to completer task
                 _search_enabled = True

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -682,6 +682,8 @@ async def pack_matches(
             section=provider,
             values=results,
         )
+    else:
+        view.clear_section(provider)
 
 
 async def fill_results(

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -668,6 +668,12 @@ async def handle_keyboard_input(
 
                 continue
 
+            if ctl and key in {
+                Qt.Key_L,
+            }:
+                # like url (link) highlight in a web browser
+                bar.focus()
+
             # selection navigation controls
             elif ctl and key in {
                 Qt.Key_D,

--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -49,7 +49,7 @@ def monitor(config, rate, name, dhost, test, tl):
     """Start a real-time watchlist UI
     """
     # global opts
-    brokermod = config['brokermod']
+    brokermod = config['brokermods'][0]
     loglevel = config['loglevel']
     log = config['log']
 
@@ -142,13 +142,13 @@ def chart(config, symbol, profile, pdb):
     _profile._pg_profile = profile
 
     # global opts
-    brokername = config['broker']
+    brokernames = config['brokers']
     tractorloglevel = config['tractorloglevel']
     pikerloglevel = config['loglevel']
 
     _main(
         sym=symbol,
-        brokername=brokername,
+        brokernames=brokernames,
         piker_loglevel=pikerloglevel,
         tractor_kwargs={
             'debug_mode': pdb,

--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -138,6 +138,13 @@ def chart(config, symbol, profile, pdb):
     from .. import _profile
     from ._chart import _main
 
+    if '.' not in symbol:
+        click.echo(click.style(
+            f'symbol: {symbol} must have a {symbol}.<provider> suffix',
+            fg='red',
+        ))
+        return
+
     # toggle to enable profiling
     _profile._pg_profile = profile
 

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -402,7 +402,9 @@ async def start_order_mode(
 
             # each clearing tick is responded individually
             elif resp in ('broker_filled',):
+
                 action = msg['action']
+
                 # TODO: some kinda progress system
                 order_mode.on_fill(
                     oid,


### PR DESCRIPTION
OK so i think this is finally ready for alpha testing!

#### Manual
- to open the search list: `ctl-space` or `ctrl-l`
  - the state from last open will be maintained
- to close the search list: `ctrl-space` (aka toggle) or `ctrl-c`
- once open, type pattern to match to provider symbols, they will appear in a per-provider results tree
- to navigate search results use either `up`/`down` arrow keys or `ctrl-j/k` (like in vim)
- to nav search result *provider-sections* you can use `ctrl-u/d` for up/down
- to select an entry (if it's not in the cache in which case it will switching automatically) use `enter`
- editting the search bar should be mostly as expected in default text editors (for now)

#### outstanding UX stuff todo (may get deferred to new issues / PRs):
- [x] no stupid blinking cursor
- [x] cache entries should be LIFO -> last selected should get moved to top and last recently before that should be next, etc
- [x] re-searching too often needs to be fixed; it results in more then necessary updates of the results tree
  - question: will this require updating specific segments of the results tree individually and how much more complicated will that make the `CompleterView.set_results()` implementation
  - providers that have already had a pattern request sent to search are searched again on slower provider debounce periods, ideally a patter search is idempotent and there should be a completion data structure that prevents *re-searches* once a provider has returned a results set for the input pattern.
  - UX feature: we could show a `searching...` entry for each provider that is currently not yet returned results
- [x] probably a `QLabel` in front of the `QLineEdit` for what kind of search we're doing 😂 
- [x] mouse selection support...not sure how i forgot this one
  
#### future wishlist
-> **made #186 to follow up on these**

```diff
- [ ] for `ib` unfortunately we need an ad-hoc futures / commodities / forex symbol set defined in the backend since they don't provide search for it; this needs to be added as a separate search task in ib's search routine
- [ ] character pattern highlighting in results entries
  - in `qutebrowser` [they re-invent the `QStyledItemDelegate`](https://github.com/qutebrowser/qutebrowser/blob/master/qutebrowser/completion/completiondelegate.py#L64) to accomplish this using `QTextEdit` 🤯 
  - here's a possible [dirty hack from the Qt forums](https://forum.qt.io/topic/61343/highlight-matched-substrings-in-qstyleditemdelegate/7)
- [ ] we need better sorting for some providers (eg. in `kraken` `adausd` will make a list with that exact match **not** at the top slot).
- [ ] better cross-provider sorting? right now i'm thinking provider order should be determined from a `provider.toml`?
- [ ] hotlists for personal positions across all asserts
- [ ] default hotlist from config (save this across chart sessions?)
- [ ] hotlist for all instruments with active clearing engine triggers/orders
- [ ] make `QLineEdit` cursor a rectangle with a nice contrasting color (like our bracket gray) 
```