### PR TITLE
Ib client scanning

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -47,7 +47,7 @@ _root_modules = [
 
 class Services(BaseModel):
 
-    actor_n: tractor._trionics.ActorNursery
+    actor_n: tractor._supervise.ActorNursery
     service_n: trio.Nursery
     debug_mode: bool  # tractor sub-actor debug mode flag
     service_tasks: dict[str, tuple[trio.CancelScope, tractor.Portal]] = {}

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -26,6 +26,7 @@ from dataclasses import asdict
 from datetime import datetime
 from functools import partial
 import itertools
+from math import isnan
 from typing import (
     Any, Optional,
     AsyncIterator, Awaitable,
@@ -502,7 +503,11 @@ class Client:
             contract,
             snapshot=True,
         )
-        ticker = await ticker.updateEvent
+
+        # ensure a last price gets filled in before we deliver quote
+        while isnan(ticker.last):
+            ticker = await ticker.updateEvent
+
         details = (await details_fute)[0]
         return contract, ticker, details
 

--- a/piker/clearing/_client.py
+++ b/piker/clearing/_client.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 
 import trio
 import tractor
-from tractor._broadcast import broadcast_receiver
+from tractor.trionics import broadcast_receiver
 
 from ..data._source import Symbol
 from ..log import get_logger

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -868,7 +868,9 @@ async def display_symbol_data(
             )
 
             async with (
-                maybe_open_vlm_display(linkedsplits, ohlcv),
+                # XXX: this slipped in during a commits refacotr,
+                # it's actually landing proper in #231
+                # maybe_open_vlm_display(linkedsplits, ohlcv),
 
                 open_order_mode(
                     feed,

--- a/snippets/ib_data_reset.py
+++ b/snippets/ib_data_reset.py
@@ -30,7 +30,7 @@ win_name = 'Interactive Brokers'  # what for gw tho?
 con = t.find_named(win_name)[0]
 
 win_id = str(con.window)
-w, h = str(con.rect.width), str(con.rect.height)
+w, h = con.rect.width, con.rect.height
 
 # TODO: seems to be a few libs for python but not sure
 # if they support all the sub commands we need, order of
@@ -40,15 +40,14 @@ w, h = str(con.rect.width), str(con.rect.height)
 # https://github.com/cphyc/pyxdotool
 subprocess.call([
     'xdotool',
-    'windowactivate',
-    '--sync',
-    win_id,
+    'windowactivate', '--sync', win_id,
+
     # move mouse to bottom left of window (where there should
     # be nothing to click).
-    'mousemove_relative', '--sync', w, h,
+    'mousemove_relative', '--sync', str(w-3), str(h-3),
 
     # NOTE: we may need to stick a `--retry 3` in here..
-    'click', '1',
+    'click', '--window', win_id, '1',
 
     # hackzorzes
     'key', 'ctrl+alt+f',

--- a/snippets/ib_data_reset.py
+++ b/snippets/ib_data_reset.py
@@ -26,29 +26,36 @@ i3 = i3ipc.Connection()
 t = i3.get_tree()
 
 # for tws
-win_name = 'Interactive Brokers'  # what for gw tho?
-con = t.find_named(win_name)[0]
+win_names: list[str] = [
+    'Interactive Brokers',  # tws running in i3
+    'IB Gateway.',  # gw running in i3
+]
 
-win_id = str(con.window)
-w, h = con.rect.width, con.rect.height
+for name in win_names:
+    results = t.find_named(name)
+    if results:
+        con = results[0]
+        print(f'Resetting data feed for {name}')
+        win_id = str(con.window)
+        w, h = con.rect.width, con.rect.height
 
-# TODO: seems to be a few libs for python but not sure
-# if they support all the sub commands we need, order of
-# most recent commit history:
-# https://github.com/rr-/pyxdotool
-# https://github.com/ShaneHutter/pyxdotool
-# https://github.com/cphyc/pyxdotool
-subprocess.call([
-    'xdotool',
-    'windowactivate', '--sync', win_id,
+        # TODO: seems to be a few libs for python but not sure
+        # if they support all the sub commands we need, order of
+        # most recent commit history:
+        # https://github.com/rr-/pyxdotool
+        # https://github.com/ShaneHutter/pyxdotool
+        # https://github.com/cphyc/pyxdotool
+        subprocess.call([
+            'xdotool',
+            'windowactivate', '--sync', win_id,
 
-    # move mouse to bottom left of window (where there should
-    # be nothing to click).
-    'mousemove_relative', '--sync', str(w-3), str(h-3),
+            # move mouse to bottom left of window (where there should
+            # be nothing to click).
+            'mousemove_relative', '--sync', str(w-3), str(h-3),
 
-    # NOTE: we may need to stick a `--retry 3` in here..
-    'click', '--window', win_id, '1',
+            # NOTE: we may need to stick a `--retry 3` in here..
+            'click', '--window', win_id, '1',
 
-    # hackzorzes
-    'key', 'ctrl+alt+f',
-])
+            # hackzorzes
+            'key', 'ctrl+alt+f',
+        ])

--- a/snippets/ib_data_reset.py
+++ b/snippets/ib_data_reset.py
@@ -1,0 +1,45 @@
+# piker: trading gear for hackers
+# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+IB api client data feed reset hack for i3.
+
+'''
+import subprocess
+
+import i3ipc
+
+i3 = i3ipc.Connection()
+t = i3.get_tree()
+
+# for tws
+win_name = 'Interactive Brokers'  # what for gw tho?
+con = t.find_named(win_name)[0]
+
+win_id = con.window
+win_width = con.rect.width
+
+# TODO: seems to be a few libs for python but not sure
+# if they support all the sub commands we need, order of
+# most recent commit history:
+# https://github.com/rr-/pyxdotool
+# https://github.com/ShaneHutter/pyxdotool
+# https://github.com/cphyc/pyxdotool
+
+subprocess.call(
+    f'xdotool windowactivate --sync {win_id} mousemove_relative '
+    f'--sync {win_width} 1 click 1 key ctrl+alt+f'.split(' ')
+)

--- a/snippets/ib_data_reset.py
+++ b/snippets/ib_data_reset.py
@@ -29,8 +29,8 @@ t = i3.get_tree()
 win_name = 'Interactive Brokers'  # what for gw tho?
 con = t.find_named(win_name)[0]
 
-win_id = con.window
-win_width = con.rect.width
+win_id = str(con.window)
+w, h = str(con.rect.width), str(con.rect.height)
 
 # TODO: seems to be a few libs for python but not sure
 # if they support all the sub commands we need, order of
@@ -38,8 +38,18 @@ win_width = con.rect.width
 # https://github.com/rr-/pyxdotool
 # https://github.com/ShaneHutter/pyxdotool
 # https://github.com/cphyc/pyxdotool
+subprocess.call([
+    'xdotool',
+    'windowactivate',
+    '--sync',
+    win_id,
+    # move mouse to bottom left of window (where there should
+    # be nothing to click).
+    'mousemove_relative', '--sync', w, h,
 
-subprocess.call(
-    f'xdotool windowactivate --sync {win_id} mousemove_relative '
-    f'--sync {win_width} 1 click 1 key ctrl+alt+f'.split(' ')
-)
+    # NOTE: we may need to stick a `--retry 3` in here..
+    'click', '1',
+
+    # hackzorzes
+    'key', 'ctrl+alt+f',
+])


### PR DESCRIPTION
Adds support for using the new `tractor.to_asyncio.open_channel_from()` cross-async-loop api and vastly improves API endpoint scanning and cacheing for the ib backend.

Some other fixes and improvements:
- only return from a `Client.get_quote()` call once a "last price" has actually been filled in (previously due to asynchrony this would sometimes be `nan`..)
- add a mostly working data feed reset hack script which works around hitting throttle limits on history queries

