### PR TITLE
Single display update loop

### DIFF
--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -34,7 +34,6 @@ import trio
 from trio.abc import ReceiveChannel
 from trio_typing import TaskStatus
 import tractor
-# from tractor import _broadcast
 from pydantic import BaseModel
 
 from ..brokers import get_brokermod
@@ -252,7 +251,7 @@ async def allocate_persistent_feed(
 
 
 @tractor.context
-async def attach_feed_bus(
+async def open_feed_bus(
 
     ctx: tractor.Context,
     brokername: str,
@@ -512,7 +511,7 @@ async def open_feed(
 
         portal.open_context(
 
-            attach_feed_bus,
+            open_feed_bus,
             brokername=brokername,
             symbol=sym,
             loglevel=loglevel,

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -90,7 +90,7 @@ async def fsp_compute(
     func_name: str,
     func: Callable,
 
-    attach_stream: bool = True,
+    attach_stream: bool = False,
     task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:

--- a/piker/ui/_app.py
+++ b/piker/ui/_app.py
@@ -85,11 +85,11 @@ async def _async_main(
     screen = godwidget.window.current_screen()
 
     # configure graphics update throttling based on display refresh rate
-    _display._clear_throttle_rate = min(
+    _display._quote_throttle_rate = min(
         round(screen.refreshRate()),
-        _display._clear_throttle_rate,
+        _display._quote_throttle_rate,
     )
-    log.info(f'Set graphics update rate to {_display._clear_throttle_rate} Hz')
+    log.info(f'Set graphics update rate to {_display._quote_throttle_rate} Hz')
 
     # TODO: do styling / themeing setup
     # _style.style_ze_sheets(godwidget)

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -868,13 +868,13 @@ async def display_symbol_data(
 
         # TODO: eventually we'll support some kind of n-compose syntax
         fsp_conf = {
-            # 'rsi': {
-            #     'fsp_func_name': 'rsi',
-            #     'params': {'period': 14},
-            #     'chart_kwargs': {
-            #         'static_yrange': (0, 100),
-            #     },
-            # },
+            'rsi': {
+                'fsp_func_name': 'rsi',
+                'params': {'period': 14},
+                'chart_kwargs': {
+                    'static_yrange': (0, 100),
+                },
+            },
         }
 
         if has_vlm(ohlcv):


### PR DESCRIPTION
More factored history from #231.

Switches to a *update-graphics-on-poll* style model where there is a single update loop that makes a couple presumptions:
- a *main* data feed (OHLCV) is normally the source for downstream calculations conducted by the fsp engine
- the source data feed is updated at the *fastest* rate and thus graphics update throttling can be oriented around that arrival rate
- down stream fsp computations can be run in parallel and pushed to shared mem but **do not need** to trigger their own graphics display update loop tasks since the outputs can simply be read from shm and displayed when the source data feeds are updated
  - this avoids necessary `trio` task switches and instead attempts to read and display as much graphical changes as possible per source data event arrival
  
You'll note inside the fsp engire the streams are now disabled by default and consumer actors will need to pass `attach_stream=True` to enable when wishing to pull per-tick data over IPC.    

Oh this also adds back in the `rsi` fsp for now which is good for peeps to test to make sure `vlm` and it together aren't introducing any new latency. By default once all the history from #231 is landed we will likely not enable `rsi` by default.