### PR TITLE
Basic status bar

### DIFF
--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -508,6 +508,8 @@ class ChartPlotWidget(pg.PlotWidget):
     def focus(self) -> None:
         # self.setFocus()
         self._vb.setFocus()
+        app = QtGui.QApplication.instance()
+        app.activeWindow().statusBar().showMessage("mode: view")
 
     def last_bar_in_view(self) -> int:
         self._ohlc[-1]['index']
@@ -1661,6 +1663,8 @@ async def _async_main(
 
     chart_app = widgets['main']
 
+
+
     # attempt to configure DPI aware font size
     screen = current_screen()
 
@@ -1674,6 +1678,10 @@ async def _async_main(
 
     # configure global DPI aware font size
     _font.configure_to_dpi(screen)
+
+    sbar = chart_app.window.statusBar()
+    sbar.setStyleSheet(f"font: {_font.px_size - 3}px")
+    sbar.showMessage('starting ze chartz...')
 
     async with trio.open_nursery() as root_n:
 
@@ -1700,6 +1708,7 @@ async def _async_main(
         symbol, _, provider = sym.rpartition('.')
 
         # this internally starts a ``chart_symbol()`` task above
+        sbar.showMessage(f'loading {provider}.{symbol}...')
         chart_app.load_symbol(provider, symbol, loglevel)
 
         root_n.start_soon(load_providers, brokernames, loglevel)

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -52,7 +52,6 @@ from ._l1 import L1Labels
 from ._graphics._ohlc import BarItems
 from ._graphics._curve import FastAppendCurve
 from ._style import (
-    _config_fonts_to_screen,
     hcolor,
     CHART_MARGINS,
     _xaxis_at,
@@ -68,7 +67,7 @@ from ..data import maybe_open_shm_array
 from .. import brokers
 from .. import data
 from ..log import get_logger
-from ._exec import run_qtractor, current_screen
+from ._exec import run_qtractor
 from ._interaction import ChartView
 from .order_mode import start_order_mode
 from .. import fsp
@@ -1687,7 +1686,7 @@ async def _async_main(
     chart_app = main_widget
 
     # attempt to configure DPI aware font size
-    screen = current_screen()
+    screen = chart_app.window.current_screen()
 
     # configure graphics update throttling based on display refresh rate
     global _clear_throttle_rate
@@ -1696,9 +1695,6 @@ async def _async_main(
         _clear_throttle_rate,
     )
     log.info(f'Set graphics update rate to {_clear_throttle_rate} Hz')
-
-    # configure global DPI aware font size
-    _config_fonts_to_screen()
 
     # TODO: do styling / themeing setup
     # _style.style_ze_sheets(chart_app)

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -51,6 +51,7 @@ from ._graphics._lines import (
 from ._l1 import L1Labels
 from ._graphics._ohlc import BarItems
 from ._graphics._curve import FastAppendCurve
+from . import _style
 from ._style import (
     _font,
     hcolor,
@@ -192,6 +193,8 @@ class ChartSpace(QtGui.QWidget):
                 symbol_key,
                 loglevel,
             )
+            self.window.status_bar.showMessage(
+                f'Loading {symbol_key}.{providername}...')
 
             self.set_chart_symbol(fqsn, linkedcharts)
 
@@ -1241,6 +1244,9 @@ async def spawn_fsps(
 
                 display_name = f'fsp.{fsp_func_name}'
 
+                linked_charts.window().status_bar.showMessage(
+                    f'Loading FSP: {display_name}...')
+
                 # TODO: load function here and introspect
                 # return stream type(s)
 
@@ -1280,6 +1286,10 @@ async def spawn_fsps(
                     display_name,
                     conf,
                 )
+
+                status = linked_charts.window().status_bar
+                if display_name in status.currentMessage():
+                    status.clearMessage()
 
         # blocks here until all fsp actors complete
 
@@ -1541,6 +1551,9 @@ async def chart_symbol(
                     add_label=False,
                 )
 
+        chart_app.window.status_bar.showMessage(
+            f'Finished loading {sym}.{brokername}')
+
         # size view to data once at outset
         chart._set_yrange()
 
@@ -1619,6 +1632,7 @@ async def chart_symbol(
             #     linked_charts,
             # )
 
+            linked_charts.window().status_bar.showMessage('Starting order mode...')
             await start_order_mode(chart, symbol, brokername)
 
 
@@ -1676,8 +1690,6 @@ async def _async_main(
 
     chart_app = widgets['main']
 
-
-
     # attempt to configure DPI aware font size
     screen = current_screen()
 
@@ -1692,8 +1704,10 @@ async def _async_main(
     # configure global DPI aware font size
     _font.configure_to_dpi(screen)
 
+    # TODO: do styling / themeing setup
+    # _style.style_ze_sheets(chart_app)
+
     sbar = chart_app.window.status_bar
-    sbar.setStyleSheet(f"font: {_font.px_size - 3}px")
     sbar.showMessage('starting ze chartz...')
 
     async with trio.open_nursery() as root_n:

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -112,7 +112,7 @@ class MainWindow(QtGui.QMainWindow):
         self.setMinimumSize(*self.size)
         self.setWindowTitle(self.title)
 
-        self._status_bar: QStatusbar = None
+        self._status_bar: QStatusBar = None
         self._status_label: QLabel = None
 
     @property
@@ -121,13 +121,13 @@ class MainWindow(QtGui.QMainWindow):
         # init mode label
         if not self._status_label:
             # TODO: i guess refactor stuff to avoid having to import here?
-            from ._style import _font, hcolor
+            from ._style import _font_small, hcolor
             self._status_label = label = QtGui.QLabel()
             label.setStyleSheet(
                 f"QLabel {{ color : {hcolor('gunmetal')}; }}"
             )
             label.setTextFormat(3)  # markdown
-            label.setFont(_font.font)
+            label.setFont(_font_small.font)
             label.setMargin(2)
             label.setAlignment(
                 QtCore.Qt.AlignVCenter
@@ -135,7 +135,6 @@ class MainWindow(QtGui.QMainWindow):
             )
             self.status_bar.addPermanentWidget(label)
             label.show()
-
 
         return self._status_label
 
@@ -155,14 +154,14 @@ class MainWindow(QtGui.QMainWindow):
         # style and cached the status bar on first access
         if not self._status_bar:
             # TODO: i guess refactor stuff to avoid having to import here?
-            from ._style import _font, hcolor
+            from ._style import _font_small, hcolor
             sb = self.statusBar()
             sb.setStyleSheet((
                 f"color : {hcolor('gunmetal')};"
                 f"background : {hcolor('default_dark')};"
-                # "min-height : 19px;"
-                f"font-size : {_font.px_size - 4}px;"
+                f"font-size : {_font_small.px_size}px;"
                 "padding : 0px;"
+                # "min-height : 19px;"
                 # "qproperty-alignment: AlignVCenter;"
             ))
             self.setStatusBar(sb)

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -124,6 +124,26 @@ class MainWindow(QtGui.QMainWindow):
         # raising KBI seems to get intercepted by by Qt so just use the system.
         os.kill(os.getpid(), signal.SIGINT)
 
+    @property
+    def status_bar(self) -> 'QStatusBar':
+        return self.statusBar()
+
+    def on_focus_change(
+        self,
+        old: QtGui.QWidget,
+        new: QtGui.QWidget,
+    ) -> None:
+
+        log.debug(f'widget focus changed from {old} -> {new}')
+
+        if new is None:
+            # cursor left window?
+            self.statusBar().showMessage('mode: none')
+
+        else:
+            name = getattr(new, 'mode_name', '')
+            self.statusBar().showMessage(name)
+
 
 def run_qtractor(
     func: Callable,
@@ -192,6 +212,10 @@ def run_qtractor(
 
     # make window and exec
     window = window_type()
+
+    # hook into app focus change events
+    app.focusChanged.connect(window.on_focus_change)
+
     instance = main_widget()
     instance.window = window
 

--- a/piker/ui/_exec.py
+++ b/piker/ui/_exec.py
@@ -40,7 +40,6 @@ from PyQt5.QtCore import (
 import qdarkstyle
 # import qdarkgraystyle
 import trio
-import tractor
 from outcome import Error
 
 from .._daemon import maybe_open_pikerd, _tractor_kwargs
@@ -114,6 +113,29 @@ class MainWindow(QtGui.QMainWindow):
         self.setMinimumSize(*self.size)
         self.setWindowTitle(self.title)
 
+        self._status_label: QLabel = None
+
+    @property
+    def status(self) -> QtGui.QLabel:
+        if not self._status_label:
+            # init mode label
+            from ._style import _font
+            self._status_label = label = QtGui.QLabel() #parent=self.status_bar)
+            label.setTextFormat(3)  # markdown
+            label.setFont(_font.font)
+            label.setMargin(4)
+            label.setText("yo")
+            # label.show()
+            label.setAlignment(
+                QtCore.Qt.AlignVCenter
+                | QtCore.Qt.AlignRight
+            )
+            self.status_bar.addPermanentWidget(label)
+            label.show()
+
+        return self._status_label
+
+
     def closeEvent(
         self,
         event: QtGui.QCloseEvent,
@@ -136,13 +158,12 @@ class MainWindow(QtGui.QMainWindow):
 
         log.debug(f'widget focus changed from {old} -> {new}')
 
-        if new is None:
-            # cursor left window?
-            self.statusBar().showMessage('mode: none')
-
-        else:
+        if new is not None:
+            # # cursor left window?
+            # self.statusBar().showMessage('mode: none')
             name = getattr(new, 'mode_name', '')
-            self.statusBar().showMessage(name)
+            self.status.setText(name)
+            # self.statusBar().showMessage(name)
 
 
 def run_qtractor(

--- a/piker/ui/_graphics/_cursor.py
+++ b/piker/ui/_graphics/_cursor.py
@@ -31,6 +31,7 @@ from .._style import (
     _xaxis_at,
     hcolor,
     _font,
+    _font_small,
 )
 from .._axes import YAxisLabel, XAxisLabel
 from ...log import get_logger
@@ -109,7 +110,7 @@ class LineDot(pg.CurvePoint):
         return False
 
 
-# TODO: change this into our own ``Label``
+# TODO: change this into our own ``_label.Label``
 class ContentsLabel(pg.LabelItem):
     """Label anchored to a ``ViewBox`` typically for displaying
     datum-wise points from the "viewed" contents.
@@ -138,21 +139,13 @@ class ContentsLabel(pg.LabelItem):
         justify_text: str = 'left',
         font_size: Optional[int] = None,
     ) -> None:
-        font_size = font_size or _font.font.pixelSize()
+
+        font_size = font_size or _font_small.px_size
 
         super().__init__(
             justify=justify_text,
             size=f'{str(font_size)}px'
         )
-
-        if _font._physical_dpi >= 97:
-            # ad-hoc scale it based on boundingRect
-            # TODO: need proper fix for this?
-            typical_br = _font._qfm.boundingRect('Qyp')
-            anchor_font_size = math.ceil(typical_br.height() * 1.25)
-
-        else:
-            anchor_font_size = font_size
 
         # anchor to viewbox
         self.setParentItem(chart._vb)
@@ -165,7 +158,7 @@ class ContentsLabel(pg.LabelItem):
 
         ydim = margins[1]
         if inspect.isfunction(margins[1]):
-            margins = margins[0], ydim(anchor_font_size)
+            margins = margins[0], ydim(font_size)
 
         self.anchor(itemPos=index, parentPos=index, offset=margins)
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -467,6 +467,9 @@ class ChartView(ViewBox):
         - zoom on right-click-n-drag to cursor position
 
     """
+
+    mode_name: str = 'mode: view'
+
     def __init__(
         self,
         parent: pg.PlotItem = None,

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -96,6 +96,8 @@ class SimpleDelegate(QStyledItemDelegate):
 
 class CompleterView(QTreeView):
 
+    mode_name: str = 'mode: search-nav'
+
     # XXX: relevant docs links:
     # - simple widget version of this:
     #   https://doc.qt.io/qt-5/qtreewidget.html#details
@@ -153,7 +155,9 @@ class CompleterView(QTreeView):
         self._font_size: int = 0  # pixels
 
     def on_pressed(self, idx: QModelIndex) -> None:
+        '''Mouse pressed on view handler.
 
+        '''
         search = self.parent()
         search.chart_current_item(clear_to_cache=False)
         search.focus()
@@ -424,6 +428,8 @@ class CompleterView(QTreeView):
 
 class SearchBar(QtWidgets.QLineEdit):
 
+    mode_name: str = 'mode: search'
+
     def __init__(
 
         self,
@@ -487,6 +493,8 @@ class SearchWidget(QtGui.QWidget):
     Includes helper methods for item management in the sub-widgets.
 
     '''
+    mode_name: str = 'mode: search'
+
     def __init__(
         self,
         chart_space: 'ChartSpace',  # type: ignore # noqa
@@ -499,7 +507,7 @@ class SearchWidget(QtGui.QWidget):
         # size it as we specify
         self.setSizePolicy(
             QtWidgets.QSizePolicy.Fixed,
-            QtWidgets.QSizePolicy.Expanding,
+            QtWidgets.QSizePolicy.Fixed,
         )
 
         self.chart_app = chart_space
@@ -618,13 +626,15 @@ class SearchWidget(QtGui.QWidget):
         # making?)
         fqsn = '.'.join([symbol, provider]).lower()
 
-        # Re-order the symbol cache on the chart to display in
-        # LIFO order. this is normally only done internally by
-        # the chart on new symbols being loaded into memory
-        chart.set_chart_symbol(fqsn, chart.linkedcharts)
-
         if clear_to_cache:
+
             self.bar.clear()
+
+            # Re-order the symbol cache on the chart to display in
+            # LIFO order. this is normally only done internally by
+            # the chart on new symbols being loaded into memory
+            chart.set_chart_symbol(fqsn, chart.linkedcharts)
+
             self.view.set_section_entries(
                 'cache',
                 values=list(reversed(chart._chart_cache)),

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -25,7 +25,6 @@ from PyQt5 import QtCore, QtGui
 from qdarkstyle import DarkPalette
 
 from ..log import get_logger
-from ._exec import current_screen
 
 log = get_logger(__name__)
 
@@ -69,13 +68,15 @@ class DpiAwareFont:
 
     @property
     def screen(self) -> QtGui.QScreen:
+        from ._window import main_window
+
         if self._screen is not None:
             try:
                 self._screen.refreshRate()
             except RuntimeError:
-                self._screen = current_screen()
+                self._screen = main_window().current_screen()
         else:
-            self._screen = current_screen()
+            self._screen = main_window().current_screen()
 
         return self._screen
 
@@ -151,6 +152,8 @@ _font_small = DpiAwareFont(font_size='small')
 
 
 def _config_fonts_to_screen() -> None:
+    'configure global DPI aware font sizes'
+
     global _font, _font_small
     _font.configure_to_dpi()
     _font_small.configure_to_dpi()

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -22,7 +22,7 @@ import math
 
 import pyqtgraph as pg
 from PyQt5 import QtCore, QtGui
-from qdarkstyle.palette import DarkPalette
+from qdarkstyle import DarkPalette
 
 from ..log import get_logger
 from ._exec import current_screen
@@ -134,8 +134,6 @@ _font = DpiAwareFont()
 # TODO: re-compute font size when main widget switches screens?
 # https://forum.qt.io/topic/54136/how-do-i-get-the-qscreen-my-widget-is-on-qapplication-desktop-screen-returns-a-qwidget-and-qobject_cast-qscreen-returns-null/3
 
-# _i3_rgba = QtGui.QColor.fromRgbF(*[0.14]*3 + [1])
-
 # splitter widget config
 _xaxis_at = 'bottom'
 
@@ -175,6 +173,7 @@ def hcolor(name: str) -> str:
         'gray': '#808080',  # like the kick
         'grayer': '#4c4c4c',
         'grayest': '#3f3f3f',
+        'i3': '#494D4F',
         'jet': '#343434',
         'cadet': '#91A3B0',
         'marengo': '#91A3B0',
@@ -185,9 +184,13 @@ def hcolor(name: str) -> str:
         'bracket': '#666666',  # like the logo
         'original': '#a9a9a9',
 
-        # palette
-        'default': DarkPalette.COLOR_BACKGROUND_NORMAL,
-        'default_light': DarkPalette.COLOR_BACKGROUND_LIGHT,
+        # from ``qdarkstyle`` palette
+        'default_darkest': DarkPalette.COLOR_BACKGROUND_1,
+        'default_dark': DarkPalette.COLOR_BACKGROUND_2,
+        'default': DarkPalette.COLOR_BACKGROUND_3,
+        'default_light': DarkPalette.COLOR_BACKGROUND_4,
+        'default_lightest': DarkPalette.COLOR_BACKGROUND_5,
+        'default_spotlight': DarkPalette.COLOR_BACKGROUND_6,
 
         'white': '#ffffff',  # for tinas and sunbathers
 

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -32,8 +32,10 @@ log = get_logger(__name__)
 # chart-wide fonts specified in inches
 _font_sizes: Dict[str, Dict[str, float]] = {
     'hi': {
-        'default':  0.0616,
-        'small':  0.055,
+        # 'default':  0.0616,
+        'default':  0.0616 * 2,
+        # 'small':  0.055,
+        'small':  6/66 * (1 + 6/16),
     },
     'lo': {
         'default':  6.5 / 64,
@@ -95,7 +97,7 @@ class DpiAwareFont:
         # take the max since scaling can make things ugly in some cases
         pdpi = screen.physicalDotsPerInch()
         ldpi = screen.logicalDotsPerInch()
-        dpi = max(pdpi, ldpi)
+        dpi = min(pdpi, ldpi)
 
         # for low dpi scale everything down
         if dpi <= 97:
@@ -105,8 +107,8 @@ class DpiAwareFont:
 
         font_size = math.floor(inches * dpi)
         log.info(
-            f"\nscreen:{screen.name()} with DPI: {dpi}"
-            f"\nbest font size is {font_size}\n"
+            f"\nscreen:{screen.name()} with pDPI: {pdpi}, lDPI: {ldpi}"
+            f"\nbest font size is {font_size} for min dpi {dpi}\n"
         )
 
         self._set_qfont_px_size(font_size)

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -101,6 +101,7 @@ class DpiAwareFont:
         pdpi = screen.physicalDotsPerInch()
         ldpi = screen.logicalDotsPerInch()
         mx_dpi = max(pdpi, ldpi)
+        mn_dpi = min(pdpi, ldpi)
         scale = round(ldpi/pdpi)
 
         if mx_dpi <= 97:  # for low dpi use larger font sizes
@@ -109,15 +110,18 @@ class DpiAwareFont:
         else:  # hidpi use smaller font sizes
             inches = _font_sizes['hi'][self._font_size]
 
+        dpi = mn_dpi
+
         # dpi is likely somewhat scaled down so use slightly larger font size
         if scale > 1 and self._font_size:
             # TODO: this denominator should probably be determined from
             # relative aspect rations or something?
-            inches *= scale / 2.5
+            inches = inches * (1 / scale) * (1 + 6/16)
+            dpi = mx_dpi
 
         self._font_inches = inches
 
-        font_size = math.floor(inches * mx_dpi)
+        font_size = math.floor(inches * dpi)
         log.info(
             f"\nscreen:{screen.name()} with pDPI: {pdpi}, lDPI: {ldpi}"
             f"\nOur best guess font size is {font_size}\n"

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -33,9 +33,7 @@ _magic_inches = 0.0666 * (1 + 6/16)
 # chart-wide fonts specified in inches
 _font_sizes: Dict[str, Dict[str, float]] = {
     'hi': {
-        # 'default':  0.0616,
         'default':  _magic_inches,
-        # 'small':  0.055,
         'small': 0.9 * _magic_inches,
     },
     'lo': {

--- a/piker/ui/_window.py
+++ b/piker/ui/_window.py
@@ -1,0 +1,180 @@
+# piker: trading gear for hackers
+# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Qt main window singletons and stuff.
+
+"""
+import os
+import signal
+import time
+from typing import Callable
+
+from pyqtgraph import QtGui
+from PyQt5 import QtCore
+from PyQt5.QtGui import QLabel, QStatusBar
+
+from ..log import get_logger
+from ._style import _font_small, hcolor
+
+
+log = get_logger(__name__)
+
+
+class MultiStatus:
+
+    bar: QStatusBar
+    statuses: list[str]
+
+    def __init__(self, bar, statuses) -> None:
+        self.bar = bar
+        self.statuses = statuses
+
+    def open_status(
+        self,
+        msg: str,
+    ) -> Callable[..., None]:
+        '''Add a status to the status bar and return a close callback which
+        when called will remove the status ``msg``.
+
+        '''
+        self.statuses.append(msg)
+
+        def remove_msg() -> None:
+            self.statuses.remove(msg)
+            self.render()
+
+        self.render()
+        return remove_msg
+
+    def render(self) -> None:
+        if self.statuses:
+            self.bar.showMessage(f'{" ".join(self.statuses)}')
+        else:
+            self.bar.clearMessage()
+
+
+class MainWindow(QtGui.QMainWindow):
+
+    size = (800, 500)
+    title = 'piker chart (ur symbol is loading bby)'
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(*self.size)
+        self.setWindowTitle(self.title)
+
+        self._status_bar: QStatusBar = None
+        self._status_label: QLabel = None
+
+    @property
+    def mode_label(self) -> QtGui.QLabel:
+
+        # init mode label
+        if not self._status_label:
+
+            self._status_label = label = QtGui.QLabel()
+            label.setStyleSheet(
+                f"QLabel {{ color : {hcolor('gunmetal')}; }}"
+            )
+            label.setTextFormat(3)  # markdown
+            label.setFont(_font_small.font)
+            label.setMargin(2)
+            label.setAlignment(
+                QtCore.Qt.AlignVCenter
+                | QtCore.Qt.AlignRight
+            )
+            self.statusBar().addPermanentWidget(label)
+            label.show()
+
+        return self._status_label
+
+    def closeEvent(
+        self,
+        event: QtGui.QCloseEvent,
+    ) -> None:
+        """Cancel the root actor asap.
+
+        """
+        # raising KBI seems to get intercepted by by Qt so just use the system.
+        os.kill(os.getpid(), signal.SIGINT)
+
+    @property
+    def status_bar(self) -> QStatusBar:
+
+        # style and cached the status bar on first access
+        if not self._status_bar:
+
+            sb = self.statusBar()
+            sb.setStyleSheet((
+                f"color : {hcolor('gunmetal')};"
+                f"background : {hcolor('default_dark')};"
+                f"font-size : {_font_small.px_size}px;"
+                "padding : 0px;"
+                # "min-height : 19px;"
+                # "qproperty-alignment: AlignVCenter;"
+            ))
+            self.setStatusBar(sb)
+            self._status_bar = MultiStatus(sb, [])
+
+        return self._status_bar
+
+    def on_focus_change(
+        self,
+        old: QtGui.QWidget,
+        new: QtGui.QWidget,
+    ) -> None:
+
+        log.debug(f'widget focus changed from {old} -> {new}')
+
+        if new is not None:
+            # cursor left window?
+            name = getattr(new, 'mode_name', '')
+            self.mode_label.setText(name)
+
+    def current_screen(self) -> QtGui.QScreen:
+        """Get a frickin screen (if we can, gawd).
+
+        """
+        app = QtGui.QApplication.instance()
+
+        for _ in range(3):
+            screen = app.screenAt(self.pos())
+            print('trying to access QScreen...')
+            if screen is None:
+                time.sleep(0.5)
+                continue
+
+            break
+        else:
+            if screen is None:
+                # try for the first one we can find
+                screen = app.screens()[0]
+
+        assert screen, "Wow Qt is dumb as shit and has no screen..."
+        return screen
+
+
+# singleton app per actor
+_qt_win: QtGui.QMainWindow = None
+
+
+def main_window() -> MainWindow:
+    'Return the actor-global Qt window.'
+
+    global _qt_win
+    assert _qt_win
+    return _qt_win

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -336,6 +336,8 @@ async def start_order_mode(
 
         # Begin order-response streaming
 
+        chart.window().status_bar.showMessage('Ready for trading')
+
         # this is where we receive **back** messages
         # about executions **from** the EMS actor
         async for msg in trades_stream:

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -309,7 +309,15 @@ async def start_order_mode(
     chart: 'ChartPlotWidget',  # noqa
     symbol: Symbol,
     brokername: str,
+
 ) -> None:
+    '''Activate chart-trader order mode loop:
+      - connect to emsd
+      - load existing positions
+      - begin order handling loop
+
+    '''
+    done = chart.window().status_bar.open_status('Starting order mode...')
 
     # spawn EMS actor-service
     async with (
@@ -335,8 +343,7 @@ async def start_order_mode(
                 return ohlc['index'][-1]
 
         # Begin order-response streaming
-
-        chart.window().status_bar.showMessage('Ready for trading')
+        done()
 
         # this is where we receive **back** messages
         # about executions **from** the EMS actor

--- a/setup.py
+++ b/setup.py
@@ -70,17 +70,12 @@ setup(
         # UI
         'PyQt5',
         'pyqtgraph',
-        'qdarkstyle==2.8.1',
-        #'kivy',  see requirement.txt; using a custom branch atm
-
-        # tsdbs
-        'pymarketstore',
-
-        #'kivy',  see requirement.txt; using a custom branch atm
-
+        'qdarkstyle >= 3.0.2',
         # fuzzy search
         'fuzzywuzzy[speedup]',
 
+        # tsdbs
+        'pymarketstore',
     ],
     tests_require=['pytest'],
     python_requires=">=3.9",  # literally for ``datetime.datetime.fromisoformat``...


### PR DESCRIPTION
Initial simple status bar to show startup sequence and current UI "mode" in a right side label.
This branch will require a `pip install -U qdarkstyle` to work since I ported to latest version.

More to come for this but it's probably ready to land as a simple starting point.

Future todos which might get moved to a new issue:
- [x] add support for status *tokens* which let async code set a status, receive a token obj that can then be called to clear that status later
- [x] support multiple (concurrenct) statuses via a `{status_1, status_2, status_3}` type text display for multiple tasks?
- ~[ ] override the default splitter background color (pretty sure it should be our `default_dark` alias)~ leaving this for now, the color grew on me.
- ~[ ] per provider/broker feed/ems statuses which down the road can be augmented with some widgets for resetting or displaying info?~ made #197 
  - thinking we should defer this to a new issue that can come with the throttling stuff in #177 ?

ping @iamzoltan @guilledk 