### PR TITLE
fix unknown kraken symbol raised error

### DIFF
--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -175,7 +175,7 @@ class Client:
         err = resp['error']
         if err:
             symbolname = pairs['pair'] if pair else None
-            raise SymbolNotFound(f'kraken: {symbolname}')
+            raise SymbolNotFound(f'{symbolname}.kraken')
 
         pairs = resp['result']
 

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -174,7 +174,8 @@ class Client:
         resp = await self._public('AssetPairs', pairs)
         err = resp['error']
         if err:
-            raise BrokerError(err)
+            symbolname = pairs['pair'] if pair else None
+            raise SymbolNotFound(f'kraken: {symbolname}')
 
         pairs = resp['result']
 


### PR DESCRIPTION
changed the error raised when the symbol passed to kraken does not match any of their tickers.