### PR TITLE
Super basic brokerd status

### DIFF
--- a/piker/calc.py
+++ b/piker/calc.py
@@ -20,10 +20,17 @@ Handy financial calculations.
 import math
 import itertools
 
+from bidict import bidict
+
+
+_mag2suffix = bidict({3: 'k', 6: 'M', 9: 'B'})
+
 
 def humanize(
+
     number: float,
     digits: int = 1
+
 ) -> str:
     '''Convert large numbers to something with at most ``digits`` and
     a letter suffix (eg. k: thousand, M: million, B: billion).
@@ -36,17 +43,36 @@ def humanize(
     if not number or number <= 0:
         return round(number, ndigits=digits)
 
-    mag2suffix = {3: 'k', 6: 'M', 9: 'B'}
     mag = math.floor(math.log(number, 10))
     if mag < 3:
         return round(number, ndigits=digits)
 
-    maxmag = max(itertools.takewhile(lambda key: mag >= key, mag2suffix))
+    maxmag = max(itertools.takewhile(lambda key: mag >= key, _mag2suffix))
 
     return "{value}{suffix}".format(
         value=round(number/10**maxmag, ndigits=digits),
-        suffix=mag2suffix[maxmag],
+        suffix=_mag2suffix[maxmag],
     )
+
+
+def puterize(
+
+    text: str,
+    digits: int = 1,
+
+) -> float:
+    '''Inverse of ``humanize()`` above.
+
+    '''
+    try:
+        suffix = str(text)[-1]
+        mult = _mag2suffix.inverse[suffix]
+        value = text.rstrip(suffix)
+        return round(float(value) * 10**mult, ndigits=digits)
+
+    except KeyError:
+        # no matching suffix try just the value
+        return float(text)
 
 
 def pnl(

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -373,7 +373,9 @@ async def open_brokerd_trades_dialogue(
     broker = feed.mod.name
 
     # TODO: make a `tractor` bug/test for this!
-    # portal = feed._brokerd_portal
+    # if only i could member what the problem was..
+    # probably some GC of the portal thing?
+    # portal = feed.portal
 
     # XXX: we must have our own portal + channel otherwise
     # when the data feed closes it may result in a half-closed

--- a/piker/ui/_forms.py
+++ b/piker/ui/_forms.py
@@ -21,7 +21,6 @@ Text entry "forms" widgets (mostly for configuration and UI user input).
 from __future__ import annotations
 from contextlib import asynccontextmanager
 from functools import partial
-from textwrap import dedent
 from typing import (
     Optional, Any, Callable, Awaitable
 )
@@ -320,14 +319,14 @@ class FieldsForm(QWidget):
         self.vbox = QVBoxLayout(self)
         # self.vbox.setAlignment(Qt.AlignVCenter)
         self.vbox.setAlignment(Qt.AlignBottom)
-        self.vbox.setContentsMargins(0, 4, 3, 6)
+        self.vbox.setContentsMargins(3, 6, 3, 6)
         self.vbox.setSpacing(0)
 
         # split layout for the (<label>: |<widget>|) parameters entry
         self.form = QFormLayout()
         self.form.setAlignment(Qt.AlignTop | Qt.AlignLeft)
-        self.form.setContentsMargins(0, 0, 0, 0)
-        self.form.setSpacing(3)
+        self.form.setContentsMargins(0, 0, 3, 0)
+        self.form.setSpacing(0)
         self.form.setHorizontalSpacing(0)
 
         self.vbox.addLayout(self.form, stretch=1/3)
@@ -645,9 +644,7 @@ def mk_fill_status_bar(
     # PnL on lhs
     bar_labels_lhs = QVBoxLayout()
     left_label = form.add_field_label(
-        dedent("""
-        {pnl:>+.2%} pnl
-        """),
+        '{pnl:>+.2%} pnl',
         font_size=bar_label_font_size,
         font_color='gunmetal',
     )
@@ -674,18 +671,13 @@ def mk_fill_status_bar(
     # https://docs.python.org/3/library/string.html#grammar-token-precision
 
     top_label = form.add_field_label(
-        # {limit:.1f} limit
-        dedent("""
-        {limit}
-        """),
+        '{limit}',
         font_size=bar_label_font_size,
         font_color='gunmetal',
     )
 
     bottom_label = form.add_field_label(
-        dedent("""
-        x: {step_size}\n
-        """),
+        'x: {step_size}',
         font_size=bar_label_font_size,
         font_color='gunmetal',
     )
@@ -788,29 +780,10 @@ def mk_order_pane_layout(
     # add pp fill bar + spacing
     vbox.addLayout(hbox, stretch=1/3)
 
-    # TODO: status labels for brokerd real-time info
-    # feed_label = form.add_field_label(
-    #     dedent("""
-    #     brokerd.ib\n
-    #     |_@{host}:{port}\n
-    #     |_consumers: {cons}\n
-    #     |_streams: {streams}\n
-    #     |_shms: {streams}\n
-    #     """),
-    #     font_size=_font_small.px_size,
-    # )
-
-    # # add feed info label
-    # vbox.addWidget(
-    #     feed_label,
-    #     alignment=Qt.AlignBottom,
-    #     # stretch=1/3,
-    # )
-
     # TODO: handle resize events and appropriately scale this
     # to the sidepane height?
     # https://doc.qt.io/qt-5/layout.html#adding-widgets-to-a-layout
-    vbox.setSpacing(_font.px_size * 1.375)
+    # vbox.setSpacing(_font.px_size * 1.375)
 
     form.show()
     return form

--- a/piker/ui/_label.py
+++ b/piker/ui/_label.py
@@ -23,7 +23,7 @@ from typing import Callable, Optional, Any
 
 import pyqtgraph as pg
 from PyQt5 import QtGui, QtWidgets
-from PyQt5.QtWidgets import QLabel
+from PyQt5.QtWidgets import QLabel, QSizePolicy
 from PyQt5.QtCore import QPointF, QRectF, Qt
 
 from ._style import (
@@ -269,8 +269,11 @@ class FormatLabel(QLabel):
         self.setTextFormat(Qt.MarkdownText)  # markdown
         self.setMargin(0)
 
-        self.setAlignment(
-            Qt.AlignVCenter
+        self.setSizePolicy(
+            QSizePolicy.Expanding,
+            QSizePolicy.Expanding,
+        )
+        self.setAlignment(Qt.AlignVCenter
             | Qt.AlignLeft
         )
         self.setText(self.fmt_str)

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -36,7 +36,7 @@ from ._anchors import (
     pp_tight_and_right,  # wanna keep it straight in the long run
     gpath_pin,
 )
-from ..calc import humanize, pnl
+from ..calc import humanize, pnl, puterize
 from ..clearing._allocate import Allocator, Position
 from ..data._normalize import iterticks
 from ..data.feed import Feed
@@ -209,16 +209,14 @@ class SettingsPane:
 
         # WRITE any settings to current pp's allocator
         try:
+            value = puterize(value)
             if key == 'limit':
-                    if size_unit == 'currency':
-                        # old = alloc.currency_limit
-                        alloc.currency_limit = float(value)
-                    else:
-                        # old = alloc.units_limit
-                        alloc.units_limit = float(value)
+                if size_unit == 'currency':
+                    alloc.currency_limit = value
+                else:
+                    alloc.units_limit = value
 
             elif key == 'slots':
-                # old = alloc.slots
                 alloc.slots = int(value)
 
             elif key == 'size_unit':
@@ -226,7 +224,7 @@ class SettingsPane:
                 # the current settings in the new units
                 alloc.size_unit = value
 
-            elif key != 'account':
+            else:
                 raise ValueError(f'Unknown setting {key}')
 
             log.info(f'settings change: {key}: {value}')

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -208,26 +208,33 @@ class SettingsPane:
         size_unit = alloc.size_unit
 
         # WRITE any settings to current pp's allocator
-        if key == 'limit':
-            if size_unit == 'currency':
-                alloc.currency_limit = float(value)
-            else:
-                alloc.units_limit = float(value)
+        try:
+            if key == 'limit':
+                    if size_unit == 'currency':
+                        # old = alloc.currency_limit
+                        alloc.currency_limit = float(value)
+                    else:
+                        # old = alloc.units_limit
+                        alloc.units_limit = float(value)
 
-        elif key == 'slots':
-            alloc.slots = int(value)
+            elif key == 'slots':
+                # old = alloc.slots
+                alloc.slots = int(value)
 
-        elif key == 'size_unit':
-            # TODO: if there's a limit size unit change re-compute
-            # the current settings in the new units
-            alloc.size_unit = value
+            elif key == 'size_unit':
+                # TODO: if there's a limit size unit change re-compute
+                # the current settings in the new units
+                alloc.size_unit = value
 
-        elif key != 'account':
-            raise ValueError(f'Unknown setting {key}')
+            elif key != 'account':
+                raise ValueError(f'Unknown setting {key}')
+
+            log.info(f'settings change: {key}: {value}')
+
+        except ValueError:
+            log.error(f'Invalid value for `{key}`: {value}')
 
         # READ out settings and update UI
-        log.info(f'settings change: {key}: {value}')
-
         suffix = {'currency': ' $', 'units': ' u'}[size_unit]
         limit = alloc.limit()
 

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -45,6 +45,7 @@ from ._position import (
     PositionTracker,
     SettingsPane,
 )
+from ._label import FormatLabel
 from ._window import MultiStatus
 from ..clearing._messages import Order
 from ._forms import open_form_input_handling
@@ -623,6 +624,64 @@ async def open_order_mode(
 
         # setup order mode sidepane widgets
         form = chart.sidepane
+        vbox = form.vbox
+
+        from textwrap import dedent
+
+        from PyQt5.QtCore import Qt
+
+        from ._style import _font, _font_small
+        from ..calc import humanize
+
+        feed_label = FormatLabel(
+            fmt_str=dedent("""
+            actor: **{actor_name}**\n
+            |_ @**{host}:{port}**\n
+            |_ throttle_hz: **{throttle_rate}**\n
+            |_ streams: **{symbols}**\n
+            |_ shm: **{shm}**\n
+            """),
+            font=_font.font,
+            font_size=_font_small.px_size - 1,
+            font_color='default_lightest',
+        )
+
+        form.feed_label = feed_label
+
+        # add feed info label
+        # vbox.addWidget(
+        vbox.insertWidget(
+            0,
+            feed_label,
+            alignment=Qt.AlignBottom,
+            # stretch=1/3,
+        )
+        # vbox.setAlignment(feed_label, Qt.AlignBottom)
+        # vbox.setAlignment(Qt.AlignBottom)
+        blank_h = chart.height() - (
+            form.height() +
+            form.fill_bar.height()
+            # feed_label.height()
+        )
+        # await tractor.breakpoint()
+
+        # vbox.setSpacing(round(blank_h / 3) - 2*_font.px_size)
+        vbox.setSpacing((1 + 5/8)*_font.px_size)
+
+        # fill in brokerd feed info
+        host, port = feed.portal.channel.raddr
+        if host == '127.0.0.1':
+            host = 'localhost'
+        mpshm = feed.shm._shm
+        shmstr = f'{humanize(mpshm.size)}'
+        form.feed_label.format(
+            actor_name=feed.portal.channel.uid[0],
+            host=host,
+            port=port,
+            symbols=len(feed.symbols),
+            shm=shmstr,
+            throttle_rate=feed.throttle_rate,
+        )
 
         order_pane = SettingsPane(
             form=form,

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -642,19 +642,17 @@ async def open_order_mode(
             |_ shm: **{shm}**\n
             """),
             font=_font.font,
-            font_size=_font_small.px_size - 1,
+            font_size=_font_small.px_size,
             font_color='default_lightest',
         )
 
         form.feed_label = feed_label
 
-        # add feed info label
-        # vbox.addWidget(
+        # add feed info label to top
         vbox.insertWidget(
             0,
             feed_label,
             alignment=Qt.AlignBottom,
-            # stretch=1/3,
         )
         # vbox.setAlignment(feed_label, Qt.AlignBottom)
         # vbox.setAlignment(Qt.AlignBottom)
@@ -663,9 +661,6 @@ async def open_order_mode(
             form.fill_bar.height()
             # feed_label.height()
         )
-        # await tractor.breakpoint()
-
-        # vbox.setSpacing(round(blank_h / 3) - 2*_font.px_size)
         vbox.setSpacing((1 + 5/8)*_font.px_size)
 
         # fill in brokerd feed info


### PR DESCRIPTION
Gives us a little label on the order mode settings pane that shows **super** (for now) basic info about the quotes feed providing `brokerd` actor.

Basically looks like this:

![screenshot-2021-09-21_15-54-15](https://user-images.githubusercontent.com/291685/134238611-bc827aca-af8a-4ec9-b247-cdd926620173.png)

Eventually we want to have some controls here for restarting feeds and full actors as needed as well as for *moving* a stream source to another remote actor / `pikerd` cluster.

This is just a super basic draft label with initial info to get things going.

Also included is some new `puterize()` func logic which let's you input values with the trader-slang suffixes `{'k', 'M', 'B'}`, basically the opposite of our `piker.calc.humanize()`.