### PR TITLE
Ugh, positions relay hotfix

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1465,7 +1465,7 @@ async def trades_dialogue(
     global _client_cache
 
     # deliver positions to subscriber before anything else
-    all_positions = {}
+    all_positions = []
 
     clients: list[tuple[Client, trio.MemoryReceiveChannel]] = []
     for account, client in _accounts2clients.items():
@@ -1480,9 +1480,7 @@ async def trades_dialogue(
         for client in _client_cache.values():
             for pos in client.positions():
                 msg = pack_position(pos)
-                all_positions.setdefault(
-                    msg.symbol, []
-                ).append(msg.dict())
+                all_positions.append(msg.dict())
 
     await ctx.started(all_positions)
 

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1333,7 +1333,10 @@ async def stream_quotes(
             # last = time.time()
 
 
-def pack_position(pos: Position) -> dict[str, Any]:
+def pack_position(
+    pos: Position
+
+) -> dict[str, Any]:
     con = pos.contract
 
     if isinstance(con, Option):
@@ -1480,6 +1483,7 @@ async def trades_dialogue(
         for client in _client_cache.values():
             for pos in client.positions():
                 msg = pack_position(pos)
+                msg.account = accounts_def.inverse[msg.account]
                 all_positions.append(msg.dict())
 
     await ctx.started(all_positions)
@@ -1636,6 +1640,7 @@ async def deliver_trade_events(
 
         elif event_name == 'position':
             msg = pack_position(item)
+            msg.account = accounts_def.inverse[msg.account]
 
         if getattr(msg, 'reqid', 0) < -1:
 

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -429,10 +429,13 @@ async def open_brokerd_trades_dialogue(
                 # by receiving order submission response messages,
                 # normalizing them to EMS messages and relaying back to
                 # the piker order client set.
+                pps = {}
+                for msg in positions:
+                    pps.setdefault(msg['symbol'], {})['account'] = msg
 
                 relay = TradesRelay(
                     brokerd_dialogue=brokerd_trades_stream,
-                    positions=positions,
+                    positions=pps,
                     consumers=1
                 )
 

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -429,9 +429,14 @@ async def open_brokerd_trades_dialogue(
                 # by receiving order submission response messages,
                 # normalizing them to EMS messages and relaying back to
                 # the piker order client set.
+
+                # locally cache and track positions per account.
                 pps = {}
                 for msg in positions:
-                    pps.setdefault(msg['symbol'], {})['account'] = msg
+                    pps.setdefault(
+                        msg['symbol'],
+                        {}
+                    )[msg['account']] = msg
 
                 relay = TradesRelay(
                     brokerd_dialogue=brokerd_trades_stream,

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -577,8 +577,8 @@ async def open_order_mode(
         for msg in pp_msgs:
 
             log.info(f'Loading pp for {symkey}:\n{pformat(msg)}')
-            account_value = msg.get('account')
-            account_name = accounts.inverse.get(account_value)
+            account_name = msg.get('account')
+            account_value = accounts.get(account_name)
             if not account_name and account_value == 'paper':
                 account_name = 'paper'
 

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -769,8 +769,9 @@ async def process_trades_and_update_ui(
 
                 # update order pane widgets
                 mode.pane.update_status_ui(tracker)
+                # display pnl
+                mode.pane.display_pnl(tracker)
 
-            mode.pane.display_pnl(tracker)
             # short circuit to next msg to avoid
             # unnecessary msg content lookups
             continue


### PR DESCRIPTION
Remnant from #223.

Must have run into some confusion with data structures in `brokerd` vs.
`emsd`. This fixes the ems `relay.positions` state tracking to be
composed maps, vs. messages from `brokerd` should just be a sequence.