### PR TITLE
Fsp hotfixes

### DIFF
--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -90,7 +90,7 @@ async def fsp_compute(
     func_name: str,
     func: Callable,
 
-    attach_stream: bool = False,
+    attach_stream: bool = True,
     task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -427,7 +427,7 @@ async def run_fsp(
     )
 
     async with (
-        portal.open_stream_from(
+        portal.open_context(
 
             # chaining entrypoint
             fsp.cascade,
@@ -437,20 +437,16 @@ async def run_fsp(
             src_shm_token=src_shm.token,
             dst_shm_token=conf['shm'].token,
             symbol=sym,
-            fsp_func_name=fsp_func_name,
+            func_name=fsp_func_name,
             loglevel=loglevel,
 
-        ) as stream,
-
+        ) as (ctx, last_index),
+        ctx.open_stream() as stream,
         open_sidepane(
             linkedsplits,
             display_name,
         ) as sidepane,
     ):
-
-        # receive last index for processed historical
-        # data-array as first msg
-        _ = await stream.receive()
 
         shm = conf['shm']
 


### PR DESCRIPTION
🤦🏼 .. this is what happens when you factor commits out from different layers of a distributed system 😂 

Main thing here was,
- use `Portal.open_context()` to talk to the fsp cluster.. since we ported to that API in #236.
- keep the fsp workers sending on streams since the aggregate throttled graphics update loop won't land until #231.. or thereabouts.

On the flip side, this did find a bunch of stuff to improve / bugfix in `tractor` so maybe not all bad.

Proposals for `tractor` from this experience:
- it should be an error to do `Context.open_stream()` **before** `Context.started()`
- there is a spawning case it isn't 'handling where the process handle is not actually ever created and thus teardown logic may run that is unecessary.  