### PR TITLE
Fix PyQt5 error

### DIFF
--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -486,7 +486,7 @@ class SearchBar(QtWidgets.QLineEdit):
             self.view.hide()
 
 
-class SearchWidget(QtGui.QWidget):
+class SearchWidget(QtWidgets.QWidget):
     '''Composed widget of ``SearchBar`` + ``CompleterView``.
 
     Includes helper methods for item management in the sub-widgets.


### PR DESCRIPTION
Fix `AttributeError: module 'PyQt5.QtGui' has no attribute 'QWidget'` during startup. See

https://stackoverflow.com/questions/45501514/attributeerror-module-pyqt5-qtgui-has-no-attribute-qwidget