### PR TITLE
Multichart ux improvements

### DIFF
--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -603,6 +603,9 @@ class ChartPlotWidget(pg.PlotWidget):
         view_color: str = 'papas_special',
         pen_color: str = 'bracket',
 
+        # TODO: load from config
+        use_open_gl: bool = False,
+
         static_yrange: Optional[tuple[float, float]] = None,
 
         **kwargs,
@@ -617,9 +620,9 @@ class ChartPlotWidget(pg.PlotWidget):
             # parent=None,
             # plotItem=None,
             # antialias=True,
-            # useOpenGL=True,
             **kwargs
         )
+        self.useOpenGL(use_open_gl)
         self.name = name
         self.data_key = data_key
         self.linked = linkedsplits

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -229,7 +229,7 @@ class GodWidget(QWidget):
             await trio.sleep(0)
 
             # resume feeds *after* rendering chart view asap
-            await chart.resume_all_feeds()
+            chart.resume_all_feeds()
 
         self.linkedsplits = linkedsplits
         symbol = linkedsplits.symbol
@@ -361,7 +361,7 @@ class LinkedSplits(QWidget):
         if not prop:
             # proportion allocated to consumer subcharts
             if ln < 2:
-                prop = 1/(.375 * 6)
+                prop = 1/3
             elif ln >= 2:
                 prop = 3/8
 
@@ -631,8 +631,11 @@ class ChartPlotWidget(pg.PlotWidget):
 
         **kwargs,
     ):
-        """Configure chart display settings.
-        """
+        '''
+        Configure initial display settings and connect view callback
+        handlers.
+
+        '''
         self.view_color = view_color
         self.pen_color = pen_color
 
@@ -692,15 +695,13 @@ class ChartPlotWidget(pg.PlotWidget):
         # for when the splitter(s) are resized
         self._vb.sigResized.connect(self._set_yrange)
 
-    async def resume_all_feeds(self):
-        async with trio.open_nursery() as n:
-            for feed in self._feeds.values():
-                n.start_soon(feed.resume)
+    def resume_all_feeds(self):
+        for feed in self._feeds.values():
+            self.linked.godwidget._root_n.start_soon(feed.resume)
 
-    async def pause_all_feeds(self):
-        async with trio.open_nursery() as n:
-            for feed in self._feeds.values():
-                n.start_soon(feed.pause)
+    def pause_all_feeds(self):
+        for feed in self._feeds.values():
+            self.linked.godwidget._root_n.start_soon(feed.pause)
 
     @property
     def view(self) -> ChartView:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -972,7 +972,11 @@ class ChartPlotWidget(pg.PlotWidget):
 
         yrange: Optional[tuple[float, float]] = None,
         range_margin: float = 0.06,
-        bars_range: Optional[tuple[int, int, int, int]] = None
+        bars_range: Optional[tuple[int, int, int, int]] = None,
+
+        # flag to prevent triggering sibling charts from the same linked
+        # set from recursion errors.
+        autoscale_linked_plots: bool = True,
 
     ) -> None:
         '''Set the viewable y-range based on embedded data.
@@ -999,39 +1003,26 @@ class ChartPlotWidget(pg.PlotWidget):
 
             l, lbar, rbar, r = bars_range or self.bars_range()
 
-            # TODO: we need a loop for auto-scaled subplots to all
-            # be triggered by one another
-            if self.name != 'volume':
-                vlm_chart = self.linked.subplots.get('volume')
-                if vlm_chart:
-                    vlm_chart._set_yrange(bars_range=(l, lbar, rbar, r))
-                    # curve = vlm_chart._graphics['volume']
-                    # if rbar - lbar < 1500:
-                    #     # print('small range')
-                    #     curve._fill = True
-                    # else:
-                    #     curve._fill = False
+            if autoscale_linked_plots:
+                # avoid recursion by sibling plots
+                linked = self.linked
+                plots = list(linked.subplots.copy().values())
+                main = linked.chart
+                if main:
+                    plots.append(main)
 
-            # figure out x-range in view such that user can scroll "off"
-            # the data set up to the point where ``_min_points_to_show``
-            # are left.
-            # view_len = r - l
+                for chart in plots:
+                    if chart and not chart._static_yrange:
+                        chart._set_yrange(
+                            bars_range=(l, lbar, rbar, r),
+                            autoscale_linked_plots=False,
+                        )
 
             # TODO: logic to check if end of bars in view
             # extra = view_len - _min_points_to_show
-
             # begin = self._arrays['ohlc'][0]['index'] - extra
-
             # # end = len(self._arrays['ohlc']) - 1 + extra
             # end = self._arrays['ohlc'][-1]['index'] - 1 + extra
-
-            # XXX: test code for only rendering lines for the bars in view.
-            # This turns out to be very very poor perf when scaling out to
-            # many bars (think > 1k) on screen.
-            # name = self.name
-            # bars = self._graphics[self.name]
-            # bars.draw_lines(
-            #   istart=max(lbar, l), iend=min(rbar, r), just_history=True)
 
             # bars_len = rbar - lbar
             # log.debug(
@@ -1039,12 +1030,6 @@ class ChartPlotWidget(pg.PlotWidget):
             #     f"view_len: {view_len}, bars_len: {bars_len}\n"
             #     f"begin: {begin}, end: {end}, extra: {extra}"
             # )
-            # self._set_xlimits(begin, end)
-
-            # TODO: this should be some kind of numpy view api
-
-
-            # bars = self._arrays['ohlc'][lbar:rbar]
 
             a = self._arrays['ohlc']
             ifirst = a[0]['index']

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -361,7 +361,7 @@ class LinkedSplits(QWidget):
         if not prop:
             # proportion allocated to consumer subcharts
             if ln < 2:
-                prop = 1/(.666 * 6)
+                prop = 1/(.375 * 6)
             elif ln >= 2:
                 prop = 3/8
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -936,11 +936,12 @@ class ChartPlotWidget(pg.PlotWidget):
         **kwargs,
 
     ) -> pg.GraphicsObject:
-        """Update the named internal graphics from ``array``.
+        '''Update the named internal graphics from ``array``.
 
-        """
-
+        '''
+        assert len(array)
         data_key = array_key or graphics_name
+
         if graphics_name not in self._overlays:
             self._arrays['ohlc'] = array
         else:
@@ -948,21 +949,19 @@ class ChartPlotWidget(pg.PlotWidget):
 
         curve = self._graphics[graphics_name]
 
-        if len(array):
-            # TODO: we should instead implement a diff based
-            # "only update with new items" on the pg.PlotCurveItem
-            # one place to dig around this might be the `QBackingStore`
-            # https://doc.qt.io/qt-5/qbackingstore.html
+        # NOTE: back when we weren't implementing the curve graphics
+        # ourselves you'd have updates using this method:
+        # curve.setData(y=array[graphics_name], x=array['index'], **kwargs)
 
-            # NOTE: back when we weren't implementing the curve graphics
-            # ourselves you'd have updates using this method:
-            # curve.setData(y=array[graphics_name], x=array['index'], **kwargs)
-
-            curve.update_from_array(
-                x=array['index'],
-                y=array[data_key],
-                **kwargs
-            )
+        # NOTE: graphics **must** implement a diff based update
+        # operation where an internal ``FastUpdateCurve._xrange`` is
+        # used to determine if the underlying path needs to be
+        # pre/ap-pended.
+        curve.update_from_array(
+            x=array['index'],
+            y=array[data_key],
+            **kwargs
+        )
 
         return curve
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -61,7 +61,10 @@ log = get_logger(__name__)
 _quote_throttle_rate: int = 58  # Hz
 
 
-def try_read(array: np.ndarray) -> Optional[np.ndarray]:
+def try_read(
+    array: np.ndarray
+
+) -> Optional[np.ndarray]:
     '''
     Try to read the last row from a shared mem array or ``None``
     if the array read returns a zero-length array result.
@@ -85,10 +88,9 @@ def try_read(array: np.ndarray) -> Optional[np.ndarray]:
         # something we need anyway, maybe there should be some kind of
         # signal that a prepend is taking place and this consumer can
         # respond (eg. redrawing graphics) accordingly.
-        log.warning(f'Read-race on shm array: {graphics_name}@{shm.token}')
 
-    # the array read was emtpy
-    return None
+        # the array read was emtpy
+        return None
 
 
 def update_fsp_chart(
@@ -101,8 +103,10 @@ def update_fsp_chart(
 
     array = shm.array
     last_row = try_read(array)
+
     # guard against unreadable case
     if not last_row:
+        log.warning(f'Read-race on shm array: {graphics_name}@{shm.token}')
         return
 
     # update graphics
@@ -175,7 +179,6 @@ def chart_maxmin(
 
 
 async def update_chart_from_quotes(
-
     linked: LinkedSplits,
     stream: tractor.MsgStream,
     ohlcv: np.ndarray,
@@ -247,17 +250,16 @@ async def update_chart_from_quotes(
     chart.show()
     last_quote = time.time()
 
-    # NOTE: all code below this loop is expected to be synchronous
-    # and thus draw instructions are not picked up jntil the next
-    # wait / iteration.
     async for quotes in stream:
 
         now = time.time()
-        quote_period = now - last_quote
-        quote_rate = round(1/quote_period, 1) if quote_period else float('inf')
+        quote_period = time.time() - last_quote
+        quote_rate = round(
+            1/quote_period, 1) if quote_period > 0 else float('inf')
+
         if (
             quote_period <= 1/_quote_throttle_rate
-            and quote_rate > _quote_throttle_rate + 2
+            and quote_rate > _quote_throttle_rate * 1.5
         ):
             log.warning(f'High quote rate {symbol.key}: {quote_rate}')
         last_quote = now
@@ -454,7 +456,8 @@ def maybe_mk_fsp_shm(
     readonly: bool = True,
 
 ) -> (ShmArray, bool):
-    '''Allocate a single row shm array for an symbol-fsp pair if none
+    '''
+    Allocate a single row shm array for an symbol-fsp pair if none
     exists, otherwise load the shm already existing for that token.
 
     '''
@@ -481,7 +484,6 @@ def maybe_mk_fsp_shm(
 
 @acm
 async def open_fsp_sidepane(
-
     linked: LinkedSplits,
     conf: dict[str, dict[str, str]],
 
@@ -570,6 +572,7 @@ async def open_fsp_cluster(
 async def maybe_open_fsp_cluster(
     workers: int = 2,
     **kwargs,
+
 ) -> AsyncGenerator[int, dict[str, tractor.Portal]]:
 
     kwargs.update(
@@ -589,7 +592,6 @@ async def maybe_open_fsp_cluster(
 
 
 async def start_fsp_displays(
-
     cluster_map: dict[str, tractor.Portal],
     linkedsplits: LinkedSplits,
     fsps: dict[str, str],
@@ -603,7 +605,8 @@ async def start_fsp_displays(
     display_in_own_task: bool = False,
 
 ) -> None:
-    '''Create sub-actors (under flat tree)
+    '''
+    Create sub-actors (under flat tree)
     for each entry in config and attach to local graphics update tasks.
 
     Pass target entrypoint and historical data.
@@ -668,9 +671,7 @@ async def start_fsp_displays(
 
 
 async def update_chart_from_fsp(
-
     portal: tractor.Portal,
-
     linkedsplits: LinkedSplits,
     brokermod: ModuleType,
     sym: str,
@@ -687,7 +688,8 @@ async def update_chart_from_fsp(
     profiler: pg.debug.Profiler,
 
 ) -> None:
-    '''FSP stream chart update loop.
+    '''
+    FSP stream chart update loop.
 
     This is called once for each entry in the fsp
     config map.
@@ -792,9 +794,7 @@ async def update_chart_from_fsp(
             level_line(chart, 80, orient_v='top')
 
         chart._set_yrange()
-
-        done()
-        chart.linked.resize_sidepanes()
+        done()  # status updates
 
         profiler(f'fsp:{func_name} starting update loop')
         profiler.finish()
@@ -912,7 +912,6 @@ def has_vlm(ohlcv: ShmArray) -> bool:
 
 @acm
 async def maybe_open_vlm_display(
-
     linked: LinkedSplits,
     ohlcv: ShmArray,
 
@@ -992,20 +991,10 @@ async def maybe_open_vlm_display(
             # size view to data once at outset
             chart._set_yrange()
 
-            # size pain to parent chart
-            # TODO: this appears to nearly fix a bug where the vlm sidepane
-            # could be sized correctly nearly immediately (since the
-            # order pane is already sized), right now it doesn't seem to
-            # fully align until the VWAP fsp-actor comes up...
-            await trio.sleep(0)
-            chart.linked.resize_sidepanes()
-            await trio.sleep(0)
-
             yield chart
 
 
 async def display_symbol_data(
-
     godwidget: GodWidget,
     provider: str,
     sym: str,
@@ -1116,24 +1105,24 @@ async def display_symbol_data(
                 'chart_kwargs': {'style': 'step'}
             },
 
-            'rsi': {
-                'func_name': 'rsi',  # literal python func ref lookup name
+            # 'rsi': {
+            #     'func_name': 'rsi',  # literal python func ref lookup name
 
-                # map of parameters to place on the fsp sidepane widget
-                # which should map to dynamic inputs available to the
-                # fsp function at runtime.
-                'params': {
-                    'period': {
-                        'default_value': 14,
-                        'widget_kwargs': {'readonly': True},
-                    },
-                },
+            #     # map of parameters to place on the fsp sidepane widget
+            #     # which should map to dynamic inputs available to the
+            #     # fsp function at runtime.
+            #     'params': {
+            #         'period': {
+            #             'default_value': 14,
+            #             'widget_kwargs': {'readonly': True},
+            #         },
+            #     },
 
-                # ``ChartPlotWidget`` options passthrough
-                'chart_kwargs': {
-                    'static_yrange': (0, 100),
-                },
-            },
+            #     # ``ChartPlotWidget`` options passthrough
+            #     'chart_kwargs': {
+            #         'static_yrange': (0, 100),
+            #     },
+            # },
         }
 
         if has_vlm(ohlcv):  # and provider != 'binance':
@@ -1201,4 +1190,10 @@ async def display_symbol_data(
                     order_mode_started
                 )
             ):
+                # let Qt run to render all widgets and make sure the
+                # sidepanes line up vertically.
+                await trio.sleep(0)
+                linkedsplits.resize_sidepanes()
+
+                # let the app run.
                 await trio.sleep_forever()

--- a/piker/ui/_forms.py
+++ b/piker/ui/_forms.py
@@ -732,7 +732,7 @@ def mk_order_pane_layout(
 
 ) -> FieldsForm:
 
-    font_size: int = _font.px_size - 1
+    font_size: int = _font.px_size - 2
 
     # TODO: maybe just allocate the whole fields form here
     # and expect an async ctx entry?

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -341,7 +341,14 @@ class ChartView(ViewBox):
         **kwargs,
 
     ):
-        super().__init__(parent=parent, **kwargs)
+        super().__init__(
+            parent=parent,
+            # TODO: look into the default view padding
+            # support that might replace somem of our
+            # ``ChartPlotWidget._set_yrange()`
+            # defaultPadding=0.,
+            **kwargs
+        )
 
         # disable vertical scrolling
         self.setMouseEnabled(x=True, y=False)
@@ -533,7 +540,6 @@ class ChartView(ViewBox):
                     # self.updateScaleBox(ev.buttonDownPos(), ev.pos())
             else:
                 # default bevavior: click to pan view
-
                 tr = self.childGroup.transform()
                 tr = fn.invertQTransform(tr)
                 tr = tr.map(dif*mask) - tr.map(Point(0, 0))

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -110,7 +110,7 @@ class DpiAwareFont:
 
         mx_dpi = max(pdpi, ldpi)
         mn_dpi = min(pdpi, ldpi)
-        scale = round(ldpi/pdpi)
+        scale = round(ldpi/pdpi, ndigits=2)
 
         if mx_dpi <= 97:  # for low dpi use larger font sizes
             inches = _font_sizes['lo'][self._font_size]
@@ -121,20 +121,28 @@ class DpiAwareFont:
         dpi = mn_dpi
 
         # dpi is likely somewhat scaled down so use slightly larger font size
-        if scale > 1 and self._font_size:
-            # TODO: this denominator should probably be determined from
-            # relative aspect ratios or something?
-            inches = inches * (1 + 6/16)
-            if scale < 2:
-                inches *= (1 / scale)
+        if scale >= 1.1 and self._font_size:
+
+            if 1.2 <= scale:
+                inches *= (1 / scale) * 1.0616
+
+            if scale < 1.4 or scale >= 1.5:
+                # TODO: this denominator should probably be determined from
+                # relative aspect ratios or something?
+                inches = inches * (1 + 6/16)
+
             dpi = mx_dpi
             log.info(f'USING MAX DPI {dpi}')
 
+        # TODO: we might want to fiddle with incrementing font size by
+        # +1 for the edge cases above. it seems doing it via scaling is
+        # always going to hit that error in range mapping from inches:
+        # float to px size: int.
         self._font_inches = inches
-
         font_size = math.floor(inches * dpi)
+
         log.info(
-            f"\nscreen:{screen.name()}"
+            f"screen:{screen.name()}]\n"
             f"pDPI: {pdpi}, lDPI: {ldpi}, scale: {scale}\n"
             f"\nOur best guess font size is {font_size}\n"
         )

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -124,14 +124,18 @@ class DpiAwareFont:
         if scale > 1 and self._font_size:
             # TODO: this denominator should probably be determined from
             # relative aspect ratios or something?
-            inches = inches * (1 / scale) * (1 + 6/16)
+            inches = inches * (1 + 6/16)
+            if scale < 2:
+                inches *= (1 / scale)
             dpi = mx_dpi
+            log.info(f'USING MAX DPI {dpi}')
 
         self._font_inches = inches
 
         font_size = math.floor(inches * dpi)
-        log.debug(
-            f"\nscreen:{screen.name()} with pDPI: {pdpi}, lDPI: {ldpi}"
+        log.info(
+            f"\nscreen:{screen.name()}"
+            f"pDPI: {pdpi}, lDPI: {ldpi}, scale: {scale}\n"
             f"\nOur best guess font size is {font_size}\n"
         )
         # apply the size

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -127,9 +127,8 @@ class DpiAwareFont:
             if 1.2 <= scale:
                 mult = 1.0375
 
-            if scale >= 2:
+            if scale >= 1.5:
                 mult = 1.375
-
 
             # TODO: this multiplier should probably be determined from
             # relative aspect ratios or something?

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -123,16 +123,17 @@ class DpiAwareFont:
         # dpi is likely somewhat scaled down so use slightly larger font size
         if scale >= 1.1 and self._font_size:
 
+            # no idea why
             if 1.2 <= scale:
-                inches *= (1 / scale) * 1.0616
+                mult = 1.0375
 
-            if scale < 1.4 or scale >= 1.5:
-                # TODO: this denominator should probably be determined from
-                # relative aspect ratios or something?
-                inches = inches * (1 + 6/16)
+            if scale >= 2:
+                mult = 1.375
 
-            dpi = mx_dpi
-            log.info(f'USING MAX DPI {dpi}')
+
+            # TODO: this multiplier should probably be determined from
+            # relative aspect ratios or something?
+            inches *= mult
 
         # TODO: we might want to fiddle with incrementing font size by
         # +1 for the edge cases above. it seems doing it via scaling is


### PR DESCRIPTION
Variety of chart UX fixups pumped out from the #231 history with the following short summary:

- auto y-ranging al overlays on all subcharts on a `LinkedSplits` chart set during view interaction
- more ad hoc fixes for dpi scaling
- futher refinements to sidepane alignment and fsp subchart space sizings
- a fix to get symbol (and thus `LinkedSplits` + its sidepane widgets) switching to be super fast again
  - there is still one issue with this documented in https://github.com/pikers/piker/issues/254
- made it so users can actually try to use the OpenGL support from `pyqtgraph` via a param to `ChartPlotWidget`
- reverted the `LinkedSplits.resume_all_feeds()` / `.pause_all_feeds()` to be sync methods again for speed