### PR TITLE
Syseng tweaks

### DIFF
--- a/piker/__init__.py
+++ b/piker/__init__.py
@@ -19,6 +19,8 @@ piker: trading gear for hackers.
 
 """
 import msgpack  # noqa
+
+# TODO: remove this now right?
 import msgpack_numpy
 
 # patch msgpack for numpy arrays

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -141,6 +141,7 @@ async def maybe_open_pikerd(
     # presume pikerd role
     async with open_pikerd(
         loglevel=loglevel,
+        debug_mode=kwargs.get('debug_mode', False),
     ) as _:
         # in the case where we're starting up the
         # tractor-piker runtime stack in **this** process

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -19,8 +19,9 @@ Structured, daemon tree service management.
 
 """
 from functools import partial
-from typing import Optional, Union
-from contextlib import asynccontextmanager
+from typing import Optional, Union, Callable
+from contextlib import asynccontextmanager, AsyncExitStack
+from collections import defaultdict
 
 from pydantic import BaseModel
 import trio
@@ -44,9 +45,33 @@ class Services(BaseModel):
     actor_n: tractor._trionics.ActorNursery
     service_n: trio.Nursery
     debug_mode: bool  # tractor sub-actor debug mode flag
+    ctx_stack: AsyncExitStack
 
     class Config:
         arbitrary_types_allowed = True
+
+    async def open_remote_ctx(
+        self,
+        portal: tractor.Portal,
+        target: Callable,
+        **kwargs,
+
+    ) -> tractor.Context:
+        '''
+        Open a context in a service sub-actor, add to a stack
+        that gets unwound at ``pikerd`` tearodwn.
+
+        This allows for allocating long-running sub-services in our main
+        daemon and explicitly controlling their lifetimes.
+
+        '''
+        ctx, first = await self.ctx_stack.enter_async_context(
+            portal.open_context(
+                target,
+            **kwargs,
+            )
+        )
+        return ctx
 
 
 _services: Optional[Services] = None
@@ -62,14 +87,14 @@ async def open_pikerd(
     debug_mode: bool = False,
 
 ) -> Optional[tractor._portal.Portal]:
-    """
+    '''
     Start a root piker daemon who's lifetime extends indefinitely
     until cancelled.
 
     A root actor nursery is created which can be used to create and keep
     alive underling services (see below).
 
-    """
+    '''
     global _services
     assert _services is None
 
@@ -91,14 +116,18 @@ async def open_pikerd(
     ) as _, tractor.open_nursery() as actor_nursery:
         async with trio.open_nursery() as service_nursery:
 
-            # assign globally for future daemon/task creation
-            _services = Services(
-                actor_n=actor_nursery,
-                service_n=service_nursery,
-                debug_mode=debug_mode,
-            )
+            # setup service mngr singleton instance
+            async with AsyncExitStack() as stack:
 
-            yield _services
+                # assign globally for future daemon/task creation
+                _services = Services(
+                    actor_n=actor_nursery,
+                    service_n=service_nursery,
+                    debug_mode=debug_mode,
+                    ctx_stack=stack,
+                )
+
+                yield _services
 
 
 @asynccontextmanager
@@ -195,15 +224,17 @@ async def spawn_brokerd(
     # call with and then have the ability to unwind the call whenevs.
 
     # non-blocking setup of brokerd service nursery
-    _services.service_n.start_soon(
-        partial(
-            portal.run,
-            _setup_persistent_brokerd,
-            brokername=brokername,
-        )
+    await _services.open_remote_ctx(
+        portal,
+        _setup_persistent_brokerd,
+        brokername=brokername,
     )
 
     return dname
+
+
+class Brokerd:
+    locks = defaultdict(trio.Lock)
 
 
 @asynccontextmanager
@@ -224,9 +255,15 @@ async def maybe_spawn_brokerd(
 
     dname = f'brokerd.{brokername}'
 
+    # serialize access to this section to avoid
+    # 2 or more tasks racing to create a daemon
+    lock = Brokerd.locks[brokername]
+    await lock.acquire()
+
     # attach to existing brokerd if possible
     async with tractor.find_actor(dname) as portal:
         if portal is not None:
+            lock.release()
             yield portal
             return
 
@@ -251,6 +288,7 @@ async def maybe_spawn_brokerd(
             )
 
         async with tractor.wait_for_actor(dname) as portal:
+            lock.release()
             yield portal
 
 

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -76,6 +76,7 @@ async def open_pikerd(
     # XXX: this may open a root actor as well
     async with tractor.open_root_actor(
             # passed through to ``open_root_actor``
+            arbiter_addr=('127.0.0.1', 6116),
             name=_root_dname,
             loglevel=loglevel,
             debug_mode=debug_mode,

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -19,7 +19,7 @@ Structured, daemon tree service management.
 
 """
 from functools import partial
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, Any
 from contextlib import asynccontextmanager, AsyncExitStack
 from collections import defaultdict
 
@@ -34,6 +34,10 @@ from .brokers import get_brokermod
 log = get_logger(__name__)
 
 _root_dname = 'pikerd'
+_tractor_kwargs: dict[str, Any] = {
+    # use a different registry addr then tractor's default
+    'arbiter_addr':  ('127.0.0.1', 6116),
+}
 _root_modules = [
     __name__,
     'piker.clearing._ems',
@@ -101,7 +105,7 @@ async def open_pikerd(
     # XXX: this may open a root actor as well
     async with tractor.open_root_actor(
             # passed through to ``open_root_actor``
-            arbiter_addr=('127.0.0.1', 6116),
+            arbiter_addr=_tractor_kwargs['arbiter_addr'],
             name=_root_dname,
             loglevel=loglevel,
             debug_mode=debug_mode,

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -341,6 +341,10 @@ def make_sub(pairs: List[str], data: Dict[str, Any]) -> Dict[str, str]:
 class AutoReconWs:
     """Make ``trio_websocketw` sockets stay up no matter the bs.
 
+    TODO:
+    apply any more insights from this:
+    https://support.kraken.com/hc/en-us/articles/360044504011-WebSocket-API-unexpected-disconnections-from-market-data-feeds
+
     """
     recon_errors = (
         ConnectionClosed,

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -179,31 +179,40 @@ async def execute_triggers(
                         # majority of iterations will be non-matches
                         continue
 
-                    # submit_price = price + price*percent_away
-                    submit_price = price + abs_diff_away
+                    action = cmd['action']
 
-                    log.info(
-                        f'Dark order triggered for price {price}\n'
-                        f'Submitting order @ price {submit_price}')
+                    if action != 'alert':
+                        # executable order submission
 
-                    reqid = await client.submit_limit(
-                        oid=oid,
+                        # submit_price = price + price*percent_away
+                        submit_price = price + abs_diff_away
 
-                        # this is a brand new order request for the
-                        # underlying broker so we set out "broker request
-                        # id" (brid) as nothing so that the broker
-                        # client knows that we aren't trying to modify
-                        # an existing order.
-                        brid=None,
+                        log.info(
+                            f'Dark order triggered for price {price}\n'
+                            f'Submitting order @ price {submit_price}')
 
-                        symbol=sym,
-                        action=cmd['action'],
-                        price=submit_price,
-                        size=cmd['size'],
-                    )
+                        reqid = await client.submit_limit(
+                            oid=oid,
 
-                    # register broker request id to ems id
-                    book._broker2ems_ids[reqid] = oid
+                            # this is a brand new order request for the
+                            # underlying broker so we set out "broker request
+                            # id" (brid) as nothing so that the broker
+                            # client knows that we aren't trying to modify
+                            # an existing order.
+                            brid=None,
+
+                            symbol=sym,
+                            action=cmd['action'],
+                            price=submit_price,
+                            size=cmd['size'],
+                        )
+
+                        # register broker request id to ems id
+                        book._broker2ems_ids[reqid] = oid
+
+                    else:
+                        # alerts have no broker request id
+                        reqid = ''
 
                     resp = {
                         'resp': 'dark_executed',

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -37,7 +37,7 @@ _context_defaults = dict(
 def pikerd(loglevel, host, tl, pdb):
     """Spawn the piker broker-daemon.
     """
-    from .._daemon import _data_mods, open_pikerd
+    from .._daemon import open_pikerd
     log = get_console_log(loglevel)
 
     if pdb:
@@ -112,11 +112,11 @@ def services(config, tl, names):
 
 
 def _load_clis() -> None:
-    from ..data import marketstore as _
-    from ..data import cli as _
-    from ..brokers import cli as _  # noqa
-    from ..ui import cli as _  # noqa
-    from ..watchlists import cli as _  # noqa
+    from ..data import marketstore  # noqa
+    from ..data import cli  # noqa
+    from ..brokers import cli  # noqa
+    from ..ui import cli  # noqa
+    from ..watchlists import cli  # noqa
 
 
 # load downstream cli modules

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -236,5 +236,8 @@ async def sample_and_broadcast(
                     trio.BrokenResourceError,
                     trio.ClosedResourceError
                 ):
-                    subs.remove(ctx)
+                    # XXX: do we need to deregister here
+                    # if it's done in the fee bus code?
+                    # so far seems like no since this should all
+                    # be single-threaded.
                     log.error(f'{ctx.chan.uid} dropped connection')

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -227,7 +227,7 @@ async def sample_and_broadcast(
             # end up triggering backpressure which which will
             # eventually block this producer end of the feed and
             # thus other consumers still attached.
-            subs = bus.subscribers[sym]
+            subs = bus._subscribers[sym]
             for ctx in subs:
                 # print(f'sub is {ctx.chan.uid}')
                 try:

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -67,11 +67,19 @@ class _FeedsBus(BaseModel):
     brokername: str
     nursery: trio.Nursery
     feeds: Dict[str, trio.CancelScope] = {}
-    subscribers: Dict[str, List[tractor.Context]] = {}
+
     task_lock: trio.StrictFIFOLock = trio.StrictFIFOLock()
+
+    # XXX: so weird but, apparently without this being `._` private
+    # pydantic will complain about private `tractor.Context` instance
+    # vars (namely `._portal` and `._cancel_scope`) at import time.
+    # Reported this bug:
+    # https://github.com/samuelcolvin/pydantic/issues/2816
+    _subscribers: Dict[str, List[tractor.Context]] = {}
 
     class Config:
         arbitrary_types_allowed = True
+        underscore_attrs_are_private = False
 
     async def cancel_all(self) -> None:
         for sym, (cs, msg, quote) in self.feeds.items():
@@ -256,7 +264,7 @@ async def attach_feed_bus(
                     loglevel=loglevel,
                 )
             )
-            bus.subscribers.setdefault(symbol, []).append(ctx)
+            bus._subscribers.setdefault(symbol, []).append(ctx)
         else:
             sub_only = True
 
@@ -269,12 +277,12 @@ async def attach_feed_bus(
     await ctx.send_yield(first_quote)
 
     if sub_only:
-        bus.subscribers[symbol].append(ctx)
+        bus._subscribers[symbol].append(ctx)
 
     try:
         await trio.sleep_forever()
     finally:
-        bus.subscribers[symbol].remove(ctx)
+        bus._subscribers[symbol].remove(ctx)
 
 
 @dataclass

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -42,7 +42,7 @@ import trio
 import tractor
 from outcome import Error
 
-from .._daemon import maybe_open_pikerd
+from .._daemon import maybe_open_pikerd, _tractor_kwargs
 from ..log import get_logger
 from ._pg_overrides import _do_overrides
 
@@ -195,6 +195,10 @@ def run_qtractor(
         'window': window,
         'main': instance,
     }
+
+
+    # override tractor's defaults
+    tractor_kwargs.update(_tractor_kwargs)
 
     # define tractor entrypoint
     async def main():

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -79,7 +79,7 @@ class DpiAwareFont:
         return self._qfont
 
     @property
-    def px_size(self):
+    def px_size(self) -> int:
         return self._qfont.pixelSize()
 
     def configure_to_dpi(self, screen: Optional[QtGui.QScreen] = None):

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -319,14 +319,10 @@ async def start_order_mode(
 ) -> None:
 
     # spawn EMS actor-service
-    async with open_ems(
-        brokername,
-        symbol,
-    ) as (book, trades_stream), open_order_mode(
-        symbol,
-        chart,
-        book,
-    ) as order_mode:
+    async with (
+        open_ems(brokername, symbol) as (book, trades_stream),
+        open_order_mode(symbol, chart, book) as order_mode
+    ):
 
         def get_index(time: float):
 

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -337,7 +337,7 @@ async def start_order_mode(
             indexes = ohlc['time'] >= time
 
             if any(indexes):
-                return ohlc['index'][indexes[-1]]
+                return ohlc['index'][indexes][-1]
             else:
                 return ohlc['index'][-1]
 

--- a/piker/ui/quantdom/charts.py
+++ b/piker/ui/quantdom/charts.py
@@ -5,41 +5,7 @@ import pyqtgraph as pg
 from PyQt5 import QtCore, QtGui
 
 
-class SampleLegendItem(pg.graphicsItems.LegendItem.ItemSample):
-
-    def paint(self, p, *args):
-        p.setRenderHint(p.Antialiasing)
-        if isinstance(self.item, tuple):
-            positive = self.item[0].opts
-            negative = self.item[1].opts
-            p.setPen(pg.mkPen(positive['pen']))
-            p.setBrush(pg.mkBrush(positive['brush']))
-            p.drawPolygon(
-                QtGui.QPolygonF(
-                    [
-                        QtCore.QPointF(0, 0),
-                        QtCore.QPointF(18, 0),
-                        QtCore.QPointF(18, 18),
-                    ]
-                )
-            )
-            p.setPen(pg.mkPen(negative['pen']))
-            p.setBrush(pg.mkBrush(negative['brush']))
-            p.drawPolygon(
-                QtGui.QPolygonF(
-                    [
-                        QtCore.QPointF(0, 0),
-                        QtCore.QPointF(0, 18),
-                        QtCore.QPointF(18, 18),
-                    ]
-                )
-            )
-        else:
-            opts = self.item.opts
-            p.setPen(pg.mkPen(opts['pen']))
-            p.drawRect(0, 10, 18, 0.5)
-
-
+# TODO: test this out as our help menu
 class CenteredTextItem(QtGui.QGraphicsTextItem):
     def __init__(
         self,


### PR DESCRIPTION
various runtime machinery adjustments made as part of getting out multi-provider search engine going in #164.

@guilledk of particular note is the `_daemon.py` adjustments to use the new `tractor` context api to async spawn sub-daemons using a `pikerd` local `AsyncContextStack`.  I feel like this api style is starting to feel nice; interested to see what you think.

 Will be rebasing #168 onto this.