### PR TITLE
`marketstore` OHCLV storage and client integration

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -19,7 +19,7 @@ Structured, daemon tree service management.
 
 """
 from typing import Optional, Union, Callable, Any
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager as acm
 from collections import defaultdict
 
 from pydantic import BaseModel
@@ -130,7 +130,7 @@ class Services(BaseModel):
 _services: Optional[Services] = None
 
 
-@asynccontextmanager
+@acm
 async def open_pikerd(
     start_method: str = 'trio',
     loglevel: Optional[str] = None,
@@ -185,7 +185,7 @@ async def open_pikerd(
             yield _services
 
 
-@asynccontextmanager
+@acm
 async def open_piker_runtime(
     name: str,
     enable_modules: list[str] = [],
@@ -226,7 +226,7 @@ async def open_piker_runtime(
         yield tractor.current_actor()
 
 
-@asynccontextmanager
+@acm
 async def maybe_open_runtime(
     loglevel: Optional[str] = None,
     **kwargs,
@@ -249,7 +249,7 @@ async def maybe_open_runtime(
         yield
 
 
-@asynccontextmanager
+@acm
 async def maybe_open_pikerd(
     loglevel: Optional[str] = None,
     **kwargs,
@@ -300,7 +300,34 @@ class Brokerd:
     locks = defaultdict(trio.Lock)
 
 
-@asynccontextmanager
+@acm
+async def find_service(
+    service_name: str,
+
+) -> tractor.Portal:
+
+    log.info(f'Scanning for existing {service_name}')
+    # attach to existing daemon by name if possible
+    async with tractor.find_actor(
+        service_name,
+        arbiter_sockaddr=_registry_addr,
+    ) as portal:
+        yield portal
+
+
+async def check_for_service(
+    service_name: str,
+
+) -> bool:
+    '''
+    Service daemon "liveness" predicate.
+
+    '''
+    async with find_service(service_name) as portal:
+        return portal is not None
+
+
+@acm
 async def maybe_spawn_daemon(
 
     service_name: str,
@@ -330,19 +357,13 @@ async def maybe_spawn_daemon(
     lock = Brokerd.locks[service_name]
     await lock.acquire()
 
-    log.info(f'Scanning for existing {service_name}')
-    # attach to existing daemon by name if possible
-    async with tractor.find_actor(
-        service_name,
-        arbiter_sockaddr=_registry_addr,
-
-    ) as portal:
+    async with find_service(service_name) as portal:
         if portal is not None:
             lock.release()
             yield portal
             return
 
-        log.warning(f"Couldn't find any existing {service_name}")
+    log.warning(f"Couldn't find any existing {service_name}")
 
     # ask root ``pikerd`` daemon to spawn the daemon we need if
     # pikerd is not live we now become the root of the
@@ -423,7 +444,7 @@ async def spawn_brokerd(
     return True
 
 
-@asynccontextmanager
+@acm
 async def maybe_spawn_brokerd(
 
     brokername: str,
@@ -485,7 +506,7 @@ async def spawn_emsd(
     return True
 
 
-@asynccontextmanager
+@acm
 async def maybe_open_emsd(
 
     brokername: str,

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -303,16 +303,15 @@ class Brokerd:
 @acm
 async def find_service(
     service_name: str,
+) -> Optional[tractor.Portal]:
 
-) -> tractor.Portal:
-
-    log.info(f'Scanning for existing {service_name}')
+    log.info(f'Scanning for service `{service_name}`')
     # attach to existing daemon by name if possible
     async with tractor.find_actor(
         service_name,
         arbiter_sockaddr=_registry_addr,
-    ) as portal:
-        yield portal
+    ) as maybe_portal:
+        yield maybe_portal
 
 
 async def check_for_service(
@@ -323,8 +322,11 @@ async def check_for_service(
     Service daemon "liveness" predicate.
 
     '''
-    async with find_service(service_name) as portal:
-        return portal is not None
+    async with tractor.query_actor(
+        service_name,
+        arbiter_sockaddr=_registry_addr,
+    ) as sockaddr:
+        return sockaddr
 
 
 @acm

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -310,7 +310,7 @@ async def maybe_spawn_daemon(
     **kwargs,
 
 ) -> tractor.Portal:
-    """
+    '''
     If no ``service_name`` daemon-actor can be found,
     spawn one in a local subactor and return a portal to it.
 
@@ -321,7 +321,7 @@ async def maybe_spawn_daemon(
     This can be seen as a service starting api for remote-actor
     clients.
 
-    """
+    '''
     if loglevel:
         get_console_log(loglevel)
 
@@ -431,7 +431,9 @@ async def maybe_spawn_brokerd(
     **kwargs,
 
 ) -> tractor.Portal:
-    '''Helper to spawn a brokerd service.
+    '''
+    Helper to spawn a brokerd service *from* a client
+    who wishes to use the sub-actor-daemon.
 
     '''
     async with maybe_spawn_daemon(

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -54,13 +54,19 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
             trio.open_nursery() as n,
         ):
             if tsdb:
+                # TODO:
+                # async with maybe_open_marketstored():
+
                 from piker.data._ahab import start_ahab
                 log.info('Spawning `marketstore` supervisor')
-                ctn_ready = await n.start(start_ahab)
+                ctn_ready = await n.start(
+                    start_ahab,
+                    'marketstored',
+                )
                 await ctn_ready.wait()
                 log.info('`marketstore` container:{uid} up')
 
-            await trio.sleep_forever()
+                await trio.sleep_forever()
 
     trio.run(main)
 

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -50,7 +50,7 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
             open_pikerd(
                 loglevel=loglevel,
                 debug_mode=pdb,
-            ) as services,
+            ),  # normally delivers a ``Services`` handle
             trio.open_nursery() as n,
         ):
             if tsdb:

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -66,7 +66,7 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
                 await ctn_ready.wait()
                 log.info('`marketstore` container:{uid} up')
 
-                await trio.sleep_forever()
+            await trio.sleep_forever()
 
     trio.run(main)
 

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -16,20 +16,6 @@ from .. import config
 log = get_logger('cli')
 DEFAULT_BROKER = 'questrade'
 
-_config_dir = click.get_app_dir('piker')
-_watchlists_data_path = os.path.join(_config_dir, 'watchlists.json')
-_context_defaults = dict(
-    default_map={
-        # Questrade specific quote poll rates
-        'monitor': {
-            'rate': 3,
-        },
-        'optschain': {
-            'rate': 1,
-        },
-    }
-)
-
 
 @click.command()
 @click.option('--loglevel', '-l', default='warning', help='Logging level')
@@ -58,7 +44,7 @@ def pikerd(loglevel, host, tl, pdb):
     trio.run(main)
 
 
-@click.group(context_settings=_context_defaults)
+@click.group(context_settings=config._context_defaults)
 @click.option(
     '--brokers', '-b',
     default=[DEFAULT_BROKER],
@@ -87,8 +73,8 @@ def cli(ctx, brokers, loglevel, tl, configdir):
         'loglevel': loglevel,
         'tractorloglevel': None,
         'log': get_console_log(loglevel),
-        'confdir': _config_dir,
-        'wl_path': _watchlists_data_path,
+        'confdir': config._config_dir,
+        'wl_path': config._watchlists_data_path,
     })
 
     # allow enabling same loglevel in ``tractor`` machinery

--- a/piker/config.py
+++ b/piker/config.py
@@ -17,6 +17,8 @@
 """
 Broker configuration mgmt.
 """
+import platform
+import sys
 import os
 from os.path import dirname
 import shutil
@@ -24,13 +26,73 @@ from typing import Optional
 
 from bidict import bidict
 import toml
-import click
 
 from .log import get_logger
 
 log = get_logger('broker-config')
 
-_config_dir = _click_config_dir = click.get_app_dir('piker')
+
+# taken from ``click`` since apparently they have some
+# super weirdness with sigint and sudo..no clue
+def get_app_dir(app_name, roaming=True, force_posix=False):
+    r"""Returns the config folder for the application.  The default behavior
+    is to return whatever is most appropriate for the operating system.
+
+    To give you an idea, for an app called ``"Foo Bar"``, something like
+    the following folders could be returned:
+
+    Mac OS X:
+      ``~/Library/Application Support/Foo Bar``
+    Mac OS X (POSIX):
+      ``~/.foo-bar``
+    Unix:
+      ``~/.config/foo-bar``
+    Unix (POSIX):
+      ``~/.foo-bar``
+    Win XP (roaming):
+      ``C:\Documents and Settings\<user>\Local Settings\Application Data\Foo Bar``
+    Win XP (not roaming):
+      ``C:\Documents and Settings\<user>\Application Data\Foo Bar``
+    Win 7 (roaming):
+      ``C:\Users\<user>\AppData\Roaming\Foo Bar``
+    Win 7 (not roaming):
+      ``C:\Users\<user>\AppData\Local\Foo Bar``
+
+    .. versionadded:: 2.0
+
+    :param app_name: the application name.  This should be properly capitalized
+                     and can contain whitespace.
+    :param roaming: controls if the folder should be roaming or not on Windows.
+                    Has no affect otherwise.
+    :param force_posix: if this is set to `True` then on any POSIX system the
+                        folder will be stored in the home folder with a leading
+                        dot instead of the XDG config home or darwin's
+                        application support folder.
+    """
+
+    def _posixify(name):
+        return "-".join(name.split()).lower()
+
+    # if WIN:
+    if platform.system() == 'Windows':
+        key = "APPDATA" if roaming else "LOCALAPPDATA"
+        folder = os.environ.get(key)
+        if folder is None:
+            folder = os.path.expanduser("~")
+        return os.path.join(folder, app_name)
+    if force_posix:
+        return os.path.join(os.path.expanduser("~/.{}".format(_posixify(app_name))))
+    if sys.platform == "darwin":
+        return os.path.join(
+            os.path.expanduser("~/Library/Application Support"), app_name
+        )
+    return os.path.join(
+        os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+        _posixify(app_name),
+    )
+
+
+_config_dir = _click_config_dir = get_app_dir('piker')
 _parent_user = os.environ.get('SUDO_USER')
 
 if _parent_user:

--- a/piker/config.py
+++ b/piker/config.py
@@ -30,8 +30,34 @@ from .log import get_logger
 
 log = get_logger('broker-config')
 
-_config_dir = click.get_app_dir('piker')
+_config_dir = _click_config_dir = click.get_app_dir('piker')
+_parent_user = os.environ.get('SUDO_USER')
+
+if _parent_user:
+    non_root_user_dir = os.path.expanduser(
+        f'~{_parent_user}'
+    )
+    root = 'root'
+    _config_dir = (
+        non_root_user_dir +
+        _click_config_dir[
+            _click_config_dir.rfind(root) + len(root):
+        ]
+    )
+
 _file_name = 'brokers.toml'
+_watchlists_data_path = os.path.join(_config_dir, 'watchlists.json')
+_context_defaults = dict(
+    default_map={
+        # Questrade specific quote poll rates
+        'monitor': {
+            'rate': 3,
+        },
+        'optschain': {
+            'rate': 1,
+        },
+    }
+)
 
 
 def _override_config_dir(

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -149,7 +149,6 @@ async def open_marketstore_container(
     '''
     # log = get_console_log('info', name=__name__)
 
-    # client = docker.from_env(**kwargs)
     async with open_docker() as client:
         # create a mount from user's local piker config dir into container
         config_dir_mnt = docker.types.Mount(

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -1,0 +1,151 @@
+# piker: trading gear for hackers
+# Copyright (C) 2018-present  Tyler Goodlet (in stewardship of piker0)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
+Supervisor for docker with included specific-image service helpers.
+
+'''
+from typing import Optional
+from contextlib import contextmanager as cm
+# import time
+
+import trio
+import tractor
+import docker
+import json
+# from docker.containers import Container
+from requests import ConnectionError
+
+from ..log import get_logger, get_console_log
+
+log = get_logger(__name__)
+
+
+_config = '''
+# mount this config using:
+# sudo docker run --mount type=bind,source="$HOME/.config/piker/",target="/etc" -i -p 5993:5993 alpacamarkets/marketstore:latest
+root_directory: data
+listen_port: 5993
+grpc_listen_port: 5995
+log_level: info
+queryable: true
+stop_grace_period: 0
+wal_rotate_interval: 5
+stale_threshold: 5
+enable_add: true
+enable_remove: false
+
+triggers:
+  - module: ondiskagg.so
+    on: "*/1Sec/OHLCV"
+    config:
+        # filter: "nasdaq"
+        destinations:
+            - 1Min
+            - 5Min
+            - 15Min
+            - 1H
+            - 1D
+
+  - module: stream.so
+    on: '*/*/*'
+    # config:
+    #     filter: "nasdaq"
+
+'''
+
+
+@cm
+def open_docker(
+    url: Optional[str] = None,
+    **kwargs,
+
+) -> docker.DockerClient:
+
+    # yield docker.Client(
+    #     base_url=url,
+    #     **kwargs
+    # ) if url else
+    yield docker.from_env(**kwargs)
+
+
+@tractor.context
+async def open_marketstore_container(
+    ctx: tractor.Context,
+    **kwargs,
+
+) -> None:
+    log = get_console_log('info', name=__name__)
+    # this cli should "just work"
+    # sudo docker run --mount
+    # type=bind,source="$HOME/.config/piker/",target="/etc" -i -p
+    # 5993:5993 alpacamarkets/marketstore:latest
+    client = docker.from_env(**kwargs)
+
+    # with open_docker() as client:
+    ctnr = client.containers.run(
+        'alpacamarkets/marketstore:latest',
+        [
+            '--mount',
+            'type=bind,source="$HOME/.config/piker/",target="/etc"',
+            '-i',
+            '-p 5993:5993',
+        ],
+        detach=True,
+    )
+    started: bool = False
+    logs = ctnr.logs(stream=True)
+
+    with trio.move_on_after(0.5):
+        for entry in logs:
+            entry = entry.decode()
+            try:
+                record = json.loads(entry.strip())
+            except json.JSONDecodeError:
+                if 'Error' in entry:
+                    raise RuntimeError(entry)
+                # await tractor.breakpoint()
+            msg = record['msg']
+
+            if "launching tcp listener for all services..." in msg:
+                started = True
+                break
+
+            await trio.sleep(0)
+
+    if not started and ctnr not in client.containers.list():
+        raise RuntimeError(
+            'Failed to start `marketstore` check logs output for deats'
+        )
+
+    await ctx.started()
+    await tractor.breakpoint()
+
+
+async def main():
+    async with tractor.open_nursery(
+        loglevel='info',
+    ) as tn:
+        portal = await tn.start_actor('ahab', enable_modules=[__name__])
+
+        async with portal.open_context(
+            open_marketstore_container
+
+        ) as (first, ctx):
+            await trio.sleep_forever()
+
+if __name__ == '__main__':
+    trio.run(main)

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -242,11 +242,12 @@ async def open_marketstore(
                             raise RuntimeError(entry)
 
                     msg = record['msg']
+                    level = record['level']
                     if msg and entry not in seen_so_far:
                         seen_so_far.add(entry)
                         if bp_on_msg:
                             await tractor.breakpoint()
-                        log.info(f'{msg}')
+                        getattr(log, level)(f'{msg}')
 
                     # if "launching tcp listener for all services..." in msg:
                     if match in msg:

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -298,7 +298,16 @@ async def start_ahab(
     task_status: TaskStatus[trio.Event] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:
+    '''
+    Start a ``docker`` container supervisor with given service name.
 
+    Currently the actor calling this task should normally be started
+    with root permissions (until we decide to use something that doesn't
+    require this, like docker's rootless mode or some wrapper project) but
+    te root perms are de-escalated after the docker supervisor sub-actor
+    is started.
+
+    '''
     cn_ready = trio.Event()
     async with tractor.open_nursery(
         loglevel='runtime',

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -22,14 +22,16 @@ financial data flows.
 from __future__ import annotations
 from collections import Counter
 import time
+from typing import TYPE_CHECKING
 
 import tractor
 import trio
 from trio_typing import TaskStatus
 
-from ._sharedmem import ShmArray
 from ..log import get_logger
 
+if TYPE_CHECKING:
+    from ._sharedmem import ShmArray
 
 log = get_logger(__name__)
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -127,11 +127,11 @@ def unpack_fqsn(fqsn: str) -> tuple[str, str, str]:
 
 
 class Symbol(BaseModel):
-    """I guess this is some kinda container thing for dealing with
+    '''
+    I guess this is some kinda container thing for dealing with
     all the different meta-data formats from brokers?
 
-    Yah, i guess dats what it izz.
-    """
+    '''
     key: str
     tick_size: float = 0.01
     lot_tick_size: float = 0.0  # "volume" precision as min step value

--- a/piker/data/cli.py
+++ b/piker/data/cli.py
@@ -111,20 +111,27 @@ def ms_stream(config: dict, names: List[str], url: str):
 )
 @click.option(
     '--port',
-    default=5995
+    default=5993
 )
 @click.pass_obj
 def ms_shell(config, tl, host, port):
-    """Start an IPython shell ready to query the local marketstore db.
-    """
-    async def main():
-        async with open_marketstore_client(host, port) as client:
-            query = client.query  # noqa
-            # TODO: write magics to query marketstore
-            from IPython import embed
-            embed()
+    '''
+    Start an IPython shell ready to query the local marketstore db.
 
-    tractor.run(main)
+    '''
+    from piker.data.marketstore import backfill_history
+    from piker._daemon import open_piker_runtime
+    async def main():
+        async with open_piker_runtime(
+            'ms_shell',
+            enable_modules=['piker.data._ahab'],
+        ):
+            await backfill_history()
+            # TODO: write magics to query marketstore
+            # from IPython import embed
+            # embed()
+
+    trio.run(main)
 
 
 @cli.command()

--- a/piker/data/cli.py
+++ b/piker/data/cli.py
@@ -16,6 +16,7 @@
 
 """
 marketstore cli.
+
 """
 from typing import List
 from functools import partial

--- a/piker/data/cli.py
+++ b/piker/data/cli.py
@@ -119,14 +119,14 @@ def ms_shell(config, tl, host, port):
     Start an IPython shell ready to query the local marketstore db.
 
     '''
-    from piker.data.marketstore import backfill_history
+    from piker.data.marketstore import backfill_history_diff
     from piker._daemon import open_piker_runtime
     async def main():
         async with open_piker_runtime(
             'ms_shell',
             enable_modules=['piker.data._ahab'],
         ):
-            await backfill_history()
+            await backfill_history_diff()
             # TODO: write magics to query marketstore
             # from IPython import embed
             # embed()

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -20,6 +20,7 @@ Data feed apis and infra.
 This module is enabled for ``brokerd`` daemons.
 
 """
+from __future__ import annotations
 from dataclasses import dataclass, field
 from contextlib import asynccontextmanager
 from functools import partial

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -192,6 +192,22 @@ async def _setup_persistent_brokerd(
         await trio.sleep_forever()
 
 
+async def start_backfill(
+    mod: ModuleType,
+    fqsn: str,
+    shm: ShmArray,
+
+    task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
+
+) -> int:
+
+    return await mod.backfill_bars(
+        fqsn,
+        shm,
+        task_status=task_status,
+    )
+
+
 async def manage_history(
     mod: ModuleType,
     bus: _FeedsBus,
@@ -222,7 +238,12 @@ async def manage_history(
     )
 
     log.info('Scanning for existing `marketstored`')
+
     is_up = await check_for_service('marketstored')
+
+    # for now only do backfilling if no tsdb can be found
+    do_backfill = not is_up and opened
+
     if is_up and opened:
         log.info('Found existing `marketstored`')
         from . import marketstore
@@ -230,6 +251,11 @@ async def manage_history(
         async with marketstore.open_storage_client(
             fqsn,
         ) as (storage, tsdb_arrays):
+
+            # TODO: get this shit workin
+            from tractor.trionics import ipython_embed
+            await ipython_embed()
+            # await ipython_embed(ns=locals())
 
             # TODO: history validation
             # assert opened, f'Persistent shm for {symbol} was already open?!'
@@ -272,16 +298,27 @@ async def manage_history(
 
                     last_dt = datetime.fromtimestamp(last_s)
                     array, next_dt = await hist(end_dt=last_dt)
+            else:
+                do_backfill = True
+
+                # await tractor.breakpoint()
 
             some_data_ready.set()
 
-    elif opened:
+    if do_backfill:
         log.info('No existing `marketstored` found..')
 
         # start history backfill task ``backfill_bars()`` is
         # a required backend func this must block until shm is
         # filled with first set of ohlc bars
-        _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
+        await bus.nursery.start(
+            start_backfill,
+            mod,
+            fqsn,
+            shm,
+        )
+
+        # _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
 
     # yield back after client connect with filled shm
     task_status.started(shm)
@@ -361,8 +398,10 @@ async def allocate_persistent_feed(
             loglevel=loglevel,
         )
     )
-    # the broker-specific fully qualified symbol name
-    bfqsn = init_msg[symbol]['fqsn']
+    # the broker-specific fully qualified symbol name,
+    # but ensure it is lower-cased for external use.
+    bfqsn = init_msg[symbol]['fqsn'].lower()
+    init_msg[symbol]['fqsn'] = bfqsn
 
     # HISTORY, run 2 tasks:
     # - a history loader / maintainer

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -36,6 +36,7 @@ from trio.abc import ReceiveChannel
 from trio_typing import TaskStatus
 import tractor
 from pydantic import BaseModel
+import numpy as np
 
 from ..brokers import get_brokermod
 from .._cacheables import maybe_open_context
@@ -276,13 +277,38 @@ async def manage_history(
                 # TODO: this should be used verbatim for the pure
                 # shm backfiller approach below.
 
+                def diff_history(
+                    array,
+                    start_dt,
+                    end_dt,
+
+                ) -> np.ndarray:
+
+                    s_diff = (last_tsdb_dt - start_dt).seconds
+
+                    # if we detect a partial frame's worth of data
+                    # that is new, slice out only that history and
+                    # write to shm.
+                    if s_diff > 0:
+                        assert last_tsdb_dt > start_dt
+                        selected = array['time'] > last_tsdb_dt.timestamp()
+                        to_push = array[selected]
+                        log.info(
+                            f'Pushing partial frame {to_push.size} to shm'
+                        )
+                        return to_push
+
+                    else:
+                        return array
+
                 # start history anal and load missing new data via backend.
                 async with open_history_client(fqsn) as hist:
 
                     # get latest query's worth of history all the way
                     # back to what is recorded in the tsdb
                     array, start_dt, end_dt = await hist(end_dt='')
-                    shm.push(array)
+                    to_push = diff_history(array, start_dt, end_dt)
+                    shm.push(to_push)
 
                     # let caller unblock and deliver latest history frame
                     task_status.started(shm)
@@ -291,33 +317,13 @@ async def manage_history(
                     # pull new history frames until we hit latest
                     # already in the tsdb
                     while start_dt > last_tsdb_dt:
-
                         array, start_dt, end_dt = await hist(end_dt=start_dt)
-                        s_diff = (last_tsdb_dt - start_dt).seconds
-
-                        # if we detect a partial frame's worth of data
-                        # that is new, slice out only that history and
-                        # write to shm.
-                        if s_diff > 0:
-                            assert last_tsdb_dt > start_dt
-                            selected = array['time'] > last_tsdb_dt.timestamp()
-                            to_push = array[selected]
-                            log.info(
-                                f'Pushing partial frame {to_push.size} to shm'
-                            )
-                            shm.push(to_push, prepend=True)
-                            break
-
-                        else:
-                            # write to shm
-                            log.info(f'Pushing {array.size} datums to shm')
-                            shm.push(array, prepend=True)
+                        to_push = diff_history(array, start_dt, end_dt)
+                        shm.push(to_push, prepend=True)
 
                     # TODO: see if there's faster multi-field reads:
                     # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
                     # re-index  with a `time` and index field
-                    # await tractor.breakpoint()
-
                     shm.push(
                         fastest[-shm._first.value:],
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -22,7 +22,6 @@ This module is enabled for ``brokerd`` daemons.
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
-from datetime import datetime
 from contextlib import asynccontextmanager
 from functools import partial
 from types import ModuleType
@@ -49,7 +48,6 @@ from ._sharedmem import (
     maybe_open_shm_array,
     attach_shm_array,
     ShmArray,
-    _secs_in_day,
 )
 from .ingest import get_ingestormod
 from ._source import (
@@ -236,119 +234,137 @@ async def manage_history(
         # we expect the sub-actor to write
         readonly=False,
     )
+    # TODO: history validation
+    if not opened:
+        raise RuntimeError(
+            "Persistent shm for sym was already open?!"
+        )
 
     log.info('Scanning for existing `marketstored`')
 
     is_up = await check_for_service('marketstored')
 
     # for now only do backfilling if no tsdb can be found
-    do_backfill = not is_up and opened
+    do_legacy_backfill = not is_up and opened
 
-    if is_up and opened:
+    open_history_client = getattr(mod, 'open_history_client', None)
+
+    if is_up and opened and open_history_client:
+
         log.info('Found existing `marketstored`')
         from . import marketstore
 
         async with marketstore.open_storage_client(
             fqsn,
-        ) as (storage, tsdb_arrays):
+        ) as storage:
 
-            # TODO: get this shit workin
-            from tractor.trionics import ipython_embed
-            await ipython_embed()
-            # await ipython_embed(ns=locals())
+            tsdb_arrays = await storage.read_ohlcv(fqsn)
 
-            # TODO: history validation
-            # assert opened, f'Persistent shm for {symbol} was already open?!'
-            # if not opened:
-            #     raise RuntimeError(
-            #         "Persistent shm for sym was already open?!"
-            #     )
+            if not tsdb_arrays:
+                do_legacy_backfill = True
 
-            if tsdb_arrays:
+            else:
                 log.info(f'Loaded tsdb history {tsdb_arrays}')
-                fastest = list(tsdb_arrays[fqsn].values())[0]
-                last_s = fastest['Epoch'][-1]
 
-                # TODO: see if there's faster multi-field reads:
-                # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
-
-                # re-index  with a `time` and index field
-                shm.push(
-                    fastest[-3 * _secs_in_day:],
-
-                    # insert the history pre a "days worth" of samples
-                    # to leave some real-time buffer space at the end.
-                    prepend=True,
-                    start=shm._len - _secs_in_day,
-                    field_map={
-                        'Epoch': 'time',
-                        'Open': 'open',
-                        'High': 'high',
-                        'Low': 'low',
-                        'Close': 'close',
-                        'Volume': 'volume',
-                    },
+                fastest = list(tsdb_arrays.values())[0]
+                times = fastest['Epoch']
+                first, last = times[0], times[-1]
+                first_tsdb_dt, last_tsdb_dt = map(
+                    pendulum.from_timestamp, [first, last]
                 )
 
+                # TODO: this should be used verbatim for the pure
+                # shm backfiller approach below.
+
                 # start history anal and load missing new data via backend.
-                async with mod.open_history_client(fqsn) as hist:
+                async with open_history_client(fqsn) as hist:
 
-                    # get latest query's worth of history
-                    array, next_dt = await hist(end_dt='')
+                    # get latest query's worth of history all the way
+                    # back to what is recorded in the tsdb
+                    array, start_dt, end_dt = await hist(end_dt='')
+                    shm.push(array)
 
-                    last_dt = datetime.fromtimestamp(last_s)
-                    array, next_dt = await hist(end_dt=last_dt)
-            else:
-                do_backfill = True
+                    # let caller unblock and deliver latest history frame
+                    task_status.started(shm)
+                    some_data_ready.set()
 
-                # await tractor.breakpoint()
+                    # pull new history frames until we hit latest
+                    # already in the tsdb
+                    while start_dt > last_tsdb_dt:
 
-            some_data_ready.set()
+                        array, start_dt, end_dt = await hist(end_dt=start_dt)
+                        s_diff = (last_tsdb_dt - start_dt).seconds
 
-    if do_backfill:
+                        # if we detect a partial frame's worth of data
+                        # that is new, slice out only that history and
+                        # write to shm.
+                        if s_diff > 0:
+                            assert last_tsdb_dt > start_dt
+                            selected = array['time'] > last_tsdb_dt.timestamp()
+                            to_push = array[selected]
+                            log.info(
+                                f'Pushing partial frame {to_push.size} to shm'
+                            )
+                            shm.push(to_push, prepend=True)
+                            break
+
+                        else:
+                            # write to shm
+                            log.info(f'Pushing {array.size} datums to shm')
+                            shm.push(array, prepend=True)
+
+                    # TODO: see if there's faster multi-field reads:
+                    # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
+                    # re-index  with a `time` and index field
+                    # await tractor.breakpoint()
+
+                    shm.push(
+                        fastest[-shm._first.value:],
+
+                        # insert the history pre a "days worth" of samples
+                        # to leave some real-time buffer space at the end.
+                        prepend=True,
+                        # start=shm._len - _secs_in_day,
+                        field_map={
+                            'Epoch': 'time',
+                            'Open': 'open',
+                            'High': 'high',
+                            'Low': 'low',
+                            'Close': 'close',
+                            'Volume': 'volume',
+                        },
+                    )
+
+                    # TODO: write new data to tsdb to be ready to for next
+                    # read.
+
+    if do_legacy_backfill:
+        # do a legacy incremental backfill from the provider.
         log.info('No existing `marketstored` found..')
 
+        bfqsn = fqsn.replace('.' + mod.name, '')
         # start history backfill task ``backfill_bars()`` is
         # a required backend func this must block until shm is
         # filled with first set of ohlc bars
         await bus.nursery.start(
             start_backfill,
             mod,
-            fqsn,
+            bfqsn,
             shm,
         )
 
-        # _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
+        # yield back after client connect with filled shm
+        task_status.started(shm)
 
-    # yield back after client connect with filled shm
-    task_status.started(shm)
+        # indicate to caller that feed can be delivered to
+        # remote requesting client since we've loaded history
+        # data that can be used.
+        some_data_ready.set()
 
-    # indicate to caller that feed can be delivered to
-    # remote requesting client since we've loaded history
-    # data that can be used.
-    some_data_ready.set()
-
-    # detect sample step size for sampled historical data
-    times = shm.array['time']
-    delay_s = times[-1] - times[times != times[-1]][-1]
-
-    # begin real-time updates of shm and tsb once the feed
-    # goes live.
-    await feed_is_live.wait()
-
-    if opened:
-        sampler.ohlcv_shms.setdefault(delay_s, []).append(shm)
-
-        # start shm incrementing for OHLC sampling at the current
-        # detected sampling period if one dne.
-        if sampler.incrementers.get(delay_s) is None:
-            await bus.start_task(
-                increment_ohlc_buffer,
-                delay_s,
-            )
-
+    # history retreival loop depending on user interaction and thus
+    # a small RPC-prot for remotely controllinlg what data is loaded
+    # for viewing.
     await trio.sleep_forever()
-    # cs.cancel()
 
 
 async def allocate_persistent_feed(
@@ -416,7 +432,7 @@ async def allocate_persistent_feed(
         manage_history,
         mod,
         bus,
-        bfqsn,
+        '.'.join((bfqsn, brokername)),
         some_data_ready,
         feed_is_live,
     )
@@ -429,7 +445,6 @@ async def allocate_persistent_feed(
 
     # true fqsn
     fqsn = '.'.join((bfqsn, brokername))
-
     # add a fqsn entry that includes the ``.<broker>`` suffix
     init_msg[fqsn] = msg
 
@@ -464,8 +479,21 @@ async def allocate_persistent_feed(
     if not start_stream:
         await trio.sleep_forever()
 
-    # backend will indicate when real-time quotes have begun.
+    # begin real-time updates of shm and tsb once the feed goes live and
+    # the backend will indicate when real-time quotes have begun.
     await feed_is_live.wait()
+
+    # start shm incrementer task for OHLC style sampling
+    # at the current detected step period.
+    times = shm.array['time']
+    delay_s = times[-1] - times[times != times[-1]][-1]
+
+    sampler.ohlcv_shms.setdefault(delay_s, []).append(shm)
+    if sampler.incrementers.get(delay_s) is None:
+        await bus.start_task(
+            increment_ohlc_buffer,
+            delay_s,
+        )
 
     sum_tick_vlm: bool = init_msg.get(
         'shm_write_opts', {}
@@ -545,7 +573,7 @@ async def open_feed_bus(
     init_msg, first_quotes = bus.feeds[symbol]
 
     msg = init_msg[symbol]
-    bfqsn = msg['fqsn']
+    bfqsn = msg['fqsn'].lower()
 
     # true fqsn
     fqsn = '.'.join([bfqsn, brokername])
@@ -864,7 +892,10 @@ async def maybe_open_feed(
 
     **kwargs,
 
-) -> (Feed, ReceiveChannel[dict[str, Any]]):
+) -> (
+    Feed,
+    ReceiveChannel[dict[str, Any]],
+):
     '''
     Maybe open a data to a ``brokerd`` daemon only if there is no
     local one for the broker-symbol pair, if one is cached use it wrapped
@@ -885,6 +916,7 @@ async def maybe_open_feed(
             'start_stream': kwargs.get('start_stream', True),
         },
         key=fqsn,
+
     ) as (cache_hit, feed):
 
         if cache_hit:

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
+'''
 ``marketstore`` integration.
 
 - client management routines
@@ -22,7 +22,7 @@
 - websocket client for subscribing to write triggers
 - todo: tick sequence stream-cloning for testing
 - todo: docker container management automation
-"""
+'''
 from contextlib import asynccontextmanager
 from typing import Dict, Any, List, Callable, Tuple, Optional
 import time
@@ -31,9 +31,9 @@ from math import isnan
 import msgpack
 import numpy as np
 import pandas as pd
-import pymarketstore as pymkts
 import tractor
 from trio_websocket import open_websocket_url
+from anyio_marketstore import open_marketstore_client, MarketstoreClient
 
 from ..log import get_logger, get_console_log
 from ..data import open_feed
@@ -43,7 +43,7 @@ log = get_logger(__name__)
 
 _tick_tbk_ids: Tuple[str, str] = ('1Sec', 'TICK')
 _tick_tbk: str = '{}/' + '/'.join(_tick_tbk_ids)
-_url: str = 'http://localhost:5993/rpc'
+
 _quote_dt = [
     # these two are required for as a "primary key"
     ('Epoch', 'i8'),
@@ -51,34 +51,27 @@ _quote_dt = [
 
     ('IsTrade', 'i1'),
     ('IsBid', 'i1'),
-    ('Price', 'f8'),
-    ('Size', 'f8')
+    ('Price', 'f4'),
+    ('Size', 'f4')
 ]
-_quote_tmp = {}.fromkeys(dict(_quote_dt).keys(), np.nan)
 
 
-class MarketStoreError(Exception):
-    "Generic marketstore client error"
-
-
-def err_on_resp(response: dict) -> None:
-    """Raise any errors found in responses from client request.
+def mk_tbk(keys: Tuple[str, str, str]) -> str:
+    """Generate a marketstore table key from a tuple.
+    Converts,
+        ``('SPY', '1Sec', 'TICK')`` -> ``"SPY/1Sec/TICK"```
     """
-    responses = response['responses']
-    if responses is not None:
-        for r in responses:
-            err = r['error']
-            if err:
-                raise MarketStoreError(err)
+    return '{}/' + '/'.join(keys)
 
 
 def quote_to_marketstore_structarray(
     quote: Dict[str, Any],
-    last_fill: Optional[float],
-
+    last_fill: Optional[float]
 ) -> np.array:
-    """Return marketstore writeable structarray from quote ``dict``.
-    """
+    '''
+    Return marketstore writeable structarray from quote ``dict``.
+    '''
+
     if last_fill:
         # new fill bby
         now = timestamp(last_fill, unit='s')
@@ -112,82 +105,21 @@ def quote_to_marketstore_structarray(
 
 
 def timestamp(date, **kwargs) -> int:
-    """Return marketstore compatible 'Epoch' integer in nanoseconds
+    '''
+    Return marketstore compatible 'Epoch' integer in nanoseconds
     from a date formatted str.
-    """
+    '''
+
     return int(pd.Timestamp(date, **kwargs).value)
-
-
-def mk_tbk(keys: Tuple[str, str, str]) -> str:
-    """Generate a marketstore table key from a tuple.
-
-    Converts,
-        ``('SPY', '1Sec', 'TICK')`` -> ``"SPY/1Sec/TICK"```
-    """
-    return '{}/' + '/'.join(keys)
-
-
-class Client:
-    """Async wrapper around the alpaca ``pymarketstore`` sync client.
-
-    This will server as the shell for building out a proper async client
-    that isn't horribly documented and un-tested..
-    """
-    def __init__(self, url: str):
-        self._client = pymkts.Client(url)
-
-    async def _invoke(
-        self,
-        meth: Callable,
-        *args,
-        **kwargs,
-    ) -> Any:
-        return err_on_resp(meth(*args, **kwargs))
-
-    async def destroy(
-        self,
-        tbk: Tuple[str, str, str],
-    ) -> None:
-        return await self._invoke(self._client.destroy, mk_tbk(tbk))
-
-    async def list_symbols(
-        self,
-        tbk: str,
-    ) -> List[str]:
-        return await self._invoke(self._client.list_symbols, mk_tbk(tbk))
-
-    async def write(
-        self,
-        symbol: str,
-        array: np.ndarray,
-    ) -> None:
-        start = time.time()
-        await self._invoke(
-            self._client.write,
-            array,
-            _tick_tbk.format(symbol),
-            isvariablelength=True
-        )
-        log.debug(f"{symbol} write time (s): {time.time() - start}")
-
-    def query(
-        self,
-        symbol,
-        tbk: Tuple[str, str] = _tick_tbk_ids,
-    ) -> pd.DataFrame:
-        # XXX: causes crash
-        # client.query(pymkts.Params(symbol, '*', 'OHCLV'
-        result = self._client.query(
-            pymkts.Params(symbol, *tbk),
-        )
-        return result.first().df()
 
 
 @asynccontextmanager
 async def get_client(
-    url: str = _url,
-) -> Client:
-    yield Client(url)
+    host: str = 'localhost',
+    port: int = 5995
+) -> MarketstoreClient:
+    async with open_marketstore_client(host, port) as client:
+        yield client
 
 
 async def ingest_quote_stream(
@@ -196,8 +128,9 @@ async def ingest_quote_stream(
     tries: int = 1,
     actorloglevel: str = None,
 ) -> None:
-    """Ingest a broker quote stream into marketstore in (sampled) tick format.
-    """
+    '''
+    Ingest a broker quote stream into marketstore.
+    '''
     async with (
         open_feed(brokername, symbols, loglevel=actorloglevel) as feed,
         get_client() as ms_client
@@ -212,107 +145,125 @@ async def ingest_quote_stream(
                         # okkk..
                         continue
 
-                    a = quote_to_marketstore_structarray({
+                    array = quote_to_marketstore_structarray({
                         'IsTrade': 1 if ticktype == 'trade' else 0,
                         'IsBid': 1 if ticktype in ('bid', 'bsize') else 0,
                         'Price': tick.get('price'),
                         'Size': tick.get('size')
                     }, last_fill=quote.get('broker_ts', None))
 
-                    log.info(a)
-                    await ms_client.write(symbol, a)
-
+                    await ms_client.write(
+                        array, _tick_tbk)
+                    
 
 async def stream_quotes(
     symbols: List[str],
+    timeframe: str = '1Min',
+    attr_group: str = 'TICK',
     host: str = 'localhost',
     port: int = 5993,
-    diff_cached: bool = True,
-    loglevel: str = None,
+    loglevel: str = None
 ) -> None:
-    """Open a symbol stream from a running instance of marketstore and
+    '''
+    Open a symbol stream from a running instance of marketstore and
     log to console.
-    """
-    # XXX: required to propagate ``tractor`` loglevel to piker logging
-    get_console_log(loglevel or tractor.current_actor().loglevel)
+    '''
 
-    tbks: Dict[str, str] = {sym: f"{sym}/*/*" for sym in symbols}
+    tbks: Dict[str, str] = {
+        sym: f'{sym}/{timeframe}/{attr_group}' for sym in symbols}
 
-    async with open_websocket_url(f'ws://{host}:{port}/ws') as ws:
-        # send subs topics to server
-        resp = await ws.send_message(
-            msgpack.dumps({'streams': list(tbks.values())})
-        )
-        log.info(resp)
 
-        async def recv() -> Dict[str, Any]:
-            return msgpack.loads((await ws.get_message()), encoding='utf-8')
 
-        streams = (await recv())['streams']
-        log.info(f"Subscribed to {streams}")
-
-        _cache = {}
-
-        while True:
-            msg = await recv()
-
-            # unpack symbol and quote data
-            # key is in format ``<SYMBOL>/<TIMEFRAME>/<ID>``
-            symbol = msg['key'].split('/')[0]
-            data = msg['data']
-
-            # calc time stamp(s)
-            s, ns = data.pop('Epoch'), data.pop('Nanoseconds')
-            ts = s * 10**9 + ns
-            data['broker_fill_time_ns'] = ts
-
-            quote = {}
-            for k, v in data.items():
-                if isnan(v):
-                    continue
-
-                quote[k.lower()] = v
-
-            quote['symbol'] = symbol
-
-            quotes = {}
-
-            if diff_cached:
-                last = _cache.setdefault(symbol, {})
-                new = set(quote.items()) - set(last.items())
-                if new:
-                    log.info(f"New quote {quote['symbol']}:\n{new}")
-
-                    # only ship diff updates and other required fields
-                    payload = {k: quote[k] for k, v in new}
-                    payload['symbol'] = symbol
-
-                    # if there was volume likely the last size of
-                    # shares traded is useful info and it's possible
-                    # that the set difference from above will disregard
-                    # a "size" value since the same # of shares were traded
-                    size = quote.get('size')
-                    volume = quote.get('volume')
-                    if size and volume:
-                        new_volume_since_last = max(
-                            volume - last.get('volume', 0), 0)
-                        log.warning(
-                            f"NEW VOLUME {symbol}:{new_volume_since_last}")
-                        payload['size'] = size
-                        payload['last'] = quote.get('last')
-
-                    # XXX: we append to a list for the options case where the
-                    # subscription topic (key) is the same for all
-                    # expiries even though this is uncessary for the
-                    # stock case (different topic [i.e. symbol] for each
-                    # quote).
-                    quotes.setdefault(symbol, []).append(payload)
-
-                    # update cache
-                    _cache[symbol].update(quote)
-            else:
-                quotes = {
-                    symbol: [{key.lower(): val for key, val in quote.items()}]}
-
-            if quotes:
-                yield quotes
+# async def stream_quotes(
+#     symbols: List[str],
+#     host: str = 'localhost',
+#     port: int = 5993,
+#     diff_cached: bool = True,
+#     loglevel: str = None,
+# ) -> None:
+#     """Open a symbol stream from a running instance of marketstore and
+#     log to console.
+#     """
+#     # XXX: required to propagate ``tractor`` loglevel to piker logging
+#     get_console_log(loglevel or tractor.current_actor().loglevel)
+# 
+#     tbks: Dict[str, str] = {sym: f"{sym}/*/*" for sym in symbols}
+# 
+#     async with open_websocket_url(f'ws://{host}:{port}/ws') as ws:
+#         # send subs topics to server
+#         resp = await ws.send_message(
+#             msgpack.dumps({'streams': list(tbks.values())})
+#         )
+#         log.info(resp)
+# 
+#         async def recv() -> Dict[str, Any]:
+#             return msgpack.loads((await ws.get_message()), encoding='utf-8')
+# 
+#         streams = (await recv())['streams']
+#         log.info(f"Subscribed to {streams}")
+# 
+#         _cache = {}
+# 
+#         while True:
+#             msg = await recv()
+# 
+#             # unpack symbol and quote data
+#             # key is in format ``<SYMBOL>/<TIMEFRAME>/<ID>``
+#             symbol = msg['key'].split('/')[0]
+#             data = msg['data']
+# 
+#             # calc time stamp(s)
+#             s, ns = data.pop('Epoch'), data.pop('Nanoseconds')
+#             ts = s * 10**9 + ns
+#             data['broker_fill_time_ns'] = ts
+# 
+#             quote = {}
+#             for k, v in data.items():
+#                 if isnan(v):
+#                     continue
+# 
+#                 quote[k.lower()] = v
+# 
+#             quote['symbol'] = symbol
+# 
+#             quotes = {}
+# 
+#             if diff_cached:
+#                 last = _cache.setdefault(symbol, {})
+#                 new = set(quote.items()) - set(last.items())
+#                 if new:
+#                     log.info(f"New quote {quote['symbol']}:\n{new}")
+# 
+#                     # only ship diff updates and other required fields
+#                     payload = {k: quote[k] for k, v in new}
+#                     payload['symbol'] = symbol
+# 
+#                     # if there was volume likely the last size of
+#                     # shares traded is useful info and it's possible
+#                     # that the set difference from above will disregard
+#                     # a "size" value since the same # of shares were traded
+#                     size = quote.get('size')
+#                     volume = quote.get('volume')
+#                     if size and volume:
+#                         new_volume_since_last = max(
+#                             volume - last.get('volume', 0), 0)
+#                         log.warning(
+#                             f"NEW VOLUME {symbol}:{new_volume_since_last}")
+#                         payload['size'] = size
+#                         payload['last'] = quote.get('last')
+# 
+#                     # XXX: we append to a list for the options case where the
+#                     # subscription topic (key) is the same for all
+#                     # expiries even though this is uncessary for the
+#                     # stock case (different topic [i.e. symbol] for each
+#                     # quote).
+#                     quotes.setdefault(symbol, []).append(payload)
+# 
+#                     # update cache
+#                     _cache[symbol].update(quote)
+#             else:
+#                 quotes = {
+#                     symbol: [{key.lower(): val for key, val in quote.items()}]}
+# 
+#             if quotes:
+#                 yield quotes

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -444,6 +444,9 @@ async def tsdb_history_update(
                 if err:
                     raise MarketStoreError(err)
 
+        from tractor.trionics import ipython_embed
+        await ipython_embed()
+
 
 async def ingest_quote_stream(
     symbols: list[str],

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -433,7 +433,13 @@ async def backfill_history_diff(
                 raise MarketStoreError(err)
 
         # TODO: backfiller loop
-        # await tractor.breakpoint()
+        from piker.ui._compression import downsample
+        x, y = downsample(
+            s1['Epoch'],
+            s1['Close'],
+            bins=10,
+        )
+        await tractor.breakpoint()
 
 
 async def ingest_quote_stream(

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -222,7 +222,6 @@ class Storage:
     '''
     High level storage api for both real-time and historical ingest.
 
-
     '''
     def __init__(
         self,
@@ -284,10 +283,7 @@ class Storage:
                 tf_in_1s.inverse[data_set.timeframe]
             ] = data_set.array
 
-        return (
-            client,
-            arrays[fqsn][timeframe] if timeframe else arrays,
-        )
+        return arrays[fqsn][timeframe] if timeframe else arrays
 
 
 @acm
@@ -406,7 +402,8 @@ async def backfill_history_diff(
             len(to_append),
             dtype=mkts_dt,
         )
-        # copy from shm array
+        # copy from shm array (yes it's this easy):
+        # https://numpy.org/doc/stable/user/basics.rec.html#assignment-from-other-structured-arrays
         mkts_array[:] = to_append[[
             'time',
             'open',

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -24,14 +24,14 @@
 - todo: docker container management automation
 '''
 from contextlib import asynccontextmanager
-from typing import Dict, Any, List, Callable, Tuple, Optional
+from typing import Any, Optional
 import time
-from math import isnan
+# from math import isnan
 
-import msgpack
+# import msgpack
 import numpy as np
 import pandas as pd
-import tractor
+# import tractor
 from trio_websocket import open_websocket_url
 from anyio_marketstore import open_marketstore_client, MarketstoreClient
 
@@ -41,7 +41,7 @@ from ..data import open_feed
 
 log = get_logger(__name__)
 
-_tick_tbk_ids: Tuple[str, str] = ('1Sec', 'TICK')
+_tick_tbk_ids: tuple[str, str] = ('1Sec', 'TICK')
 _tick_tbk: str = '{}/' + '/'.join(_tick_tbk_ids)
 
 _quote_dt = [
@@ -56,16 +56,18 @@ _quote_dt = [
 ]
 
 
-def mk_tbk(keys: Tuple[str, str, str]) -> str:
-    """Generate a marketstore table key from a tuple.
+def mk_tbk(keys: tuple[str, str, str]) -> str:
+    '''
+    Generate a marketstore table key from a tuple.
     Converts,
         ``('SPY', '1Sec', 'TICK')`` -> ``"SPY/1Sec/TICK"```
-    """
+
+    '''
     return '{}/' + '/'.join(keys)
 
 
 def quote_to_marketstore_structarray(
-    quote: Dict[str, Any],
+    quote: dict[str, Any],
     last_fill: Optional[float]
 ) -> np.array:
     '''
@@ -83,7 +85,7 @@ def quote_to_marketstore_structarray(
         
     secs, ns = now / 10**9, now % 10**9
 
-    # pack into List[Tuple[str, Any]]
+    # pack into list[tuple[str, Any]]
     array_input = []
 
     # insert 'Epoch' entry first and then 'Nanoseconds'.
@@ -123,17 +125,19 @@ async def get_client(
 
 
 async def ingest_quote_stream(
-    symbols: List[str],
+    symbols: list[str],
     brokername: str,
     tries: int = 1,
-    actorloglevel: str = None,
+    loglevel: str = None,
+
 ) -> None:
     '''
-    Ingest a broker quote stream into marketstore.
+    Ingest a broker quote stream into a ``marketstore`` tsdb.
+
     '''
     async with (
-        open_feed(brokername, symbols, loglevel=actorloglevel) as feed,
-        get_client() as ms_client
+        open_feed(brokername, symbols, loglevel=loglevel) as feed,
+        get_client() as ms_client,
     ):
         async for quotes in feed.stream:
             log.info(quotes)
@@ -152,30 +156,30 @@ async def ingest_quote_stream(
                         'Size': tick.get('size')
                     }, last_fill=quote.get('broker_ts', None))
 
-                    await ms_client.write(
-                        array, _tick_tbk)
-                    
+                    await ms_client.write(array, _tick_tbk)
+
 
 async def stream_quotes(
-    symbols: List[str],
+    symbols: list[str],
     timeframe: str = '1Min',
     attr_group: str = 'TICK',
     host: str = 'localhost',
     port: int = 5993,
     loglevel: str = None
+
 ) -> None:
     '''
     Open a symbol stream from a running instance of marketstore and
     log to console.
     '''
 
-    tbks: Dict[str, str] = {
+    tbks: dict[str, str] = {
         sym: f'{sym}/{timeframe}/{attr_group}' for sym in symbols}
 
 
 
 # async def stream_quotes(
-#     symbols: List[str],
+#     symbols: list[str],
 #     host: str = 'localhost',
 #     port: int = 5993,
 #     diff_cached: bool = True,
@@ -187,7 +191,7 @@ async def stream_quotes(
 #     # XXX: required to propagate ``tractor`` loglevel to piker logging
 #     get_console_log(loglevel or tractor.current_actor().loglevel)
 # 
-#     tbks: Dict[str, str] = {sym: f"{sym}/*/*" for sym in symbols}
+#     tbks: dict[str, str] = {sym: f"{sym}/*/*" for sym in symbols}
 # 
 #     async with open_websocket_url(f'ws://{host}:{port}/ws') as ws:
 #         # send subs topics to server
@@ -196,7 +200,7 @@ async def stream_quotes(
 #         )
 #         log.info(resp)
 # 
-#         async def recv() -> Dict[str, Any]:
+#         async def recv() -> dict[str, Any]:
 #             return msgpack.loads((await ws.get_message()), encoding='utf-8')
 # 
 #         streams = (await recv())['streams']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@
 # pin this to a dev branch that we have more control over especially
 # as more graphics stuff gets hashed out.
 -e git+https://github.com/pikers/pyqtgraph.git@piker_pin#egg=pyqtgraph
+
+
+# our async client for ``marketstore`` (the tsdb)
+-e git+https://github.com/pikers/anyio-marketstore.git@master#egg=anyio-marketstore

--- a/scripts/ib_data_reset.py
+++ b/scripts/ib_data_reset.py
@@ -54,7 +54,7 @@ for name in win_names:
         # disconnect?
         for key_combo, timeout in [
             # only required if we need a connection reset.
-            ('ctrl+alt+r', 12),
+            # ('ctrl+alt+r', 12),
             # data feed reset.
             ('ctrl+alt+f', 6)
         ]:

--- a/scripts/ib_data_reset.py
+++ b/scripts/ib_data_reset.py
@@ -30,11 +30,13 @@ orig_win_id = t.find_focused().window
 # for tws
 win_names: list[str] = [
     'Interactive Brokers',  # tws running in i3
-    'IB Gateway.',  # gw running in i3
+    'IB Gateway',  # gw running in i3
+    # 'IB',  # gw running in i3 (newer version?)
 ]
 
 for name in win_names:
-    results = t.find_named(name)
+    results = t.find_titled(name)
+    print(f'results for {name}: {results}')
     if results:
         con = results[0]
         print(f'Resetting data feed for {name}')

--- a/scripts/ib_data_reset.py
+++ b/scripts/ib_data_reset.py
@@ -53,7 +53,9 @@ for name in win_names:
         # TODO: only run the reconnect (2nd) kc on a detected
         # disconnect?
         for key_combo, timeout in [
+            # only required if we need a connection reset.
             ('ctrl+alt+r', 12),
+            # data feed reset.
             ('ctrl+alt+f', 6)
         ]:
             subprocess.call([

--- a/scripts/ib_data_reset.py
+++ b/scripts/ib_data_reset.py
@@ -1,5 +1,5 @@
 # piker: trading gear for hackers
-# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+# Copyright (C) Tyler Goodlet (in stewardship for pikers)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -49,22 +49,30 @@ for name in win_names:
         # https://github.com/rr-/pyxdotool
         # https://github.com/ShaneHutter/pyxdotool
         # https://github.com/cphyc/pyxdotool
-        subprocess.call([
-            'xdotool',
-            'windowactivate', '--sync', win_id,
 
-            # move mouse to bottom left of window (where there should
-            # be nothing to click).
-            'mousemove_relative', '--sync', str(w-4), str(h-4),
+        # TODO: only run the reconnect (2nd) kc on a detected
+        # disconnect?
+        for key_combo, timeout in [
+            ('ctrl+alt+r', 12),
+            ('ctrl+alt+f', 6)
+        ]:
+            subprocess.call([
+                'xdotool',
+                'windowactivate', '--sync', win_id,
 
-            # NOTE: we may need to stick a `--retry 3` in here..
-            'click', '--window', win_id, '--repeat', '3', '1',
+                # move mouse to bottom left of window (where there should
+                # be nothing to click).
+                'mousemove_relative', '--sync', str(w-4), str(h-4),
 
-            # hackzorzes
-            'key', 'ctrl+alt+f',
-            ],
-            timeout=1,
-        )
+                # NOTE: we may need to stick a `--retry 3` in here..
+                'click', '--window', win_id,
+                '--repeat', '3', '1',
+
+                # hackzorzes
+                'key', key_combo,
+                ],
+                timeout=timeout,
+            )
 
 # re-activate and focus original window
 subprocess.call([

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,14 @@ setup(
         # tsdbs
         'pymarketstore',
     ],
+    extras_require={
+
+        # serialization
+        'tsdb': [
+            'docker',
+        ],
+
+    },
     tests_require=['pytest'],
     python_requires=">=3.9",  # literally for ``datetime.datetime.fromisoformat``...
     keywords=["async", "trading", "finance", "quant", "charting"],


### PR DESCRIPTION
Update outdated `ingest` backend and replace the in-repo async wrapped marketstore client with the new:
https://github.com/pikers/anyio-marketstore

Includes support for a `tractor` based supervisor actor and thus resolves #143 which was merged in via the sub-PR #284.

---
#### ingest TODOs:
- [x] re-add `destroy` cli piker cmd (now implemented as `Storage.delete_ts()`)
- [ ] tick ingest to `marketstore` from `brokerd` feeds:
  - [ ] experiment with `techtonicdb` schema and if it can be used with the [aggregator plugin](https://github.com/alpacahq/marketstore/tree/master/contrib/ondiskagg) (got a feeling we'll need to write at least a `1Sec` bucket in order for this to work looking at the code:
    - [`aggregate()` calls into `model.FromTrades()`](https://github.com/alpacahq/marketstore/pull/399/files#diff-392952832ca30145443aff46786de412b7b5876a33e5dbcbb34dde20637c6370R285) and [`FromTrades()` only accepts a min step of `1Sec`](https://github.com/alpacahq/marketstore/pull/399/files#diff-cf7320bc8ecabe28fa6f7712d8df43143d3fa8577667f777c792db773ea5fbdbR192-R205)
    - we might be able to either write a golang plugin/extension to do it from pure tick data or we can make this part of a piker actor?
- [x] ~ohlcv ingest and load from multiple backends:~ this was added as part of the new history in #308.
  - `ib` seems like the natural place to start since `1s` is already offered in their history
    - we'll need separate series for dark vs. regular vlm
    - we'll likely want to write a diffing and syncing system to validate new captured histories from real-time runs (which almost always are slightly different)
  - `kraken` has tick history which has been a [todo for a while](#95)
- [ ] benchmark binance tick feed against [binancefeeder](https://github.com/alpacahq/marketstore/tree/master/contrib/binancefeeder)

---
#### `_ahab` TODO:
 - [ ] probably deliver back net-socket info over the `ctx.started()` call?
   - [ ] grprc socket
   - [ ] ws addr
 - [x] cli support for running `pikerd` with the tsdb stuff spawned?
   - [x] maybe a `--tsdb` or `--data` or something?
 - [ ] figure out what to do with the `mkts.yaml` config?
   - we could push a template from code to the user dir?
   - or should we just always gen it from python?
  - step by step interaction test lisit:
   - [x] `pikerd --tsdb` should raise `DockerNotStarted` and appropriate perms error on no `sudo` (for now)
   - [x] ctrl-c should kill container instance
     - [ ] this **does not really work** when run with `sudo` since we relinquish root perms in order to create shms.. 
   