### PR TITLE
Fast step curve

### DIFF
--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -137,6 +137,9 @@ class FastAppendCurve(pg.PlotCurveItem):
         # print(f"xrange: {self._xrange}")
         istart, istop = self._xrange
 
+        # compute the length diffs between the first/last index entry in
+        # the input data and the last indexes we have on record from the
+        # last time we updated the curve index.
         prepend_length = istart - x[0]
         append_length = x[-1] - istop
 
@@ -149,7 +152,7 @@ class FastAppendCurve(pg.PlotCurveItem):
             # by default we only pull data up to the last (current) index
             x_out, y_out = x[:-1], y[:-1]
 
-        if self.path is None or prepend_length:
+        if self.path is None or prepend_length > 0:
             self.path = pg.functions.arrayToQPath(
                 x_out,
                 y_out,
@@ -177,7 +180,7 @@ class FastAppendCurve(pg.PlotCurveItem):
         #     # self.path.moveTo(new_x[0], new_y[0])
         #     self.path.connectPath(old_path)
 
-        elif append_length:
+        elif append_length > 0:
             if self._step_mode:
                 new_x, new_y = step_path_arrays_from_1d(
                     x[-append_length - 2:-1],

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -22,9 +22,87 @@ from typing import Tuple
 
 import numpy as np
 import pyqtgraph as pg
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtGui, QtWidgets
+from PyQt5.QtCore import (
+    QLineF,
+    QSizeF,
+    QRectF,
+    QPointF,
+)
 
 from .._profile import pg_profile_enabled
+from ._style import hcolor
+
+
+def step_path_arrays_from_1d(
+    x: np.ndarray,
+    y: np.ndarray,
+
+) -> (np.ndarray, np.ndarray):
+    '''Generate a "step mode" curve aligned with OHLC style bars
+    such that each segment spans each bar (aka "centered" style).
+
+    '''
+    y_out = y.copy()
+    x_out = x.copy()
+    x2 = np.empty(
+        # the data + 2 endpoints on either end for
+        # "termination of the path".
+        (len(x) + 1, 2),
+        # we want to align with OHLC or other sampling style
+        # bars likely so we need fractinal values
+        dtype=float,
+    )
+    x2[0] = x[0] - 0.5
+    x2[1] = x[0] + 0.5
+    x2[1:] = x[:, np.newaxis] + 0.5
+
+    # flatten to 1-d
+    x_out = x2.reshape(x2.size)
+
+    # we create a 1d with 2 extra indexes to
+    # hold the start and (current) end value for the steps
+    # on either end
+    y_out = np.empty(
+        2*len(y) + 2,
+        dtype=y.dtype
+    )
+    y2 = np.empty((len(y), 2), dtype=y.dtype)
+    y2[:] = y[:, np.newaxis]
+
+    # flatten and set 0 endpoints
+    y_out[1:-1] = y2.reshape(y2.size)
+    y_out[0] = 0
+    y_out[-1] = 0
+
+    return x_out, y_out
+
+
+def step_lines_from_point(
+    index: float,
+    level: float,
+
+) -> Tuple[QLineF]:
+
+    # TODO: maybe consider using `QGraphicsLineItem` ??
+    # gives us a ``.boundingRect()`` on the objects which may make
+    # computing the composite bounding rect of the last bars + the
+    # history path faster since it's done in C++:
+    # https://doc.qt.io/qt-5/qgraphicslineitem.html
+
+    # index = x[0]
+    # level = y[0]
+
+    # (x0 - 0.5, 0) -> (x0 - 0.5, y0)
+    left = QLineF(index - 0.5, 0, index - 0.5, level)
+
+    # (x0 - 0.5, y0) -> (x1 + 0.5, y1)
+    top = QLineF(index - 0.5, level, index + 0.5, level)
+
+    # (x1 + 0.5, y1 -> (x1 + 0.5, 0)
+    right = QLineF(index + 0.5, level, index + 0.5, 0)
+
+    return [left, top, right]
 
 
 # TODO: got a feeling that dropping this inheritance gets us even more speedups
@@ -41,10 +119,13 @@ class FastAppendCurve(pg.PlotCurveItem):
         # we're basically only using the pen setting now...
         super().__init__(*args, **kwargs)
 
-        self._last_line: QtCore.QLineF = None
+        self._last_line: QLineF = None
         self._xrange: Tuple[int, int] = self.dataBounds(ax=0)
         self._step_mode: bool = step_mode
 
+        self.setBrush(hcolor('bracket'))
+
+        breakpoint()
         # TODO: one question still remaining is if this makes trasform
         # interactions slower (such as zooming) and if so maybe if/when
         # we implement a "history" mode for the view we disable this in
@@ -53,8 +134,9 @@ class FastAppendCurve(pg.PlotCurveItem):
 
     def update_from_array(
         self,
-        x,
-        y,
+        x: np.ndarray,
+        y: np.ndarray,
+
     ) -> QtGui.QPainterPath:
 
         profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
@@ -69,37 +151,7 @@ class FastAppendCurve(pg.PlotCurveItem):
         # step mode: draw flat top discrete "step"
         # over the index space for each datum.
         if self._step_mode:
-            y_out = y.copy()
-            x_out = x.copy()
-            x2 = np.empty(
-                # the data + 2 endpoints on either end for
-                # "termination of the path".
-                (len(x) + 1, 2),
-                # we want to align with OHLC or other sampling style
-                # bars likely so we need fractinal values
-                dtype=float,
-            )
-            x2[0] = x[0] - 0.5
-            x2[1] = x[0] + 0.5
-            x2[1:] = x[:, np.newaxis] + 0.5
-
-            # flatten to 1-d
-            x_out = x2.reshape(x2.size)
-
-            # we create a 1d with 2 extra indexes to
-            # hold the start and (current) end value for the steps
-            # on either end
-            y_out = np.empty(
-                2*len(y) + 2,
-                dtype=y.dtype
-            )
-            y2 = np.empty((len(y), 2), dtype=y.dtype)
-            y2[:] = y[:,np.newaxis]
-            # flatten 
-            y_out[1:-1] = y2.reshape(y2.size)
-            y_out[0] = 0
-            y_out[-1] = 0
-
+            x_out, y_out = step_path_arrays_from_1d(x[:-1], y[:-1])
             # TODO: see ``painter.fillPath()`` call
             # inside parent's ``.paint()`` to get
             # a solid brush under the curve.
@@ -107,7 +159,6 @@ class FastAppendCurve(pg.PlotCurveItem):
         else:
             # by default we only pull data up to the last (current) index
             x_out, y_out = x[:-1], y[:-1]
-
 
         if self.path is None or prepend_length:
             self.path = pg.functions.arrayToQPath(
@@ -139,6 +190,11 @@ class FastAppendCurve(pg.PlotCurveItem):
             new_y = y[-append_length - 2:-1]
             # print((new_x, new_y))
 
+            if self._step_mode:
+                new_x, new_y = step_path_arrays_from_1d(new_x, new_y)
+                new_x = new_x[2:]
+                new_y = new_y[2:]
+
             append_path = pg.functions.arrayToQPath(
                 new_x,
                 new_y,
@@ -148,6 +204,7 @@ class FastAppendCurve(pg.PlotCurveItem):
             # self.path.moveTo(new_x[0], new_y[0])
             # self.path.connectPath(append_path)
             self.path.connectPath(append_path)
+            # self.fill_path.connectPath(
 
             # XXX: pretty annoying but, without this there's little
             # artefacts on the append updates to the curve...
@@ -163,7 +220,10 @@ class FastAppendCurve(pg.PlotCurveItem):
         self.yData = y
 
         self._xrange = x[0], x[-1]
-        self._last_line = QtCore.QLineF(x[-2], y[-2], x[-1], y[-1])
+        if self._step_mode:
+            self._last_step_lines = step_lines_from_point(x[-1], y[-1])
+        else:
+            self._last_line = QLineF(x[-2], y[-2], x[-1], y[-1])
 
         # trigger redraw of path
         # do update before reverting to cache mode
@@ -193,13 +253,13 @@ class FastAppendCurve(pg.PlotCurveItem):
         w = hb_size.width() + 1
         h = hb_size.height() + 1
 
-        br = QtCore.QRectF(
+        br = QRectF(
 
             # top left
-            QtCore.QPointF(hb.topLeft()),
+            QPointF(hb.topLeft()),
 
             # total size
-            QtCore.QSizeF(w, h)
+            QSizeF(w, h)
         )
         # print(f'bounding rect: {br}')
         return br
@@ -215,8 +275,19 @@ class FastAppendCurve(pg.PlotCurveItem):
         # p.setRenderHint(p.Antialiasing, True)
 
         p.setPen(self.opts['pen'])
-        p.drawLine(self._last_line)
-        profiler('.drawLine()')
 
-        p.drawPath(self.path)
-        profiler('.drawPath()')
+        if self._step_mode:
+            p.drawLines(*tuple(filter(bool, self._last_step_lines)))
+
+            # fill_path = QtGui.QPainterPath(self.path)
+            self.path.closeSubpath()
+            p.fillPath(self.path, self.opts['brush'])
+            p.drawPath(self.path)
+            profiler('.drawPath()')
+
+        else:
+            p.drawLine(self._last_line)
+            profiler('.drawLine()')
+
+            p.drawPath(self.path)
+            profiler('.drawPath()')

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -59,6 +59,19 @@ class FastAppendCurve(pg.PlotCurveItem):
         prepend_length = istart - x[0]
         append_length = x[-1] - istop
 
+        # TODO: step mode support
+        # if self.stepMode in ("center", True):  ## support True for back-compat
+        #     x2 = np.empty((len(x),2), dtype=x.dtype)
+        #     x2[:] = x[:, np.newaxis]
+
+        #     ## If we have a fill level, add two extra points at either end
+        #     x = x2.reshape(x2.size)
+        #     y2 = np.empty((len(y)+2,2), dtype=y.dtype)
+        #     y2[1:-1] = y[:,np.newaxis]
+        #     y = y2.reshape(y2.size)[1:-1]
+        #     y[0] = self.opts['fillLevel']
+        #     y[-1] = self.opts['fillLevel']
+
         if self.path is None or prepend_length:
             self.path = pg.functions.arrayToQPath(
                 x[:-1],

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -182,12 +182,14 @@ class BarItems(pg.GraphicsObject):
         # scene: 'QGraphicsScene',  # noqa
         plotitem: 'pg.PlotItem',  # noqa
         pen_color: str = 'bracket',
+        last_bar_color: str = 'bracket',
     ) -> None:
         super().__init__()
 
         # XXX: for the mega-lulz increasing width here increases draw latency...
         # so probably don't do it until we figure that out.
         self.bars_pen = pg.mkPen(hcolor(pen_color), width=1)
+        self.last_bar_pen = pg.mkPen(hcolor(last_bar_color), width=2)
 
         # NOTE: this prevents redraws on mouse interaction which is
         # a huge boon for avg interaction latency.
@@ -364,7 +366,6 @@ class BarItems(pg.GraphicsObject):
         profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
 
         # p.setCompositionMode(0)
-        p.setPen(self.bars_pen)
 
         # TODO: one thing we could try here is pictures being drawn of
         # a fixed count of bars such that based on the viewbox indices we
@@ -372,9 +373,11 @@ class BarItems(pg.GraphicsObject):
         # as is necesarry for what's in "view". Not sure if this will
         # lead to any perf gains other then when zoomed in to less bars
         # in view.
+        p.setPen(self.last_bar_pen)
         p.drawLines(*tuple(filter(bool, self._last_bar_lines)))
         profiler('draw last bar')
 
+        p.setPen(self.bars_pen)
         p.drawPath(self.path)
         profiler('draw history path')
 

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -186,8 +186,8 @@ class BarItems(pg.GraphicsObject):
     ) -> None:
         super().__init__()
 
-        # XXX: for the mega-lulz increasing width here increases draw latency...
-        # so probably don't do it until we figure that out.
+        # XXX: for the mega-lulz increasing width here increases draw
+        # latency...  so probably don't do it until we figure that out.
         self.bars_pen = pg.mkPen(hcolor(pen_color), width=1)
         self.last_bar_pen = pg.mkPen(hcolor(last_bar_color), width=2)
 
@@ -356,31 +356,6 @@ class BarItems(pg.GraphicsObject):
         if flip_cache:
             self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
 
-    def paint(
-        self,
-        p: QtGui.QPainter,
-        opt: QtWidgets.QStyleOptionGraphicsItem,
-        w: QtWidgets.QWidget
-    ) -> None:
-
-        profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
-
-        # p.setCompositionMode(0)
-
-        # TODO: one thing we could try here is pictures being drawn of
-        # a fixed count of bars such that based on the viewbox indices we
-        # only draw the "rounded up" number of "pictures worth" of bars
-        # as is necesarry for what's in "view". Not sure if this will
-        # lead to any perf gains other then when zoomed in to less bars
-        # in view.
-        p.setPen(self.last_bar_pen)
-        p.drawLines(*tuple(filter(bool, self._last_bar_lines)))
-        profiler('draw last bar')
-
-        p.setPen(self.bars_pen)
-        p.drawPath(self.path)
-        profiler('draw history path')
-
     def boundingRect(self):
         # Qt docs: https://doc.qt.io/qt-5/qgraphicsitem.html#boundingRect
 
@@ -424,3 +399,28 @@ class BarItems(pg.GraphicsObject):
             )
 
         )
+
+    def paint(
+        self,
+        p: QtGui.QPainter,
+        opt: QtWidgets.QStyleOptionGraphicsItem,
+        w: QtWidgets.QWidget
+    ) -> None:
+
+        profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
+
+        # p.setCompositionMode(0)
+
+        # TODO: one thing we could try here is pictures being drawn of
+        # a fixed count of bars such that based on the viewbox indices we
+        # only draw the "rounded up" number of "pictures worth" of bars
+        # as is necesarry for what's in "view". Not sure if this will
+        # lead to any perf gains other then when zoomed in to less bars
+        # in view.
+        p.setPen(self.last_bar_pen)
+        p.drawLines(*tuple(filter(bool, self._last_bar_lines)))
+        profiler('draw last bar')
+
+        p.setPen(self.bars_pen)
+        p.drawPath(self.path)
+        profiler('draw history path')

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -146,7 +146,7 @@ def path_arrays_from_ohlc(
         # specifies that the first edge is never connected to the
         # prior bars last edge thus providing a small "gap"/"space"
         # between bars determined by ``bar_gap``.
-        c[istart:istop] = (0, 1, 1, 1, 1, 1)
+        c[istart:istop] = (1, 1, 1, 1, 1, 0)
 
     return x, y, c
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@
 # are often untested in tractor's CI and/or being tested by us
 # first before committing as core features in tractor's base.
 -e git+git://github.com/goodboy/tractor.git@piker_pin#egg=tractor
+
+# `pyqtgraph` peeps keep breaking, fixing, improving so might as well
+# pin this to a dev branch that we have more control over especially
+# as more graphics stuff gets hashed out.
+-e git+git://github.com/pikers/pyqtgraph.git@piker_pin#egg=pyqtgraph


### PR DESCRIPTION
This adds a so called "step curve" graphic that is drawn as sequence of line segments per discrete datum in the domain. It can be thought of what a histogram typically looks like except we don't draw "separator lines" (vertical segments that touch the zero line) between each datum thus giving the appearance of a continuous curve where for each sample in the x, there is a flat segment in the y spanning that sample index in the x.

`pyqtgraph` actually already has this feature [inside the `PlotCurveItem` type](https://github.com/pyqtgraph/pyqtgraph/blob/8436457cc38b66d060a0d5afd7c92fb0a2cca4cb/pyqtgraph/graphicsItems/PlotCurveItem.py#L537) but it's somewhat hard to configure correctly to our sampling style (OHLC typically) and is **not** optimized for real-time update like our rewrite of `PlotCurveItem`. Further the `fillLevel` support is horrendously slow is used with `stepMode` as is demonstrated (and hopefully solved) in https://github.com/pyqtgraph/pyqtgraph/pull/2032.

I actually personally prefer the style now of this non-filled version anyway but we may want to support it if it's improved in `pyqtgraph` core.

Some additional niceties include highlighting the most recent curve-step-segment to distinguish it from history data. It's much easier to see what is the live data step, even from a far out zoom.

Also note, this PR does not include any actual usage of the new graphic 😂

That is all coming in #231.

  