### PR TITLE
Basic vlm display

### DIFF
--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -56,6 +56,7 @@ from ._style import (
 )
 from ..data.feed import Feed
 from ..data._source import Symbol
+from ..data._sharedmem import ShmArray
 from ..log import get_logger
 from ._interaction import ChartView
 from ._forms import FieldsForm
@@ -632,7 +633,8 @@ class ChartPlotWidget(pg.PlotWidget):
             'ohlc': array,
         }
         self._graphics = {}  # registry of underlying graphics
-        self._overlays = set()  # registry of overlay curve names
+        # registry of overlay curve names
+        self._overlays: dict[str, ShmArray] = {}
 
         self._feeds: dict[Symbol, Feed] = {}
 
@@ -808,8 +810,9 @@ class ChartPlotWidget(pg.PlotWidget):
         the input array ``data``.
 
         """
+        color = color or self.pen_color or 'default_light'
         pdi_kwargs.update({
-            'color': color or self.pen_color or 'default_light'
+            'color': color
         })
 
         data_key = array_key or name
@@ -856,7 +859,7 @@ class ChartPlotWidget(pg.PlotWidget):
 
         if overlay:
             anchor_at = ('bottom', 'left')
-            self._overlays.add(name)
+            self._overlays[name] = None
 
         else:
             anchor_at = ('top', 'left')

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -528,7 +528,7 @@ class LinkedSplits(QWidget):
                 name,
                 array,
                 array_key=array_key,
-                color='default_lightest',
+                color='default_light',
             )
 
         elif style == 'step':
@@ -789,7 +789,7 @@ class ChartPlotWidget(pg.PlotWidget):
             update_func=ContentsLabel.update_from_ohlc,
         )
 
-        self._add_sticky(name)
+        self._add_sticky(name, bg_color='davies')
 
         return graphics
 
@@ -863,7 +863,7 @@ class ChartPlotWidget(pg.PlotWidget):
 
             # TODO: something instead of stickies for overlays
             # (we need something that avoids clutter on x-axis).
-            self._add_sticky(name, bg_color='default_light')
+            self._add_sticky(name, bg_color=color)
 
         if self.linked.cursor:
             self.linked.cursor.add_curve_cursor(self, curve)
@@ -877,6 +877,7 @@ class ChartPlotWidget(pg.PlotWidget):
 
         return curve
 
+    # TODO: make this a ctx mngr
     def _add_sticky(
         self,
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -959,6 +959,7 @@ class ChartPlotWidget(pg.PlotWidget):
         *,
         yrange: Optional[tuple[float, float]] = None,
         range_margin: float = 0.06,
+        bars_range: Optional[tuple[int, int, int, int]] = None
     ) -> None:
         '''Set the viewable y-range based on embedded data.
 
@@ -982,7 +983,18 @@ class ChartPlotWidget(pg.PlotWidget):
             # Determine max, min y values in viewable x-range from data.
             # Make sure min bars/datums on screen is adhered.
 
-            l, lbar, rbar, r = self.bars_range()
+            l, lbar, rbar, r = bars_range or self.bars_range()
+
+            if self.name != 'volume':
+                vlm_chart = self.linked.subplots.get('volume')
+                if vlm_chart:
+                    vlm_chart._set_yrange(bars_range=(l, lbar, rbar, r))
+                    curve = vlm_chart._graphics['volume']
+                    # if rbar - lbar < 1500:
+                    #     # print('small range')
+                    #     curve._fill = True
+                    # else:
+                    #     curve._fill = False
 
             # figure out x-range in view such that user can scroll "off"
             # the data set up to the point where ``_min_points_to_show``

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -341,19 +341,28 @@ class LinkedSplits(QWidget):
 
     def set_split_sizes(
         self,
-        prop: float = 0.375,  # proportion allocated to consumer subcharts
+        prop: Optional[float] = None,
 
     ) -> None:
         '''Set the proportion of space allocated for linked subcharts.
 
         '''
+        ln = len(self.subplots)
+
+        if not prop:
+            # proportion allocated to consumer subcharts
+            if ln < 2:
+                prop = 1/(.666 * 6)
+            elif ln >= 2:
+                prop = 3/8
+
         major = 1 - prop
-        min_h_ind = int((self.height() * prop) / len(self.subplots))
+        min_h_ind = int((self.height() * prop) / ln)
 
         sizes = [int(self.height() * major)]
-        sizes.extend([min_h_ind] * len(self.subplots))
+        sizes.extend([min_h_ind] * ln)
 
-        self.splitter.setSizes(sizes)  # , int(self.height()*0.2)
+        self.splitter.setSizes(sizes)
 
     def focus(self) -> None:
         if self.chart is not None:
@@ -528,6 +537,8 @@ class LinkedSplits(QWidget):
                 array,
                 array_key=array_key,
                 step_mode=True,
+                color='davies',
+                fill_color='davies',
             )
 
         else:
@@ -800,12 +811,9 @@ class ChartPlotWidget(pg.PlotWidget):
         the input array ``data``.
 
         """
-        color = color or self.pen_color or 'default_light'
-
-        _pdi_defaults = {
-            'pen': pg.mkPen(hcolor(color)),
-        }
-        pdi_kwargs.update(_pdi_defaults)
+        pdi_kwargs.update({
+            'color': color or self.pen_color or 'default_light'
+        })
 
         data_key = array_key or name
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -824,13 +824,13 @@ async def display_symbol_data(
 
         # TODO: eventually we'll support some kind of n-compose syntax
         fsp_conf = {
-            'rsi': {
-                'fsp_func_name': 'rsi',
-                'params': {'period': 14},
-                'chart_kwargs': {
-                    'static_yrange': (0, 100),
-                },
-            },
+            # 'rsi': {
+            #     'fsp_func_name': 'rsi',
+            #     'params': {'period': 14},
+            #     'chart_kwargs': {
+            #         'static_yrange': (0, 100),
+            #     },
+            # },
         }
 
         if has_vlm(ohlcv):

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -205,19 +205,26 @@ def hcolor(name: str) -> str:
         'svags': '#0a0e14',
 
         # fifty shades
+        'original': '#a9a9a9',
         'gray': '#808080',  # like the kick
         'grayer': '#4c4c4c',
         'grayest': '#3f3f3f',
-        'i3': '#494D4F',
-        'jet': '#343434',
         'cadet': '#91A3B0',
         'marengo': '#91A3B0',
-        'charcoal': '#36454F',
         'gunmetal': '#91A3B0',
         'battleship': '#848482',
-        'davies': '#555555',
+
+        # bluish
+        'charcoal': '#36454F',
+
+        # default bars
         'bracket': '#666666',  # like the logo
-        'original': '#a9a9a9',
+
+        # work well for filled polygons which want a 'bracket' feel
+        # going light to dark
+        'davies': '#555555',
+        'i3': '#494D4F',
+        'jet': '#343434',
 
         # from ``qdarkstyle`` palette
         'default_darkest': DarkPalette.COLOR_BACKGROUND_1,


### PR DESCRIPTION
This pulls out the base functionality to get a volume subchart from #231.

The purpose of splitting out this work is,
- to make code review simpler and demonstrate the initial UX changes and graphics implementation in use
- create **clear a demarcation commit** to compare and benchmark versus the new FSP driven approach eventually built out in #231 
- get users testing before bringing in more complex `pyqtgraph` extensions which were developed as part of #231 and pertain to what will be shared aggregated feeds on a single chart

Please feel free to check out this branch and run it through the wringer 😂  