### PR TITLE
Account select icons

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1469,6 +1469,7 @@ async def trades_dialogue(
 
     # deliver positions to subscriber before anything else
     all_positions = []
+    accounts = set()
 
     clients: list[tuple[Client, trio.MemoryReceiveChannel]] = []
     for account, client in _accounts2clients.items():
@@ -1484,9 +1485,10 @@ async def trades_dialogue(
             for pos in client.positions():
                 msg = pack_position(pos)
                 msg.account = accounts_def.inverse[msg.account]
+                accounts.add(msg.account)
                 all_positions.append(msg.dict())
 
-    await ctx.started(all_positions)
+    await ctx.started((all_positions, accounts))
 
     async with (
         ctx.open_stream() as ems_stream,

--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -86,14 +86,7 @@ class Allocator(BaseModel):
         underscore_attrs_are_private = False
 
     symbol: Symbol
-    accounts: bidict[str, Optional[str]]
     account: Optional[str] = 'paper'
-
-    @validator('account', pre=False)
-    def set_account(cls, v, values):
-        if v:
-            return values['accounts'][v]
-
     size_unit: SizeUnit = 'currency'
     _size_units: dict[str, Optional[str]] = _size_units
 
@@ -127,9 +120,6 @@ class Allocator(BaseModel):
             return self.currency_limit
         else:
             return self.units_limit
-
-    def account_name(self) -> str:
-        return self.accounts.inverse[self.account]
 
     def next_order_info(
         self,
@@ -234,7 +224,7 @@ class Allocator(BaseModel):
             'slots_used': slots_used,
 
             # update line LHS label with account name
-            'account': self.account_name(),
+            'account': self.account,
         }
 
     def slots_used(
@@ -264,7 +254,6 @@ class Allocator(BaseModel):
 def mk_allocator(
 
     symbol: Symbol,
-    accounts: dict[str, str],
     startup_pp: Position,
 
     # default allocation settings
@@ -293,7 +282,6 @@ def mk_allocator(
 
     alloc = Allocator(
         symbol=symbol,
-        accounts=accounts,
         **defaults,
     )
 

--- a/piker/clearing/_client.py
+++ b/piker/clearing/_client.py
@@ -210,7 +210,7 @@ async def open_ems(
                 broker=broker,
                 symbol=symbol.key,
 
-            ) as (ctx, positions),
+            ) as (ctx, (positions, accounts)),
 
             # open 2-way trade command stream
             ctx.open_stream() as trades_stream,
@@ -222,4 +222,4 @@ async def open_ems(
                     trades_stream
                 )
 
-                yield book, trades_stream, positions
+                yield book, trades_stream, positions, accounts

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -463,7 +463,7 @@ async def trades_dialogue(
         # TODO: load paper positions per broker from .toml config file
         # and pass as symbol to position data mapping: ``dict[str, dict]``
         # await ctx.started(all_positions)
-        await ctx.started({})
+        await ctx.started(({}, {'paper',}))
 
         async with (
             ctx.open_stream() as ems_stream,

--- a/piker/ui/_forms.py
+++ b/piker/ui/_forms.py
@@ -42,12 +42,10 @@ from PyQt5.QtWidgets import (
     QStyledItemDelegate,
     QStyleOptionViewItem,
 )
-# import pydantic
 
 from ._event import open_handlers
 from ._style import hcolor, _font, _font_small, DpiAwareFont
 from ._label import FormatLabel
-from .. import config
 
 
 class FontAndChartAwareLineEdit(QLineEdit):
@@ -71,17 +69,21 @@ class FontAndChartAwareLineEdit(QLineEdit):
 
         if width_in_chars:
             self._chars = int(width_in_chars)
+            x_size_policy = QSizePolicy.Fixed
 
         else:
             # chart count which will be used to calculate
             # width of input field.
-            self._chars: int = 9
+            self._chars: int = 6
+            # fit to surroundingn frame width
+            x_size_policy = QSizePolicy.Expanding
 
         super().__init__(parent)
+
         # size it as we specify
         # https://doc.qt.io/qt-5/qsizepolicy.html#Policy-enum
         self.setSizePolicy(
-            QSizePolicy.Expanding,
+            x_size_policy,
             QSizePolicy.Fixed,
         )
         self.setFont(font.font)
@@ -99,11 +101,11 @@ class FontAndChartAwareLineEdit(QLineEdit):
         dpi_font = self.dpi_font
         psh.setHeight(dpi_font.px_size)
 
-        # space for ``._chars: int``
-        char_w_pxs = dpi_font.boundingRect(self.text()).width()
-        chars_w = char_w_pxs + 6  # * dpi_font.scale() * self._chars
-        psh.setWidth(chars_w)
-
+        # make space for ``._chars: int`` for of characters in view
+        # TODO: somehow this math ain't right?
+        chars_w_pxs = dpi_font.boundingRect('0'*self._chars).width()
+        scale = round(dpi_font.scale())
+        psh.setWidth(chars_w_pxs * scale)
         return psh
 
     def set_width_in_chars(
@@ -167,23 +169,93 @@ class FontScaledDelegate(QStyledItemDelegate):
     #     QStyledItemDelegate.paint(self, painter, option, index)
 
 
-# NOTE: in theory we can put icons on the RHS side with this hackery:
-# https://stackoverflow.com/a/64256969
-# class ComboBox(QComboBox):
-#     def __init__(
-#         self,
-#         parent=None,
-#     ) -> None:
-#         super().__init__(parent=parent)
+class Selection(QComboBox):
 
-#     def showPopup(self):
-#         print('show')
-#         QComboBox.showPopup(self)
+    def __init__(
+        self,
+        parent=None,
 
-#     def hidePopup(self):
-#         # self.setItemDelegate(FontScaledDelegate(self.parent()))
-#         print('hide')
-#         QComboBox.hidePopup(self)
+    ) -> None:
+
+        self._items: dict[str, int] = {}
+
+        super().__init__(parent=parent)
+        self.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        # make line edit expand to surrounding frame
+        self.setSizePolicy(
+            QSizePolicy.Expanding,
+            QSizePolicy.Fixed,
+        )
+        view = self.view()
+        view.setUniformItemSizes(True)
+
+        # TODO: this doesn't seem to work for the currently selected item?
+        self.setItemDelegate(FontScaledDelegate(self))
+
+    def set_style(
+        self,
+
+        color: str,
+        font_size: int,
+
+    ) -> None:
+
+        self.setStyleSheet(
+            f"""QComboBox {{
+                color : {hcolor(color)};
+                font-size : {font_size}px;
+            }}
+            """
+        )
+
+    def set_items(
+        self,
+        keys: list[str],
+
+    ) -> None:
+        '''Write keys to the selection verbatim.
+
+        All other items are cleared beforehand.
+        '''
+        self.clear()
+        self._items.clear()
+
+        for i, key in enumerate(keys):
+            strkey = str(key)
+            self.insertItem(i, strkey)
+
+            # store map of entry keys to row indexes
+            self._items[strkey] = i
+
+        # compute max item size so that the weird
+        # "style item delegate" thing can then specify
+        # that size on each item...
+        keys.sort()
+        br = _font.boundingRect(str(keys[-1]))
+        _, h = br.width(), br.height()
+
+        # TODO: something better then this monkey patch
+        view = self.view()
+
+        # XXX: see size policy settings of line edit
+        # view._max_item_size = w, h
+
+        self.setMinimumHeight(h)  # at least one entry in view
+        view.setMaximumHeight(6*h)  # limit to 6 items max in view
+
+        icon_size = round(h * 0.75)
+        self.setIconSize(QSize(icon_size, icon_size))
+
+    # # NOTE: in theory we can put icons on the RHS side with this hackery:
+    # # https://stackoverflow.com/a/64256969
+    # def showPopup(self):
+    #     print('show')
+    #     QComboBox.showPopup(self)
+
+    # def hidePopup(self):
+    #     # self.setItemDelegate(FontScaledDelegate(self.parent()))
+    #     print('hide')
+    #     QComboBox.hidePopup(self)
 
 
 # slew of resources which helped get this where it is:
@@ -279,6 +351,7 @@ class FieldsForm(QWidget):
 
         edit = FontAndChartAwareLineEdit(
             parent=self,
+            # width_in_chars=6,
         )
         edit.setStyleSheet(
             f"""QLineEdit {{
@@ -301,66 +374,23 @@ class FieldsForm(QWidget):
         label_name: str,
         values: list[str],
 
-    ) -> QComboBox:
+    ) -> Selection:
 
         # TODO: maybe a distint layout per "field" item?
         label = self.add_field_label(label_name)
 
-        select = QComboBox(self)
+        select = Selection(self)
+        select.set_style(color='gunmetal', font_size=self._font_size)
         select._key = key
-        select._items: dict[str, int] = {}
-
-        for i, value in enumerate(values):
-            strkey = str(value)
-            select.insertItem(i, strkey)
-
-            # store map of entry keys to row indexes
-            select._items[strkey] = i
-
-        select.setStyleSheet(
-            f"""QComboBox {{
-                color : {hcolor('gunmetal')};
-                font-size : {self._font_size}px;
-            }}
-            """
-        )
-        select.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        select.set_items(values)
 
         self.setSizePolicy(
             QSizePolicy.Fixed,
             QSizePolicy.Fixed,
         )
-        view = select.view()
-        view.setUniformItemSizes(True)
-
-        # TODO: this doesn't seem to work for the currently selected item?
-        select.setItemDelegate(FontScaledDelegate(self))
-
-        # compute maximum item size so that the weird
-        # "style item delegate" thing can then specify
-        # that size on each item...
-        values.sort()
-        br = _font.boundingRect(str(values[-1]))
-        _, h = br.width(), br.height()
-
-        icon_size = round(h * 0.75)
-        select.setIconSize(QSize(icon_size, icon_size))
-
-        # TODO: something better then this monkey patch
-        # view._max_item_size = w, h
-
-        # limit to 6 items?
-        view.setMaximumHeight(6*h)
-
-        # one entry in view
-        select.setMinimumHeight(h)
-
         select.show()
-
         self.form.addRow(label, select)
-
         self.fields[key] = select
-
         return select
 
 
@@ -669,7 +699,6 @@ def mk_order_pane_layout(
 ) -> FieldsForm:
 
     font_size: int = _font.px_size - 1
-    accounts = config.load_accounts()
 
     # TODO: maybe just allocate the whole fields form here
     # and expect an async ctx entry?
@@ -679,7 +708,7 @@ def mk_order_pane_layout(
             'account': {
                 'label': '**account**:',
                 'type': 'select',
-                'default_value': accounts.keys(),
+                'default_value': ['paper'],
             },
             'size_unit': {
                 'label': '**allocate**:',
@@ -721,7 +750,6 @@ def mk_order_pane_layout(
         form,
         pane_vbox=vbox,
         label_font_size=font_size,
-
     )
     # TODO: would be nice to have some better way of reffing these over
     # monkey patching...

--- a/piker/ui/_forms.py
+++ b/piker/ui/_forms.py
@@ -157,12 +157,33 @@ class FontScaledDelegate(QStyledItemDelegate):
         else:
             return super().sizeHint(option, index)
 
+    # NOTE: hack to display icons on RHS
     # TODO: is there a way to set this stype option once?
-    def paint(self, painter, option, index):
-        # display icons on RHS
-        # https://stackoverflow.com/a/39943629
-        option.decorationPosition = QtGui.QStyleOptionViewItem.Right
-        super().paint(painter, option, index)
+    # def paint(self, painter, option, index):
+    #     # display icons on RHS
+    #     # https://stackoverflow.com/a/39943629
+    #     option.decorationPosition = QtGui.QStyleOptionViewItem.Right
+    #     option.decorationAlignment = Qt.AlignRight | Qt.AlignVCenter
+    #     QStyledItemDelegate.paint(self, painter, option, index)
+
+
+# NOTE: in theory we can put icons on the RHS side with this hackery:
+# https://stackoverflow.com/a/64256969
+# class ComboBox(QComboBox):
+#     def __init__(
+#         self,
+#         parent=None,
+#     ) -> None:
+#         super().__init__(parent=parent)
+
+#     def showPopup(self):
+#         print('show')
+#         QComboBox.showPopup(self)
+
+#     def hidePopup(self):
+#         # self.setItemDelegate(FontScaledDelegate(self.parent()))
+#         print('hide')
+#         QComboBox.hidePopup(self)
 
 
 # slew of resources which helped get this where it is:
@@ -171,7 +192,6 @@ class FontScaledDelegate(QStyledItemDelegate):
 # https://stackoverflow.com/questions/6337589/qlistwidget-adjust-size-to-content#6370892
 # https://stackoverflow.com/questions/25304267/qt-resize-of-qlistview
 # https://stackoverflow.com/questions/28227406/how-to-set-qlistview-rows-height-permanently
-
 class FieldsForm(QWidget):
 
     vbox: QVBoxLayout
@@ -287,7 +307,6 @@ class FieldsForm(QWidget):
         label = self.add_field_label(label_name)
 
         select = QComboBox(self)
-
         select._key = key
         select._items: dict[str, int] = {}
 
@@ -313,6 +332,7 @@ class FieldsForm(QWidget):
         )
         view = select.view()
         view.setUniformItemSizes(True)
+
         # TODO: this doesn't seem to work for the currently selected item?
         select.setItemDelegate(FontScaledDelegate(self))
 
@@ -323,7 +343,8 @@ class FieldsForm(QWidget):
         br = _font.boundingRect(str(values[-1]))
         _, h = br.width(), br.height()
 
-        select.setIconSize(QSize(h, h))
+        icon_size = round(h * 0.75)
+        select.setIconSize(QSize(icon_size, icon_size))
 
         # TODO: something better then this monkey patch
         # view._max_item_size = w, h
@@ -647,8 +668,7 @@ def mk_order_pane_layout(
 
 ) -> FieldsForm:
 
-    # font_size: int = _font_small.px_size - 2
-    font_size: int = _font.px_size - 2
+    font_size: int = _font.px_size - 1
     accounts = config.load_accounts()
 
     # TODO: maybe just allocate the whole fields form here

--- a/piker/ui/_icons.py
+++ b/piker/ui/_icons.py
@@ -51,6 +51,8 @@ def mk_icons(
     if _icons:
         return _icons
 
+    _icons[None] = QIcon()  # the "null" icon
+
     # load account selection using current style
     for name, icon_name in _icon_names.items():
 

--- a/piker/ui/_icons.py
+++ b/piker/ui/_icons.py
@@ -1,0 +1,88 @@
+# piker: trading gear for hackers
+# Copyright (C) Tyler Goodlet (in stewardship for pikers)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+``QIcon`` hackery.
+
+'''
+from PyQt5.QtWidgets import QStyle
+from PyQt5.QtGui import (
+    QIcon, QPixmap, QColor
+)
+from PyQt5.QtCore import QSize
+
+from ._style import hcolor
+
+# https://www.pythonguis.com/faq/built-in-qicons-pyqt/
+# account status icons taken from built-in set
+_icon_names: dict[str, str] = {
+    # these two seem to work for our mask hack done below to
+    # change the coloring.
+    'long_pp': 'SP_TitleBarShadeButton',
+    'short_pp': 'SP_TitleBarUnshadeButton',
+    'ready': 'SP_MediaPlay',
+}
+_icons: dict[str, QIcon] = {}
+
+
+def mk_icons(
+
+    style: QStyle,
+    size: QSize,
+
+) -> dict[str, QIcon]:
+    '''This helper is indempotent.
+
+    '''
+    global _icons, _icon_names
+    if _icons:
+        return _icons
+
+    # load account selection using current style
+    for name, icon_name in _icon_names.items():
+
+        stdpixmap = getattr(QStyle, icon_name)
+        stdicon = style.standardIcon(stdpixmap)
+        pixmap = stdicon.pixmap(size)
+
+        # fill hack from SO to change icon color:
+        # https://stackoverflow.com/a/38369468
+        out_pixmap = QPixmap(size)
+        out_pixmap.fill(QColor(hcolor('default_spotlight')))
+        out_pixmap.setMask(pixmap.createHeuristicMask())
+
+        # TODO: not idea why this doesn't work / looks like
+        # trash.  Sure would be nice to just generate our own
+        # pixmaps on the fly..
+        # p = QPainter(out_pixmap)
+        # p.setOpacity(1)
+        # p.setBrush(QColor(hcolor('papas_special')))
+        # p.setPen(QColor(hcolor('default_lightest')))
+        # path = mk_marker_path(style='|<')
+        # p.scale(6, 6)
+        # # p.translate(0, 0)
+        # p.drawPath(path)
+        # p.save()
+        # p.end()
+        # del p
+        # icon = QIcon(out_pixmap)
+
+        icon = QIcon()
+        icon.addPixmap(out_pixmap)
+
+        _icons[name] = icon
+
+    return _icons

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -270,7 +270,7 @@ async def handle_viewmode_kb_inputs(
             edit.selectAll()
             # un-highlight on ctrl release
             on_next_release = edit.deselect
-            pp_pane.update_status_ui()
+            pp_pane.update_status_ui(pp_pane.order_mode.current_pp)
 
         else:  # none active
 

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -133,6 +133,15 @@ class SettingsPane:
     # encompasing high level namespace
     order_mode: Optional['OrderMode'] = None  # typing: ignore # noqa
 
+    def set_accounts(
+        self,
+        names: list[str],
+        sizes: Optional[list[float]] = None,
+    ) -> None:
+
+        combo = self.form.fields['account']
+        return combo.set_items(names)
+
     def update_accounts_icon(
         self,
         status: str,  # one of the values in ``_icons`` above

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -42,7 +42,6 @@ from ..data._normalize import iterticks
 from ..data.feed import Feed
 from ._label import Label
 from ._lines import LevelLine, order_line
-from ._icons import mk_icons
 from ._style import _font
 from ._forms import FieldsForm, FillStatusBar, QLabel
 from ..log import get_logger
@@ -142,28 +141,8 @@ class SettingsPane:
         combo = self.form.fields['account']
         return combo.set_items(names)
 
-    def update_accounts_icon(
-        self,
-        status: str,  # one of the values in ``_icons`` above
-        keys: Optional[list[str]] = None,
-
-    ) -> None:
-
-        form = self.form
-        icons = mk_icons(
-            form.style(),
-            form.fields['account'].iconSize()
-        )
-        acct_select = form.fields['account']
-        keys = list(keys or acct_select._items.keys())
-        for key in keys:
-            i = acct_select._items[key]
-            icon = icons[status]
-            acct_select.setItemIcon(i, icon)
-
     def on_selection_change(
         self,
-
         text: str,
         key: str,
 
@@ -299,6 +278,26 @@ class SettingsPane:
             # min(round(prop * slots), slots)
             min(used, slots)
         )
+        self.update_account_icons({alloc.account_name(): pp.live_pp})
+
+    def update_account_icons(
+        self,
+        pps: dict[str, Position],
+
+    ) -> None:
+
+        form = self.form
+        accounts = form.fields['account']
+
+        for account_name, pp in pps.items():
+            icon_name = None
+
+            if pp.size > 0:
+                icon_name = 'long_pp'
+            elif pp.size < 0:
+                icon_name = 'short_pp'
+
+            accounts.set_icon(account_name, icon_name)
 
     def display_pnl(
         self,

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -185,11 +185,11 @@ class SettingsPane:
                     f'Account `{account_name}` can not be set for {sym}'
                 )
                 self.form.fields['account'].setCurrentText(
-                    old_tracker.alloc.account_name())
+                    old_tracker.alloc.account)
                 return
 
             self.order_mode.current_pp = tracker
-            assert tracker.alloc.account_name() == account_name
+            assert tracker.alloc.account == account_name
             self.form.fields['account'].setCurrentText(account_name)
             tracker.show()
             tracker.hide_info()
@@ -278,7 +278,7 @@ class SettingsPane:
             # min(round(prop * slots), slots)
             min(used, slots)
         )
-        self.update_account_icons({alloc.account_name(): pp.live_pp})
+        self.update_account_icons({alloc.account: pp.live_pp})
 
     def update_account_icons(
         self,
@@ -332,7 +332,7 @@ class SettingsPane:
             )
 
             log.info(
-                f'Starting pnl display for {tracker.alloc.account_name()}')
+                f'Starting pnl display for {tracker.alloc.account}')
             self.order_mode.nursery.start_soon(
                 display_pnl,
                 feed,
@@ -654,7 +654,7 @@ class PositionTracker:
                 'fiat_size': round(price * size, ndigits=2),
 
                 # TODO: per account lines on a single (or very related) symbol
-                'account': self.alloc.account_name(),
+                'account': self.alloc.account,
             })
             line.show()
 

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -25,10 +25,10 @@ from math import floor, copysign
 from typing import Optional
 
 
-from PyQt5.QtWidgets import QStyle
-from PyQt5.QtGui import (
-    QIcon, QPixmap, QColor
-)
+# from PyQt5.QtWidgets import QStyle
+# from PyQt5.QtGui import (
+#     QIcon, QPixmap, QColor
+# )
 from pyqtgraph import functions as fn
 
 from ._annotate import LevelMarker
@@ -42,7 +42,8 @@ from ..data._normalize import iterticks
 from ..data.feed import Feed
 from ._label import Label
 from ._lines import LevelLine, order_line
-from ._style import _font, hcolor
+from ._icons import mk_icons
+from ._style import _font
 from ._forms import FieldsForm, FillStatusBar, QLabel
 from ..log import get_logger
 
@@ -113,18 +114,6 @@ async def display_pnl(
         assert _pnl_tasks.pop(key)
 
 
-# https://www.pythonguis.com/faq/built-in-qicons-pyqt/
-# account status icons taken from built-in set
-_icon_names: dict[str, str] = {
-    # these two seem to work for our mask hack done below to
-    # change the coloring.
-    'long_pp': 'SP_TitleBarShadeButton',
-    'short_pp': 'SP_TitleBarUnshadeButton',
-    'ready': 'SP_MediaPlay',
-}
-_icons: dict[str, QIcon] = {}
-
-
 @dataclass
 class SettingsPane:
     '''Composite set of widgets plus an allocator model for configuring
@@ -152,52 +141,15 @@ class SettingsPane:
     ) -> None:
 
         form = self.form
-
-        global _icons, _icon_name
-        if not _icons:
-            # load account selection using current style
-            for name, icon_name in _icon_names.items():
-
-                stdpixmap = getattr(QStyle, icon_name)
-                stdicon = form.style().standardIcon(stdpixmap)
-                combo = form.fields['account']
-                size = combo.iconSize()
-                pixmap = stdicon.pixmap(combo.iconSize())
-
-                # fill hack from SO to change icon color:
-                # https://stackoverflow.com/a/38369468
-                out_pixmap = QPixmap(size)
-                out_pixmap.fill(QColor(hcolor('default_spotlight')))
-                out_pixmap.setMask(pixmap.createHeuristicMask())
-
-                # TODO: not idea why this doesn't work / looks like
-                # trash.  Sure would be nice to just generate our own
-                # pixmaps on the fly..
-                # p = QPainter(out_pixmap)
-                # p.setOpacity(1)
-                # p.setBrush(QColor(hcolor('papas_special')))
-                # p.setPen(QColor(hcolor('default_lightest')))
-                # path = mk_marker_path(style='|<')
-                # p.scale(6, 6)
-                # # p.translate(0, 0)
-                # p.drawPath(path)
-                # p.save()
-                # p.end()
-                # del p
-                # icon = QIcon(out_pixmap)
-
-                icon = QIcon()
-                icon.addPixmap(out_pixmap)
-
-                _icons[name] = icon
-
+        icons = mk_icons(
+            form.style(),
+            form.fields['account'].iconSize()
+        )
         acct_select = form.fields['account']
         keys = list(keys or acct_select._items.keys())
-
-        # breakpoint()
         for key in keys:
             i = acct_select._items[key]
-            icon = _icons[status]
+            icon = icons[status]
             acct_select.setItemIcon(i, icon)
 
     def on_selection_change(

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -118,7 +118,7 @@ class CompleterView(QTreeView):
         self.setModel(model)
         self.setAlternatingRowColors(True)
         # TODO: size this based on DPI font
-        self.setIndentation(20)
+        self.setIndentation(_font.px_size)
 
         # self.setUniformRowHeights(True)
         # self.setColumnWidth(0, 3)

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -223,7 +223,7 @@ class OrderMode:
         order = self._staged_order = Order(
             action=action,
             price=price,
-            account=self.current_pp.alloc.account_name(),
+            account=self.current_pp.alloc.account,
             size=0,
             symbol=symbol,
             brokers=symbol.brokers,
@@ -600,7 +600,6 @@ async def open_order_mode(
             # allocator
             alloc = mk_allocator(
                 symbol=symbol,
-                accounts=accounts,
                 account=account_name,
 
                 # if this startup size is greater the allocator limit,
@@ -640,7 +639,6 @@ async def open_order_mode(
             # allocator
             alloc = mk_allocator(
                 symbol=symbol,
-                accounts=accounts,
                 account=account_name,
                 startup_pp=startup_pp,
             )

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -549,9 +549,6 @@ async def open_order_mode(
         lines = LineEditor(chart=chart)
         arrows = ArrowEditor(chart, {})
 
-        # allocation and account settings side pane
-        form = chart.sidepane
-
         # symbol id
         symbol = chart.linked.symbol
         symkey = symbol.key
@@ -645,7 +642,9 @@ async def open_order_mode(
             pp_tracker.hide()
             trackers[account_name] = pp_tracker
 
-        # order pane widgets and allocation model
+        # setup order mode sidepane widgets
+        form = chart.sidepane
+
         order_pane = SettingsPane(
             form=form,
             # XXX: ugh, so hideous...
@@ -654,6 +653,17 @@ async def open_order_mode(
             step_label=form.bottom_label,
             limit_label=form.top_label,
         )
+        # set all entries as unavailable at startup and then fill out
+        # positions and ready icons
+        # order_pane.update_accounts_icon('unavailable')
+
+        for name, tracker in trackers.items():
+            if tracker.live_pp.size > 0:
+                order_pane.update_accounts_icon('long_pp', [name])
+            elif tracker.live_pp.size < 0:
+                order_pane.update_accounts_icon('short_pp', [name])
+            # else:
+            #     order_pane.update_accounts_icon('ready', [name])
 
         # top level abstraction which wraps all this crazyness into
         # a namespace..

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -665,15 +665,9 @@ async def open_order_mode(
         )
         order_pane.set_accounts(list(trackers.keys()))
 
-        # set all entries as unavailable at startup and then fill out
-        # positions and ready icons
-        # order_pane.update_accounts_icon('unavailable')
-
+        # update pp icons
         for name, tracker in trackers.items():
-            if tracker.live_pp.size > 0:
-                order_pane.update_accounts_icon('long_pp', [name])
-            elif tracker.live_pp.size < 0:
-                order_pane.update_accounts_icon('short_pp', [name])
+            order_pane.update_account_icons({name: tracker.live_pp})
 
         # top level abstraction which wraps all this crazyness into
         # a namespace..


### PR DESCRIPTION
A first draft towards #224.

Tried a few things (with some minor success) but still not happy with it.

---
The list of problems on [adding icons to `QComboBox`](https://doc.qt.io/qt-5/qcombobox.html#setItemIcon):
- right now we're using the [built-in icons set](https://www.pythonguis.com/faq/built-in-qicons-pyqt/) but there's also ways to get [linux-specific icons](https://specifications.freedesktop.org/icon-naming-spec/latest/ar01s04.html) (which seem to be loaded [like this](https://stackoverflow.com/questions/7253976/how-do-i-add-an-icon-to-qcombobox-in-qt)) as is mentioned in this blog post
  - here's the hot [SO tips](https://stackoverflow.com/questions/52358982/how-to-use-qstylestandardicon-standardpixmap-with-qstylestandardpixmap) on coverting std icons to `QIcon`
- trying to get icons to show up on the RHS (the most infuriating part so far):
    - [x] [customizing the `.paint()` on the delegate](https://stackoverflow.com/questions/39941183/pyqt-add-icon-to-right-side-of-qlistwidget-item) worked for **the view items only** (**not** the current item label) but it seems like we should be able to set this once up front no? (maybe somehow setting a [`QStyleOptionComboBox`](https://doc.qt.io/qt-5/qstyleoptioncombobox.html), but no idea where to do that...)
    - [ ] to try, this SO on [hiding the icon in the current item label](https://stackoverflow.com/questions/45546155/hide-icon-from-the-label-of-qcombobox) which is hacky as heck but seems to have give some insight?
- trying to get the icons themselves to match our color scheme / using custom graphics
 
    - [x] trying to fill the built-in icons using [a pixmap mask hack](https://stackoverflow.com/questions/13350631/simple-color-fill-qicons-in-qt)
    - [ ] it may be possible to generate pixmap icons from polygons, not sure if we need to add a [`.drawIcon()`](https://doc.qt.io/qt-5/qicon.html#making-classes-that-use-qicon) method or not (to what though?) but this might play with the `QPixMap` section we have in #124.
      - tried this using what is the [std apis](https://stackoverflow.com/questions/17888795/how-to-use-qpainter-on-qpixmap) and couldn't get it to work or look good at all. left a `TODO` in the icon generation code..
  
  
 ---
 Other `Qt` notes from this tinkering:
 -  it might be possible to specify view item heights [without a custom delegate](https://stackoverflow.com/questions/13308341/qcombobox-abstractitemviewitem?rq=1) 