### PR TITLE
Naive feed throttling

### DIFF
--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -724,7 +724,7 @@ async def _emsd_main(
             _router.feeds[(broker, symbol)] = feed
 
         # XXX: this should be initial price quote from target provider
-        first_quote = await feed.receive()
+        first_quote = feed.first_quote
 
         # open a stream with the brokerd backend for order
         # flow dialogue

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -229,10 +229,10 @@ async def sample_and_broadcast(
             # thus other consumers still attached.
             subs = bus._subscribers[sym.lower()]
 
-            for ctx in subs:
+            for stream in subs:
                 # print(f'sub is {ctx.chan.uid}')
                 try:
-                    await ctx.send_yield({sym: quote})
+                    await stream.send({sym: quote})
                 except (
                     trio.BrokenResourceError,
                     trio.ClosedResourceError
@@ -241,4 +241,4 @@ async def sample_and_broadcast(
                     # if it's done in the fee bus code?
                     # so far seems like no since this should all
                     # be single-threaded.
-                    log.error(f'{ctx.chan.uid} dropped connection')
+                    log.error(f'{stream._ctx.chan.uid} dropped connection')

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1515,9 +1515,14 @@ async def chart_symbol(
     brokermod = brokers.get_brokermod(provider)
 
     async with data.open_feed(
+
         provider,
         [sym],
         loglevel=loglevel,
+
+        # 60 FPS to limit context switches
+        tick_throttle=_clear_throttle_rate,
+
     ) as feed:
 
         ohlcv: ShmArray = feed.shm


### PR DESCRIPTION
First attempt at addressing #192 in a very very naive way.

Summary:
- port `data.feed.open_feed()` machinery to use `@tractor.context` apis
- add a `data._sampling.uniform_rate_send()` quote limiter which allows for queuing L1 ticks and throttling quote transmission to clients (like the charts) at a constant rate (like 60 FPS).

There's still lots of much fancier stuff that can be done from here as mentioned in #107 for fast shm tick queuing and in #109 for potential graphics side optimizations.

I think this is at least providing a good start point for further queuingn eng work 😎 