### PR TITLE
Overlayed $vlm

### DIFF
--- a/piker/fsp/_momo.py
+++ b/piker/fsp/_momo.py
@@ -1,5 +1,5 @@
 # piker: trading gear for hackers
-# Copyright (C) 2018-present  Tyler Goodlet (in stewardship of piker0)
+# Copyright (C) Tyler Goodlet (in stewardship of pikers)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/piker/ui/_anchors.py
+++ b/piker/ui/_anchors.py
@@ -18,21 +18,26 @@
 Anchor funtions for UI placement of annotions.
 
 '''
-from typing import Callable
+from __future__ import annotations
+from typing import Callable, TYPE_CHECKING
 
 from PyQt5.QtCore import QPointF
 from PyQt5.QtWidgets import QGraphicsPathItem
 
-from ._label import Label
+if TYPE_CHECKING:
+    from ._axes import PriceAxis
+    from ._chart import ChartPlotWidget
+    from ._label import Label
 
 
 def marker_right_points(
-
-    chart: 'ChartPlotWidget',  # noqa
+    chart: ChartPlotWidget,  # noqa
     marker_size: int = 20,
 
 ) -> (float, float, float):
-    '''Return x-dimension, y-axis-aware, level-line marker oriented scene values.
+    '''
+    Return x-dimension, y-axis-aware, level-line marker oriented scene
+    values.
 
     X values correspond to set the end of a level line, end of
     a paried level line marker, and the right most side of the "right"
@@ -57,16 +62,17 @@ def vbr_left(
     label: Label,
 
 ) -> Callable[..., float]:
-    """Return a closure which gives the scene x-coordinate for the
-    leftmost point of the containing view box.
+    '''
+    Return a closure which gives the scene x-coordinate for the leftmost
+    point of the containing view box.
 
-    """
+    '''
     return label.vbr().left
 
 
 def right_axis(
 
-    chart: 'ChartPlotWidget',  # noqa
+    chart: ChartPlotWidget,  # noqa
     label: Label,
 
     side: str = 'left',
@@ -141,13 +147,13 @@ def gpath_pin(
         return path_br.bottomRight() - QPointF(label.w, label.h / 6)
 
 
-
 def pp_tight_and_right(
     label: Label
 
 ) -> QPointF:
-    '''Place *just* right of the pp label.
+    '''
+    Place *just* right of the pp label.
 
     '''
-    txt = label.txt
+    # txt = label.txt
     return label.txt.pos() + QPointF(label.w - label.h/3, 0)

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -287,6 +287,8 @@ class AxisLabel(pg.GraphicsObject):
         self.path = None
         self.rect = None
 
+        self._pw = self.pixelWidth()
+
     def paint(
         self,
         p: QtGui.QPainter,
@@ -419,6 +421,7 @@ class XAxisLabel(AxisLabel):
         abs_pos: QPointF,  # scene coords
         value: float,  # data for text
         offset: int = 0  # if have margins, k?
+
     ) -> None:
 
         timestrs = self._parent._indexes_to_timestrs([int(value)])
@@ -433,17 +436,19 @@ class XAxisLabel(AxisLabel):
 
         w = self.boundingRect().width()
 
-        self.setPos(QPointF(
-            abs_pos.x() - w/2,
-            y_offset/2,
-        ))
+        self.setPos(
+            QPointF(
+                abs_pos.x() - w/2 - self._pw,
+                y_offset/2,
+            )
+        )
         self.update()
 
     def _draw_arrow_path(self):
         y_offset = self._parent.style['tickTextOffset'][1]
         path = QtGui.QPainterPath()
         h, w = self.rect.height(), self.rect.width()
-        middle = w/2 - 0.5
+        middle = w/2 - self._pw * 0.5
         aw = h/2
         left = middle - aw
         right = middle + aw
@@ -513,10 +518,12 @@ class YAxisLabel(AxisLabel):
         br = self.boundingRect()
         h = br.height()
 
-        self.setPos(QPointF(
-            x_offset,
-            abs_pos.y() - h / 2 - self._y_margin / 2
-        ))
+        self.setPos(
+            QPointF(
+                x_offset,
+                abs_pos.y() - h / 2 - self._pw,
+            )
+        )
         self.update()
 
     def update_on_resize(self, vr, r):
@@ -553,7 +560,7 @@ class YAxisLabel(AxisLabel):
         path = QtGui.QPainterPath()
         h = self.rect.height()
         path.moveTo(0, 0)
-        path.lineTo(-x_offset - h/4, h/2.)
+        path.lineTo(-x_offset - h/4, h/2. - self._pw/2)
         path.lineTo(0, h)
         path.closeSubpath()
         self.path = path

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -862,6 +862,7 @@ class ChartPlotWidget(pg.PlotWidget):
     def overlay_plotitem(
         self,
         name: str,
+        axis_kwargs: dict = {},
 
     ) -> pg.PlotItem:
         # Custom viewbox impl
@@ -875,6 +876,7 @@ class ChartPlotWidget(pg.PlotWidget):
         yaxis = PriceAxis(
             orientation='right',
             linkedsplits=self.linked,
+            **axis_kwargs,
         )
 
         plotitem = pg.PlotItem(

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -43,8 +43,8 @@ log = get_logger(__name__)
 # latency (in terms of perceived lag in cross hair) so really be sure
 # there's an improvement if you want to change it!
 
-_mouse_rate_limit = 58  # TODO; should we calc current screen refresh rate?
-_debounce_delay = 1 / 60
+_mouse_rate_limit = 120  # TODO; should we calc current screen refresh rate?
+_debounce_delay = 1 / 40
 _ch_label_opac = 1
 
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -655,7 +655,7 @@ async def open_vlm_displays(
 
         last_val_sticky.update_from_data(-1, value)
 
-        chart.update_curve_from_array(
+        vlm_curve = chart.update_curve_from_array(
             'volume',
             shm.array,
         )
@@ -690,10 +690,11 @@ async def open_vlm_displays(
 
             pi = chart.overlay_plotitem(
                 'dolla_vlm',
+                index=0,  # place axis on inside (nearest to chart)
+                axis_title=' $vlm',
+                axis_side='right',
                 axis_kwargs={
-                    # 'humanize': True,
-                    # 'text': 'dvlm',
-                    'typical_max_str': ' 99.9 M ',
+                    'typical_max_str': ' 100.0 M ',
                     'formatter': partial(
                         humanize,
                         digits=2,
@@ -701,10 +702,6 @@ async def open_vlm_displays(
                 },
 
             )
-
-            # add axis title
-            raxis = pi.getAxis('right')
-            raxis.set_title(' $vlm', view=pi.getViewBox())
 
             # add custom auto range handler
             pi.vb._maxmin = partial(maxmin, name='dolla_vlm')
@@ -716,13 +713,18 @@ async def open_vlm_displays(
 
                 array_key='dolla_vlm',
                 overlay=pi,
-                color='charcoal',
+                # color='bracket',
+                # TODO: this color or dark volume
+                # color='charcoal',
                 step_mode=True,
                 # **conf.get('chart_kwargs', {})
             )
             # TODO: is there a way to "sync" the dual axes such that only
             # one curve is needed?
-            # curve.hide()
+            # hide the original vlm curve since the $vlm one is now
+            # displayed and the curves are effectively the same minus
+            # liquidity events (well at least on low OHLC periods - 1s).
+            vlm_curve.hide()
 
             # TODO: we need a better API to do this..
             # specially store ref to shm for lookup in display loop

--- a/piker/ui/_label.py
+++ b/piker/ui/_label.py
@@ -34,7 +34,7 @@ from ._style import (
 
 
 class Label:
-    """
+    '''
     A plain ol' "scene label" using an underlying ``QGraphicsTextItem``.
 
     After hacking for many days on multiple "label" systems inside
@@ -50,10 +50,8 @@ class Label:
     small, re-usable label components that can actually be used to build
     production grade UIs...
 
-    """
-
+    '''
     def __init__(
-
         self,
         view: pg.ViewBox,
         fmt_str: str,
@@ -63,6 +61,7 @@ class Label:
         font_size: str = 'small',
         opacity: float = 1,
         fields: dict = {},
+        parent: pg.GraphicsObject = None,
         update_on_range_change: bool = True,
 
     ) -> None:
@@ -71,11 +70,13 @@ class Label:
         self._fmt_str = fmt_str
         self._view_xy = QPointF(0, 0)
 
-        self.scene_anchor: Optional[Callable[..., QPointF]] = None
+        self.scene_anchor: Optional[
+            Callable[..., QPointF]
+        ] = None
 
         self._x_offset = x_offset
 
-        txt = self.txt = QtWidgets.QGraphicsTextItem()
+        txt = self.txt = QtWidgets.QGraphicsTextItem(parent=parent)
         txt.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
 
         vb.scene().addItem(txt)
@@ -86,7 +87,6 @@ class Label:
         )
         dpi_font.configure_to_dpi()
         txt.setFont(dpi_font.font)
-
         txt.setOpacity(opacity)
 
         # register viewbox callbacks
@@ -109,7 +109,7 @@ class Label:
         # self.setTextInteractionFlags(QtGui.Qt.TextEditorInteraction)
 
     @property
-    def color(self):
+    def color(self) -> str:
         return self._hcolor
 
     @color.setter
@@ -118,9 +118,10 @@ class Label:
         self._hcolor = color
 
     def update(self) -> None:
-        '''Update this label either by invoking its
-        user defined anchoring function, or by positioning
-        to the last recorded data view coordinates.
+        '''
+        Update this label either by invoking its user defined anchoring
+        function, or by positioning to the last recorded data view
+        coordinates.
 
         '''
         # move label in scene coords to desired position
@@ -234,7 +235,8 @@ class Label:
 
 
 class FormatLabel(QLabel):
-    '''Kinda similar to above but using the widget apis.
+    '''
+    Kinda similar to above but using the widget apis.
 
     '''
     def __init__(
@@ -273,8 +275,8 @@ class FormatLabel(QLabel):
             QSizePolicy.Expanding,
             QSizePolicy.Expanding,
         )
-        self.setAlignment(Qt.AlignVCenter
-            | Qt.AlignLeft
+        self.setAlignment(
+            Qt.AlignVCenter | Qt.AlignLeft
         )
         self.setText(self.fmt_str)
 

--- a/piker/ui/_lines.py
+++ b/piker/ui/_lines.py
@@ -334,10 +334,11 @@ class LevelLine(pg.InfiniteLine):
         w: QtWidgets.QWidget
 
     ) -> None:
-        """Core paint which we override (yet again)
+        '''
+        Core paint which we override (yet again)
         from pg..
 
-        """
+        '''
         p.setRenderHint(p.Antialiasing)
 
         # these are in viewbox coords


### PR DESCRIPTION
Final touches on getting *overlayed unit and dollar* volume curves as our default sub-chart 🏄🏼 

The main bit of fancyness comes from the new `humanize()`d axes values and a single curve which starts as the unit vlm until the $vlm fsp is fully spawned at which point the curve is flipped to the latter. Also includes nice minimal labels for each y-axis below in the space available to the x-axis 😎 

