### PR TITLE
Minor fixes to make piker installable again

### DIFF
--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -181,7 +181,7 @@ class Client:
     ) -> dict:
         if since is None:
             since = arrow.utcnow().floor('minute').shift(
-                minutes=-count).timestamp
+                minutes=-count).timestamp()
         # UTC 2017-07-02 12:53:20 is oldest seconds value
         since = str(max(1499000000, since))
         json = await self._public(

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         ]
     },
     install_requires=[
+        'toml',
         'click',
         'colorlog',
         'attrs',
@@ -69,7 +70,7 @@ setup(
         # UI
         'PyQt5',
         'pyqtgraph',
-        'qdarkstyle',
+        'qdarkstyle==2.8.1',
 
         # tsdbs
         'pymarketstore',


### PR DESCRIPTION
Pinned some dependencies, and updated an `arrow` timestamp API used in `kraken` backend.