### PR TITLE
Wait on daemon portals, concurrently.

### DIFF
--- a/piker/brokers/_util.py
+++ b/piker/brokers/_util.py
@@ -53,6 +53,6 @@ def resproc(
         log.exception(f"Failed to process {resp}:\n{resp.text}")
         raise BrokerError(resp.text)
     else:
-        log.trace(f"Received json contents:\n{colorize_json(json)}")
+        log.debug(f"Received json contents:\n{colorize_json(json)}")
 
     return json if return_json else resp


### PR DESCRIPTION
Rework our daemon "service manager" to drop the use of `AsyncExitStack` and instead use plain tasks, spawned in the `pikerd` actor, to wait on sub-daemons and bubble up any errors captured therein.

The original use of an async exit stack is very problematic since we have no way to collect errors from opened `tractor.Context`'s *to* sub-daemons *as these errors arrive*. This is of course because even if you wait on the exit of the stack the LIFO ordering may not capture an error from an earlier *pushed* daemon portal (and thus propagate it to the surrounding nursery / cancel scope) since these contexts are **not** being waited upon **concurrently**.

Instead spawn a task for each sub-daemon which both waits on the opened context and portal. Now when any daemon errors, `pikerd` will see that immediately and deal with it accordingly (which is right now just to bail as well).

