### PR TITLE
Ib adhoc derivs search

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -283,7 +283,7 @@ async def maybe_spawn_daemon(
     lock = Brokerd.locks[service_name]
     await lock.acquire()
 
-    # attach to existing brokerd if possible
+    # attach to existing daemon by name if possible
     async with tractor.find_actor(service_name) as portal:
         if portal is not None:
             lock.release()

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -496,6 +496,7 @@ class Client:
         price: float,
         action: str,
         size: int,
+        account: str = '',  # if blank the "default" tws account is used
 
         # XXX: by default 0 tells ``ib_insync`` methods that there is no
         # existing order so ask the client to create a new one (which it
@@ -518,6 +519,7 @@ class Client:
             Order(
                 orderId=reqid or 0,  # stupid api devs..
                 action=action.upper(),  # BUY/SELL
+                account=account,
                 orderType='LMT',
                 lmtPrice=price,
                 totalQuantity=size,

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1,5 +1,5 @@
 # piker: trading gear for hackers
-# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+# Copyright (C) Tyler Goodlet (in stewardship for pikers)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -171,6 +171,7 @@ _adhoc_futes_set = {
     # equities
     'nq.globex',
     'mnq.globex',
+
     'es.globex',
     'mes.globex',
 
@@ -178,8 +179,20 @@ _adhoc_futes_set = {
     'brr.cmecrypto',
     'ethusdrr.cmecrypto',
 
+    # agriculture
+    'he.globex',  # lean hogs
+    'le.globex',  # live cattle (geezers)
+    'gf.globex',  # feeder cattle (younguns)
+
+    # raw
+    'lb.globex',  # random len lumber
+
     # metals
-    'xauusd.cmdty',
+    'xauusd.cmdty',  # gold spot
+    'gc.nymex',
+    'mgc.nymex',
+
+    'xagusd.cmdty',  # silver spot
 }
 
 # exchanges we don't support at the moment due to not knowing
@@ -556,7 +569,7 @@ class Client:
             else:
                 item = ('status', obj)
 
-            log.info(f'eventkit event -> {eventkit_obj}: {item}')
+            log.info(f'eventkit event ->\n{pformat(item)}')
 
             try:
                 to_trio.send_nowait(item)
@@ -1362,11 +1375,34 @@ async def trades_dialogue(
         # ib-gw goes down? Not sure exactly how that's happening looking
         # at the eventkit code above but we should probably handle it...
         async for event_name, item in ib_trade_events_stream:
+            print(f' ib sending {item}')
 
-            # XXX: begin normalization of nonsense ib_insync internal
-            # object-state tracking representations...
+            # TODO: templating the ib statuses in comparison with other
+            # brokers is likely the way to go:
+            # https://interactivebrokers.github.io/tws-api/interfaceIBApi_1_1EWrapper.html#a17f2a02d6449710b6394d0266a353313
+            # short list:
+            # - PendingSubmit
+            # - PendingCancel
+            # - PreSubmitted (simulated orders)
+            # - ApiCancelled (cancelled by client before submission
+            #                 to routing)
+            # - Cancelled
+            # - Filled
+            # - Inactive (reject or cancelled but not by trader)
+
+            # XXX: here's some other sucky cases from the api
+            # - short-sale but securities haven't been located, in this
+            #   case we should probably keep the order in some kind of
+            #   weird state or cancel it outright?
+            # status='PendingSubmit', message=''),
+            # status='Cancelled', message='Error 404,
+            #   reqId 1550: Order held while securities are located.'),
+            # status='PreSubmitted', message='')],
 
             if event_name == 'status':
+
+                # XXX: begin normalization of nonsense ib_insync internal
+                # object-state tracking representations...
 
                 # unwrap needed data from ib_insync internal types
                 trade: Trade = item
@@ -1378,10 +1414,13 @@ async def trades_dialogue(
 
                     reqid=trade.order.orderId,
                     time_ns=time.time_ns(),  # cuz why not
+
+                    # everyone doin camel case..
                     status=status.status.lower(),  # force lower case
 
                     filled=status.filled,
                     reason=status.whyHeld,
+
                     # this seems to not be necessarily up to date in the
                     # execDetails event.. so we have to send it here I guess?
                     remaining=status.remaining,
@@ -1500,6 +1539,12 @@ async def open_symbol_search(
             if not pattern or pattern.isspace():
                 log.warning('empty pattern received, skipping..')
 
+                # TODO: *BUG* if nothing is returned here the client
+                # side will cache a null set result and not showing
+                # anything to the use on re-searches when this query
+                # timed out. We probably need a special "timeout" msg
+                # or something...
+
                 # XXX: this unblocks the far end search task which may
                 # hold up a multi-search nursery block
                 await stream.send({})
@@ -1507,7 +1552,7 @@ async def open_symbol_search(
                 continue
 
             log.debug(f'searching for {pattern}')
-            # await tractor.breakpoint()
+
             last = time.time()
             results = await _trio_run_client_method(
                 method='search_stocks',

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1093,6 +1093,11 @@ async def _setup_quote_stream(
                 # decouple broadcast mem chan
                 _quote_streams.pop(symbol, None)
 
+            # except trio.WouldBlock:
+            #     # for slow debugging purposes to avoid clobbering prompt
+            #     # with log msgs
+            #     pass
+
         ticker.updateEvent.connect(push)
 
         return from_aio

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -26,7 +26,7 @@ from dataclasses import asdict
 from datetime import datetime
 from functools import partial
 from typing import (
-    List, Dict, Any, Tuple, Optional,
+    Any, Optional,
     AsyncIterator, Awaitable,
 )
 import asyncio
@@ -226,8 +226,8 @@ class Client:
         self.ib.RaiseRequestErrors = True
 
         # contract cache
-        self._contracts: Dict[str, Contract] = {}
-        self._feeds: Dict[str, trio.abc.SendChannel] = {}
+        self._contracts: dict[str, Contract] = {}
+        self._feeds: dict[str, trio.abc.SendChannel] = {}
 
         # NOTE: the ib.client here is "throttled" to 45 rps by default
 
@@ -242,7 +242,7 @@ class Client:
         period_count: int = int(2e3),  # <- max per 1s sample query
 
         is_paid_feed: bool = False,  # placeholder
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Retreive OHLCV bars for a symbol over a range to the present.
         """
         bars_kwargs = {'whatToShow': 'TRADES'}
@@ -369,7 +369,7 @@ class Client:
         upto: int = 3,
         asdicts: bool = True,
 
-    ) -> Dict[str, ContractDetails]:
+    ) -> dict[str, ContractDetails]:
 
         # TODO add search though our adhoc-locally defined symbol set
         # for futes/cmdtys/
@@ -399,7 +399,7 @@ class Client:
         # ``wrapper.starTicker()`` currently cashes ticker instances
         # which means getting a singel quote will potentially look up
         # a quote for a ticker that it already streaming and thus run
-        # into state clobbering (eg. List: Ticker.ticks). It probably
+        # into state clobbering (eg. list: Ticker.ticks). It probably
         # makes sense to try this once we get the pub-sub working on
         # individual symbols...
 
@@ -660,7 +660,7 @@ class Client:
     async def positions(
         self,
         account: str = '',
-    ) -> List[Position]:
+    ) -> list[Position]:
         """
         Retrieve position info for ``account``.
         """
@@ -1067,12 +1067,12 @@ asset_type_map = {
 }
 
 
-_quote_streams: Dict[str, trio.abc.ReceiveStream] = {}
+_quote_streams: dict[str, trio.abc.ReceiveStream] = {}
 
 
 async def _setup_quote_stream(
     symbol: str,
-    opts: Tuple[int] = ('375', '233', '236'),
+    opts: tuple[int] = ('375', '233', '236'),
     contract: Optional[Contract] = None,
 ) -> None:
     """Stream a ticker using the std L1 api.
@@ -1148,13 +1148,13 @@ async def start_aio_quote_stream(
 async def stream_quotes(
 
     send_chan: trio.abc.SendChannel,
-    symbols: List[str],
+    symbols: list[str],
     shm: ShmArray,
     feed_is_live: trio.Event,
     loglevel: str = None,
 
     # startup sync
-    task_status: TaskStatus[Tuple[Dict, Dict]] = trio.TASK_STATUS_IGNORED,
+    task_status: TaskStatus[tuple[dict, dict]] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:
     """Stream symbol quotes.
@@ -1285,7 +1285,7 @@ async def stream_quotes(
             # last = time.time()
 
 
-def pack_position(pos: Position) -> Dict[str, Any]:
+def pack_position(pos: Position) -> dict[str, Any]:
     con = pos.contract
 
     if isinstance(con, Option):
@@ -1367,7 +1367,7 @@ async def trades_dialogue(
     ctx: tractor.Context,
     loglevel: str = None,
 
-) -> AsyncIterator[Dict[str, Any]]:
+) -> AsyncIterator[dict[str, Any]]:
 
     # XXX: required to propagate ``tractor`` loglevel to piker logging
     get_console_log(loglevel or tractor.current_actor().loglevel)

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -701,6 +701,10 @@ async def _aio_get_client(
             # grab first cached client
             client = list(_client_cache.values())[0]
 
+        if not client.ib.isConnected():
+            # we have a stale client to re-allocate
+            raise KeyError
+
         yield client
 
     except (KeyError, IndexError):
@@ -780,7 +784,6 @@ async def _aio_run_client_method(
             kwargs['to_trio'] = to_trio
 
         log.runtime(f'Running {meth}({kwargs})')
-
         return await async_meth(**kwargs)
 
 


### PR DESCRIPTION
Start building out a derivatives and commodities symbol map inside the `ib` backend since there is no search for such symbols in the API (only equities).

todo:
- add a search routine over the ad-hoc symbols dict
- i'd like to add in support for loading existing orders on api connect
-  for orders that get "delayed" (like say no stocks to borrow for shorting) sometime the order gets submitted to the *when it available queue* in tws but we get no / aren't processing wtv event comes back from that. imo we should just cancel orders like this and expect the user to read the error on console for now.