### PR TITLE
Trade ratez

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1042,6 +1042,7 @@ tick_types = {
     # https://interactivebrokers.github.io/tws-api/tick_types.html#rt_volume
     48: 'dark_trade',
 
+    # standard L1 ticks
     0: 'bsize',
     1: 'bid',
     2: 'ask',
@@ -1049,6 +1050,12 @@ tick_types = {
     4: 'last',
     5: 'size',
     8: 'volume',
+
+    # ``ib_insync`` already packs these into
+    # quotes under the following fields.
+    # 55: 'trades_per_min',  # `'tradeRate'`
+    # 56: 'vlm_per_min',  # `'volumeRate'`
+    # 89: 'shortable',  # `'shortableShares'`
 }
 
 
@@ -1263,7 +1270,13 @@ async def _setup_quote_stream(
     to_trio: trio.abc.SendChannel,
 
     symbol: str,
-    opts: tuple[int] = ('375', '233', '236'),
+    opts: tuple[int] = (
+        '375',  # RT trade volume (excludes utrades)
+        '233',  # RT trade volume (includes utrades)
+        '236',  # Shortable shares
+        '294',  # Trade rate / minute
+        '295',  # Vlm rate / minute
+    ),
     contract: Optional[Contract] = None,
 
 ) -> trio.abc.ReceiveChannel:

--- a/piker/data/_normalize.py
+++ b/piker/data/_normalize.py
@@ -24,7 +24,10 @@ from typing import AsyncIterator
 
 def iterticks(
     quote: dict,
-    types: tuple[str] = ('trade', 'dark_trade'),
+    types: tuple[str] = (
+        'trade',
+        'dark_trade',
+    ),
     deduplicate_darks: bool = False,
 
 ) -> AsyncIterator:
@@ -47,17 +50,20 @@ def iterticks(
         if deduplicate_darks:
             for tick in ticks:
                 ttype = tick.get('type')
-                sig = (
-                    tick['time'],
-                    tick['price'],
-                    tick['size']
-                )
 
-                if ttype == 'dark_trade':
-                    darks[sig] = tick
+                time = tick.get('time', None)
+                if time:
+                    sig = (
+                        time,
+                        tick['price'],
+                        tick['size']
+                    )
 
-                elif ttype == 'trade':
-                    trades[sig] = tick
+                    if ttype == 'dark_trade':
+                        darks[sig] = tick
+
+                    elif ttype == 'trade':
+                        trades[sig] = tick
 
             # filter duplicates
             for sig, tick in trades.items():

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -252,7 +252,7 @@ async def sample_and_broadcast(
                             try:
                                 stream.send_nowait((sym, quote))
                             except trio.WouldBlock:
-                                ctx = getattr(sream, '_ctx', None)
+                                ctx = getattr(stream, '_ctx', None)
                                 if ctx:
                                     log.warning(
                                         f'Feed overrun {bus.brokername} ->'
@@ -371,7 +371,7 @@ async def uniform_rate_send(
 
             # we have a quote already so send it now.
 
-        measured_rate = 1 / (time.time() - last_send)
+        # measured_rate = 1 / (time.time() - last_send)
         # log.info(
         #     f'`{sym}` throttled send hz: {round(measured_rate, ndigits=1)}'
         # )

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -567,7 +567,7 @@ async def open_feed(
             shm_token = data['shm_token']
 
             # XXX: msgspec won't relay through the tuples XD
-            shm_token['dtype_descr'] = list(
+            shm_token['dtype_descr'] = tuple(
                 map(tuple, shm_token['dtype_descr']))
 
             assert shm_token == shm.token  # sanity

--- a/piker/fsp/_api.py
+++ b/piker/fsp/_api.py
@@ -143,6 +143,7 @@ def maybe_mk_fsp_shm(
     exists, otherwise load the shm already existing for that token.
 
     '''
+    assert isinstance(sym, str), '`sym` should be file-name-friendly `str`'
     uid = tractor.current_actor().uid
 
     # TODO: load output types from `Fsp`

--- a/piker/fsp/_api.py
+++ b/piker/fsp/_api.py
@@ -40,6 +40,8 @@ from tractor.msg import NamespacePath
 from ..data._sharedmem import (
     ShmArray,
     maybe_open_shm_array,
+    attach_shm_array,
+    _Token,
 )
 from ..log import get_logger
 
@@ -72,6 +74,13 @@ class Fsp:
     # - custom function wrappers,
     # https://wrapt.readthedocs.io/en/latest/wrappers.html#custom-function-wrappers
 
+    # actor-local map of source flow shm tokens
+    # + the consuming fsp *to* the consumers output
+    # shm flow.
+    _flow_registry: dict[
+        tuple[_Token, str], _Token,
+    ] = {}
+
     def __init__(
         self,
         func: Callable[..., Awaitable],
@@ -93,7 +102,7 @@ class Fsp:
         self.config: dict[str, Any] = config
 
         # register with declared set.
-        _fsp_registry[self.ns_path] = func
+        _fsp_registry[self.ns_path] = self
 
     @property
     def name(self) -> str:
@@ -110,6 +119,24 @@ class Fsp:
         **kwargs
     ):
         return self.func(*args, **kwargs)
+
+    # TODO: lru_cache this? prettty sure it'll work?
+    def get_shm(
+        self,
+        src_shm: ShmArray,
+
+    ) -> ShmArray:
+        '''
+        Provide access to allocated shared mem array
+        for this "instance" of a signal processor for
+        the given ``key``.
+
+        '''
+        dst_token = self._flow_registry[
+            (src_shm._token, self.name)
+        ]
+        shm = attach_shm_array(dst_token)
+        return shm
 
 
 def fsp(
@@ -132,19 +159,27 @@ def fsp(
     return Fsp(wrapped, outputs=(wrapped.__name__,))
 
 
+def mk_fsp_shm_key(
+    sym: str,
+    target: Fsp
+
+) -> str:
+    uid = tractor.current_actor().uid
+    return f'{sym}.fsp.{target.name}.{".".join(uid)}'
+
+
 def maybe_mk_fsp_shm(
     sym: str,
-    target: fsp,
+    target: Fsp,
     readonly: bool = True,
 
-) -> (ShmArray, bool):
+) -> (str, ShmArray, bool):
     '''
     Allocate a single row shm array for an symbol-fsp pair if none
     exists, otherwise load the shm already existing for that token.
 
     '''
     assert isinstance(sym, str), '`sym` should be file-name-friendly `str`'
-    uid = tractor.current_actor().uid
 
     # TODO: load output types from `Fsp`
     # - should `index` be a required internal field?
@@ -153,7 +188,7 @@ def maybe_mk_fsp_shm(
         [(field_name, float) for field_name in target.outputs]
     )
 
-    key = f'{sym}.fsp.{target.name}.{".".join(uid)}'
+    key = mk_fsp_shm_key(sym, target)
 
     shm, opened = maybe_open_shm_array(
         key,
@@ -161,4 +196,4 @@ def maybe_mk_fsp_shm(
         dtype=fsp_dtype,
         readonly=True,
     )
-    return shm, opened
+    return key, shm, opened

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -135,11 +135,17 @@ async def fsp_compute(
                 output = history_output[key]
 
                 if history is None:
+
+                    if output is None:
+                        length = len(src.array)
+                    else:
+                        length = len(output)
+
                     # using the first output, determine
                     # the length of the struct-array that
                     # will be pushed to shm.
                     history = np.zeros(
-                        len(output),
+                        length,
                         dtype=dst.array.dtype
                     )
 

--- a/piker/fsp/_volume.py
+++ b/piker/fsp/_volume.py
@@ -272,6 +272,11 @@ async def flow_rates(
     vr = quote.get('volumeRate')
     yield '1m_vlm_rate', vr or 0
 
+    yield 'trade_rate', 0
+    yield 'dark_trade_rate', 0
+    yield 'dvlm_rate', 0
+    yield 'dark_dvlm_rate', 0
+
     # NOTE: in theory we could dynamically allocate a cascade based on
     # this call but not sure if that's too "dynamic" in terms of
     # validating cascade flows from message typing perspective.
@@ -279,10 +284,6 @@ async def flow_rates(
     # attach to ``dolla_vlm`` fsp running
     # on this same source flow.
     dvlm_shm = dolla_vlm.get_shm(ohlcv)
-
-    # breakpoint()
-    # import tractor
-    # await tractor.breakpoint()
 
     # precompute arithmetic mean weights (all ones)
     seq = np.full((period,), 1)
@@ -306,7 +307,9 @@ async def flow_rates(
                 period,
                 weights=weights,
             )
-            yield 'trade_rate', trade_rate_wma[-1]
+            trade_rate = trade_rate_wma[-1]
+            # print(trade_rate)
+            yield 'trade_rate', trade_rate
         else:
             # instantaneous rate per sample step
             count = dvlm_shm.array['trade_count'][-1]

--- a/piker/fsp/_volume.py
+++ b/piker/fsp/_volume.py
@@ -215,12 +215,12 @@ async def flow_rates(
 
             tr = quote['tradeRate']
             if tr != ltr:
-                print(f'trade rate: {tr}')
+                # print(f'trade rate: {tr}')
                 yield '1m_trade_rate', tr
                 ltr = tr
 
             vr = quote['volumeRate']
             if vr != lvr:
-                print(f'vlm rate: {vr}')
+                # print(f'vlm rate: {vr}')
                 yield '1m_vlm_rate', vr
                 lvr = vr

--- a/piker/fsp/_volume.py
+++ b/piker/fsp/_volume.py
@@ -193,7 +193,7 @@ async def dolla_vlm(
         '1m_trade_rate',
         '1m_vlm_rate',
     ),
-    curve_style='step',
+    curve_style='line',
 )
 async def flow_rates(
     source: AsyncReceiver[dict],
@@ -213,14 +213,14 @@ async def flow_rates(
     async for quote in source:
         if quote:
 
-            tr = quote['tradeRate'],
+            tr = quote['tradeRate']
             if tr != ltr:
                 print(f'trade rate: {tr}')
                 yield '1m_trade_rate', tr
                 ltr = tr
 
-            vr = quote['volumeRate'],
+            vr = quote['volumeRate']
             if vr != lvr:
-                print(f'vlm rate: {tr}')
-                yield '1m_vlm_rate', tr
-                ltr = tr
+                print(f'vlm rate: {vr}')
+                yield '1m_vlm_rate', vr
+                lvr = vr

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -44,10 +44,14 @@ class Axis(pg.AxisItem):
         self,
         linkedsplits,
         typical_max_str: str = '100 000.000',
+        text_color: str = 'bracket',
         **kwargs
 
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__(
+            # textPen=textPen,
+            **kwargs
+        )
 
         # XXX: pretty sure this makes things slower
         # self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
@@ -74,14 +78,27 @@ class Axis(pg.AxisItem):
         })
 
         self.setTickFont(_font.font)
+
         # NOTE: this is for surrounding "border"
         self.setPen(_axis_pen)
+
         # this is the text color
-        self.setTextPen(_axis_pen)
+        # self.setTextPen(pg.mkPen(hcolor(text_color)))
+        self.text_color = text_color
+
         self.typical_br = _font._qfm.boundingRect(typical_max_str)
 
         # size the pertinent axis dimension to a "typical value"
         self.size_to_values()
+
+    @property
+    def text_color(self) -> str:
+        return self._text_color
+
+    @text_color.setter
+    def text_color(self, text_color: str) -> None:
+        self.setTextPen(pg.mkPen(hcolor(text_color)))
+        self._text_color = text_color
 
     def size_to_values(self) -> None:
         pass
@@ -109,7 +126,8 @@ class PriceAxis(Axis):
     def set_title(
         self,
         title: str,
-        view: Optional[ChartView] = None
+        view: Optional[ChartView] = None,
+        color: Optional[str] = None,
 
     ) -> Label:
         '''
@@ -123,7 +141,7 @@ class PriceAxis(Axis):
         label = self.title = Label(
             view=view or self.linkedView(),
             fmt_str=title,
-            color='bracket',
+            color=color or self.text_color,
             parent=self,
             # update_on_range_change=False,
         )

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1164,7 +1164,10 @@ class ChartPlotWidget(pg.PlotWidget):
         #     f"begin: {begin}, end: {end}, extra: {extra}"
         # )
 
-        a = self._arrays[name or self.name]
+        a = self._arrays.get(name or self.name)
+        if a is None:
+            return None
+
         ifirst = a[0]['index']
         bars = a[lbar - ifirst:rbar - ifirst + 1]
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -33,6 +33,7 @@ from PyQt5.QtWidgets import (
 import numpy as np
 import pyqtgraph as pg
 import trio
+from pydantic import BaseModel
 
 from ._axes import (
     DynamicDateAxis,
@@ -614,17 +615,30 @@ class LinkedSplits(QWidget):
                 cpw.sidepane.setMinimumWidth(sp_w)
                 cpw.sidepane.setMaximumWidth(sp_w)
 
-# import pydantic
 
-# class Graphics(pydantic.BaseModel):
+# class FlowsTable(pydantic.BaseModel):
 #     '''
 #     Data-AGGRegate: high level API onto multiple (categorized)
-#     ``ShmArray``s with high level processing routines for
-#     graphics computations and display.
+#     ``Flow``s with high level processing routines for
+#     multi-graphics computations and display.
 
 #     '''
-#     arrays: dict[str, np.ndarray] = {}
-#     graphics: dict[str, pg.GraphicsObject] = {}
+#     flows: dict[str, np.ndarray] = {}
+
+
+class Flow(BaseModel):
+    '''
+    (FinancialSignal-)Flow compound type which wraps a real-time
+    graphics (curve) and its backing data stream together for high level
+    access and control.
+
+    '''
+    class Config:
+        arbitrary_types_allowed = True
+
+    name: str
+    plot: pg.PlotItem
+    shm: Optional[ShmArray] = None  # may be filled in "later"
 
 
 class ChartPlotWidget(pg.PlotWidget):
@@ -721,8 +735,9 @@ class ChartPlotWidget(pg.PlotWidget):
             self.data_key: array,
         }
         self._graphics = {}  # registry of underlying graphics
+
         # registry of overlay curve names
-        self._overlays: dict[str, ShmArray] = {}
+        self._flows: dict[str, Flow] = {}
 
         self._feeds: dict[Symbol, Feed] = {}
 
@@ -981,7 +996,7 @@ class ChartPlotWidget(pg.PlotWidget):
         # TODO: this probably needs its own method?
         if overlay:
             # anchor_at = ('bottom', 'left')
-            self._overlays[name] = None
+            self._flows[name] = Flow(name=name, plot=pi)
 
             if isinstance(overlay, pg.PlotItem):
                 if overlay not in self.pi_overlay.overlays:
@@ -1062,7 +1077,7 @@ class ChartPlotWidget(pg.PlotWidget):
         assert len(array)
         data_key = array_key or graphics_name
 
-        if graphics_name not in self._overlays:
+        if graphics_name not in self._flows:
             self._arrays[self.name] = array
         else:
             self._arrays[data_key] = array
@@ -1164,12 +1179,15 @@ class ChartPlotWidget(pg.PlotWidget):
         #     f"begin: {begin}, end: {end}, extra: {extra}"
         # )
 
+        # TODO: here we should instead look up the ``Flow.shm.array``
+        # and read directly from shm to avoid copying to memory first
+        # and then reading it again here.
         a = self._arrays.get(name or self.name)
         if a is None:
             return None
 
         ifirst = a[0]['index']
-        bars = a[lbar - ifirst:rbar - ifirst + 1]
+        bars = a[lbar - ifirst:(rbar - ifirst) + 1]
 
         if not len(bars):
             # likely no data loaded yet or extreme scrolling?

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -995,15 +995,15 @@ class ChartPlotWidget(pg.PlotWidget):
 
         # TODO: this probably needs its own method?
         if overlay:
-            # anchor_at = ('bottom', 'left')
-            self._flows[name] = Flow(name=name, plot=pi)
-
             if isinstance(overlay, pg.PlotItem):
                 if overlay not in self.pi_overlay.overlays:
                     raise RuntimeError(
                             f'{overlay} must be from `.plotitem_overlay()`'
                         )
                 pi = overlay
+
+            # anchor_at = ('bottom', 'left')
+            self._flows[name] = Flow(name=name, plot=pi)
 
         else:
             # anchor_at = ('top', 'left')

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -253,7 +253,7 @@ class ContentsLabels:
                 and index < array[-1]['index']
             ):
                 # out of range
-                print('out of range?')
+                print('WTF out of range?')
                 continue
 
             # array = chart._arrays[name]
@@ -550,17 +550,20 @@ class Cursor(pg.GraphicsObject):
                 for cursor in opts.get('cursors', ()):
                     cursor.setIndex(ix)
 
-                # update the label on the bottom of the crosshair
-                axes = plot.plotItem.axes
-
+                # Update the label on the bottom of the crosshair.
                 # TODO: make this an up-front calc that we update
-                # on axis-widget resize events.
+                # on axis-widget resize events instead of on every mouse
+                # update cylce.
+
                 # left axis offset width for calcuating
                 # absolute x-axis label placement.
                 left_axis_width = 0
-                left = axes.get('left')
-                if left:
-                    left_axis_width = left['item'].width()
+                if len(plot.pi_overlay.overlays):
+                    # breakpoint()
+                    lefts = plot.pi_overlay.get_axes('left')
+                    if lefts:
+                        for left in lefts:
+                            left_axis_width += left.width()
 
                 # map back to abs (label-local) coordinates
                 self.xaxis_label.update_label(

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -24,6 +24,7 @@ import numpy as np
 import pyqtgraph as pg
 from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import (
+    Qt,
     QLineF,
     QSizeF,
     QRectF,
@@ -85,6 +86,14 @@ def step_path_arrays_from_1d(
         return x_out, y_out
 
 
+_line_styles: dict[str, int] = {
+    'solid': Qt.PenStyle.SolidLine,
+    'dash': Qt.PenStyle.DashLine,
+    'dot': Qt.PenStyle.DotLine,
+    'dashdot': Qt.PenStyle.DashDotLine,
+}
+
+
 # TODO: got a feeling that dropping this inheritance gets us even more speedups
 class FastAppendCurve(pg.PlotCurveItem):
     '''
@@ -106,6 +115,7 @@ class FastAppendCurve(pg.PlotCurveItem):
         step_mode: bool = False,
         color: str = 'default_lightest',
         fill_color: Optional[str] = None,
+        style: str = 'solid',
 
         **kwargs
 
@@ -118,7 +128,11 @@ class FastAppendCurve(pg.PlotCurveItem):
         self._xrange: tuple[int, int] = self.dataBounds(ax=0)
 
         # all history of curve is drawn in single px thickness
-        self.setPen(hcolor(color))
+        pen = pg.mkPen(hcolor(color))
+        pen.setStyle(_line_styles[style])
+        if 'dash' in style:
+            pen.setDashPattern([6, 6])
+        self.setPen(pen)
 
         # last segment is drawn in 2px thickness for emphasis
         self.last_step_pen = pg.mkPen(hcolor(color), width=2)

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -130,8 +130,10 @@ class FastAppendCurve(pg.PlotCurveItem):
         # all history of curve is drawn in single px thickness
         pen = pg.mkPen(hcolor(color))
         pen.setStyle(_line_styles[style])
+
         if 'dash' in style:
-            pen.setDashPattern([6, 6])
+            pen.setDashPattern([8, 3])
+
         self.setPen(pen)
 
         # last segment is drawn in 2px thickness for emphasis
@@ -287,6 +289,7 @@ class FastAppendCurve(pg.PlotCurveItem):
                 x_last + 0.5, y_last
             )
         else:
+            # print((x[-1], y_last))
             self._last_line = QLineF(
                 x[-2], y[-2],
                 x[-1], y_last
@@ -337,6 +340,7 @@ class FastAppendCurve(pg.PlotCurveItem):
         p: QtGui.QPainter,
         opt: QtWidgets.QStyleOptionGraphicsItem,
         w: QtWidgets.QWidget
+
     ) -> None:
 
         profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
@@ -354,11 +358,11 @@ class FastAppendCurve(pg.PlotCurveItem):
             # p.drawPath(self.path)
             # profiler('.drawPath()')
 
-        # else:
         p.setPen(self.last_step_pen)
         p.drawLine(self._last_line)
         profiler('.drawLine()')
 
+        # else:
         p.setPen(self.opts['pen'])
         p.drawPath(self.path)
         profiler('.drawPath()')

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -106,7 +106,7 @@ def chart_maxmin(
     return last_bars_range, mx, max(mn, 0), mx_vlm_in_view
 
 
-async def update_linked_charts_graphics(
+async def graphics_update_loop(
     linked: LinkedSplits,
     stream: tractor.MsgStream,
     ohlcv: np.ndarray,
@@ -258,13 +258,15 @@ async def update_linked_charts_graphics(
                     )
                     last_mx_vlm = mx_vlm_in_view
 
-                for curve_name, shm in vlm_chart._overlays.items():
+                for curve_name, flow in vlm_chart._flows.items():
                     update_fsp_chart(
                         vlm_chart,
-                        shm,
+                        flow.shm,
                         curve_name,
                         array_key=curve_name,
                     )
+                    # is this even doing anything?
+                    flow.plot.vb._set_yrange()
 
             ticks_frame = quote.get('ticks', ())
 
@@ -411,14 +413,14 @@ async def update_linked_charts_graphics(
                 # TODO: all overlays on all subplots..
 
             # run synchronous update on all derived overlays
-            for curve_name, shm in chart._overlays.items():
+            for curve_name, flow in chart._flows.items():
                 update_fsp_chart(
                     chart,
-                    shm,
+                    flow.shm,
                     curve_name,
                     array_key=curve_name,
                 )
-                # chart._set_yrange()
+                # chart.view._set_yrange()
 
 
 async def check_for_new_bars(
@@ -473,11 +475,11 @@ async def check_for_new_bars(
             )
 
             # main chart overlays
-            for name in price_chart._overlays:
-
+            # for name in price_chart._flows:
+            for curve_name in price_chart._flows:
                 price_chart.update_curve_from_array(
-                    name,
-                    price_chart._arrays[name]
+                    curve_name,
+                    price_chart._arrays[curve_name]
                 )
 
             # each subplot
@@ -614,7 +616,7 @@ async def display_symbol_data(
 
             # start graphics update loop after receiving first live quote
             ln.start_soon(
-                update_linked_charts_graphics,
+                graphics_update_loop,
                 linkedsplits,
                 feed.stream,
                 ohlcv,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -54,7 +54,7 @@ from ..log import get_logger
 log = get_logger(__name__)
 
 # TODO: load this from a config.toml!
-_quote_throttle_rate: int = 58  # Hz
+_quote_throttle_rate: int = 6 + 16  # Hz
 
 
 # a working tick-type-classes template
@@ -266,7 +266,10 @@ async def graphics_update_loop(
                         array_key=curve_name,
                     )
                     # is this even doing anything?
-                    flow.plot.vb._set_yrange()
+                    flow.plot.vb._set_yrange(
+                        autoscale_linked_plots=False,
+                        name=curve_name,
+                    )
 
             ticks_frame = quote.get('ticks', ())
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -250,7 +250,7 @@ async def run_fsp_ui(
                 **conf.get('chart_kwargs', {})
             )
             # specially store ref to shm for lookup in display loop
-            chart._overlays[name] = shm
+            chart._flows[name].shm = shm
 
         else:
             # create a new sub-chart widget for this fsp
@@ -634,7 +634,9 @@ async def open_vlm_displays(
             for name in names:
                 mxmn = chart.maxmin(name=name)
                 if mxmn:
-                    mx = max(mxmn[1], mx)
+                    ymax = mxmn[1]
+                    if ymax > mx:
+                        mx = ymax
 
             return 0, mx
 
@@ -730,8 +732,8 @@ async def open_vlm_displays(
 
             # all to be overlayed curve names
             fields = [
-                'dolla_vlm',
-                'dark_vlm',
+               'dolla_vlm',
+               'dark_vlm',
             ]
             dvlm_rate_fields = [
                 'dvlm_rate',
@@ -794,7 +796,7 @@ async def open_vlm_displays(
                     # specially store ref to shm for lookup in display loop
                     # since only a placeholder of `None` is entered in
                     # ``.draw_curve()``.
-                    chart._overlays[name] = shm
+                    chart._flows[name].shm = shm
 
             chart_curves(
                 fields,
@@ -857,7 +859,7 @@ async def open_vlm_displays(
 
                 # dashed line to represent "individual trades" being
                 # more "granular" B)
-                # style='dash',
+                style='dash',
             )
 
             for pi in (dvlm_pi, tr_pi):

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -844,7 +844,7 @@ async def open_vlm_displays(
 
                 # TODO: dynamically update period (and thus this axis?)
                 # title from user input.
-                axis_title='clears/P',
+                axis_title='clrs/Ts',
 
                 axis_side='left',
                 axis_kwargs={

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -158,7 +158,11 @@ async def open_fsp_sidepane(
     sidepane.model = FspConfig()
 
     # just a logger for now until we get fsp configs up and running.
-    async def settings_change(key: str, value: str) -> bool:
+    async def settings_change(
+        key: str,
+        value: str
+
+    ) -> bool:
         print(f'{key}: {value}')
         return True
 
@@ -573,12 +577,14 @@ async def open_vlm_displays(
     async with (
         open_fsp_sidepane(
             linked, {
-                'vlm': {
+                'flows': {
+
+                    # TODO: add support for dynamically changing these
                     'params': {
-                        'price_func': {
-                            'default_value': 'chl3',
-                            # tell target ``Edit`` widget to not allow
-                            # edits for now.
+                        u'\u03BC' + '_type': {'default_value': 'arithmetic'},
+                        'period': {
+                            'default_value': '16',
+                            # make widget un-editable for now.
                             'widget_kwargs': {'readonly': True},
                         },
                     },

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -842,7 +842,11 @@ async def open_vlm_displays(
             tr_pi = chart.overlay_plotitem(
                 'trade_rates',
                 index=1,  # place axis on inside (nearest to chart)
-                axis_title='tr(16) ',
+
+                # TODO: dynamically update period (and thus this axis?)
+                # title from user input.
+                axis_title='clears/P',
+
                 axis_side='left',
                 axis_kwargs={
                     'typical_max_str': ' 10.0 M ',

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -841,7 +841,6 @@ async def open_vlm_displays(
             ####################
             tr_pi = chart.overlay_plotitem(
                 'trade_rates',
-                index=1,  # place axis on inside (nearest to chart)
 
                 # TODO: dynamically update period (and thus this axis?)
                 # title from user input.

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -632,6 +632,7 @@ async def open_vlm_displays(
 
             mx = 0
             for name in names:
+
                 mxmn = chart.maxmin(name=name)
                 if mxmn:
                     ymax = mxmn[1]
@@ -640,7 +641,7 @@ async def open_vlm_displays(
 
             return 0, mx
 
-        chart.view._maxmin = partial(maxmin, names=['volume'])
+        chart.view.maxmin = partial(maxmin, names=['volume'])
 
         # TODO: fix the x-axis label issue where if you put
         # the axis on the left it's totally not lined up...
@@ -812,6 +813,7 @@ async def open_vlm_displays(
                 flow_rates,
                 {  # fsp engine conf
                     'func_name': 'flow_rates',
+                    'zero_on_step': True,
                 },
                 # loglevel,
             )
@@ -844,13 +846,13 @@ async def open_vlm_displays(
                 },
 
             )
-
             # add custom auto range handler
-            tr_pi.vb._maxmin = partial(
+            tr_pi.vb.maxmin = partial(
                 maxmin,
                 # keep both regular and dark vlm in view
                 names=trade_rate_fields,
             )
+
             chart_curves(
                 trade_rate_fields,
                 tr_pi,

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -421,6 +421,14 @@ class ChartView(ViewBox):
         if self._maxmin is None:
             self._maxmin = chart.maxmin
 
+    @property
+    def maxmin(self) -> Callable:
+        return self._maxmin
+
+    @maxmin.setter
+    def maxmin(self, callback: Callable) -> None:
+        self._maxmin = callback
+
     def wheelEvent(
         self,
         ev,
@@ -678,6 +686,7 @@ class ChartView(ViewBox):
         # flag to prevent triggering sibling charts from the same linked
         # set from recursion errors.
         autoscale_linked_plots: bool = True,
+        name: Optional[str] = None,
         # autoscale_overlays: bool = False,
 
     ) -> None:
@@ -735,6 +744,7 @@ class ChartView(ViewBox):
                         )
 
         if set_range:
+
             yrange = self._maxmin()
             if yrange is None:
                 return

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -731,7 +731,11 @@ class ChartView(ViewBox):
                         )
 
         if set_range:
-            ylow, yhigh = self._maxmin()
+            yrange =  self._maxmin()
+            if yrange is None:
+                return
+
+            ylow, yhigh = yrange
 
             # view margins: stay within a % of the "true range"
             diff = yhigh - ylow

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -342,7 +342,7 @@ class ChartView(ViewBox):
     wheelEventRelay = QtCore.Signal(object, object, object)
 
     event_relay_source: 'Optional[ViewBox]' = None
-    relays: dict[str, Signal] = {}
+    relays: dict[str, QtCore.Signal] = {}
 
     def __init__(
         self,
@@ -474,7 +474,11 @@ class ChartView(ViewBox):
             # lastPos = ev.lastPos()
             # dif = pos - lastPos
             # dif = dif * -1
-            center = Point(fn.invertQTransform(self.childGroup.transform()).map(ev.pos()))
+            center = Point(
+                fn.invertQTransform(
+                    self.childGroup.transform()
+                ).map(ev.pos())
+            )
             # scale_y = 1.3 ** (center.y() * -1 / 20)
             self.scaleBy(s, center)
 
@@ -674,7 +678,7 @@ class ChartView(ViewBox):
         # flag to prevent triggering sibling charts from the same linked
         # set from recursion errors.
         autoscale_linked_plots: bool = True,
-        autoscale_overlays: bool = False,
+        # autoscale_overlays: bool = False,
 
     ) -> None:
         '''
@@ -731,7 +735,7 @@ class ChartView(ViewBox):
                         )
 
         if set_range:
-            yrange =  self._maxmin()
+            yrange = self._maxmin()
             if yrange is None:
                 return
 

--- a/piker/ui/_overlay.py
+++ b/piker/ui/_overlay.py
@@ -508,7 +508,7 @@ class PlotItemOverlay:
 
     ) -> None:
 
-        index = index or 0
+        index = index or len(self.overlays)
         root = self.root_plotitem
         # layout: QGraphicsGridLayout = root.layout
         self.overlays.insert(index, plotitem)

--- a/piker/ui/_overlay.py
+++ b/piker/ui/_overlay.py
@@ -103,11 +103,6 @@ class ComposedGridLayout:
             dict[str, AxisItem],
         ] = {}
 
-        self._axes2pi: dict[
-            AxisItem,
-            dict[str, PlotItem],
-        ] = {}
-
         # TODO: better name?
         # construct surrounding layouts for placing outer axes and
         # their legends and title labels.
@@ -158,8 +153,8 @@ class ComposedGridLayout:
         for name, axis_info in plotitem.axes.items():
             axis = axis_info['item']
             # register this plot's (maybe re-placed) axes for lookup.
-            self._pi2axes.setdefault(index, {})[name] = axis
-            self._axes2pi.setdefault(index, {})[name] = plotitem
+            # print(f'inserting {name}:{axis} to index {index}')
+            self._pi2axes.setdefault(name, {})[index] = axis
 
         # enter plot into list for index tracking
         self.items.insert(index, plotitem)
@@ -213,11 +208,12 @@ class ComposedGridLayout:
 
             # invert insert index for layouts which are
             # not-left-to-right, top-to-bottom insert oriented
+            insert_index = index
             if name in ('top', 'left'):
-                index = min(len(axes) - index, 0)
-                assert index >= 0
+                insert_index = min(len(axes) - index, 0)
+                assert insert_index >= 0
 
-            linlayout.insertItem(index, axis)
+            linlayout.insertItem(insert_index, axis)
             axes.insert(index, axis)
 
         self._register_item(index, plotitem)
@@ -243,13 +239,15 @@ class ComposedGridLayout:
         plot: PlotItem,
         name: str,
 
-    ) -> AxisItem:
+    ) -> Optional[AxisItem]:
         '''
-        Retrieve the named axis for overlayed ``plot``.
+        Retrieve the named axis for overlayed ``plot`` or ``None``
+        if axis for that name is not shown.
 
         '''
         index = self.items.index(plot)
-        return self._pi2axes[index][name]
+        named = self._pi2axes[name]
+        return named.get(index)
 
     def pop(
         self,
@@ -341,7 +339,7 @@ def mk_relay_method(
             # halt/short circuit the graphicscene loop). Further the
             # surrounding handler for this signal must be allowed to execute
             # and get processed by **this consumer**.
-            print(f'{vb.name} rx relayed from {relayed_from.name}')
+            # print(f'{vb.name} rx relayed from {relayed_from.name}')
             ev.ignore()
 
             return slot(
@@ -351,7 +349,7 @@ def mk_relay_method(
             )
 
         if axis is not None:
-            print(f'{vb.name} handling axis event:\n{str(ev)}')
+            # print(f'{vb.name} handling axis event:\n{str(ev)}')
             ev.accept()
             return slot(
                 vb,
@@ -490,7 +488,6 @@ class PlotItemOverlay:
         vb.setZValue(1000)  # XXX: critical for scene layering/relaying
 
         self.overlays: list[PlotItem] = []
-        from piker.ui._overlay import ComposedGridLayout
         self.layout = ComposedGridLayout(
             root_plotitem,
             root_plotitem.layout,
@@ -612,6 +609,26 @@ class PlotItemOverlay:
 
         '''
         return self.layout.get_axis(plot, name)
+
+    def get_axes(
+        self,
+        name: str,
+
+    ) -> list[AxisItem]:
+        '''
+        Retrieve all axes for all plots with ``name: str``.
+
+        If a particular overlay doesn't have a displayed named axis
+        then it is not delivered in the returned ``list``.
+
+        '''
+        axes = []
+        for plot in self.overlays:
+            axis = self.layout.get_axis(plot, name)
+            if axis:
+                axes.append(axis)
+
+        return axes
 
     # TODO: i guess we need this if you want to detach existing plots
     # dynamically? XXX: untested as of now.

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -433,9 +433,12 @@ class OrderMode:
             [
                 'notify-send',
                 '-u', 'normal',
-                '-t', '10000',
+                '-t', '1616',
                 'piker',
-                f'alert: {msg}',
+
+                # TODO: add in standard fill/exec info that maybe we
+                # pack in a broker independent way?
+                f'{msg["resp"]}: {msg["trigger_price"]}',
             ],
         )
         log.runtime(result)
@@ -666,7 +669,7 @@ async def open_order_mode(
         )
         # vbox.setAlignment(feed_label, Qt.AlignBottom)
         # vbox.setAlignment(Qt.AlignBottom)
-        blank_h = chart.height() - (
+        _ = chart.height() - (
             form.height() +
             form.fill_bar.height()
             # feed_label.height()


### PR DESCRIPTION
WIP displaying overlayed "flow rates" on top of our volume fsp subchart 😎 

Basically the idea here is to plot measure flow in windowed metric terms to give a view into HFT activity as well as compare rates across instruments/markets.

Currently we're displaying the values provided verbatim by IB [ticks `294` & `295`](https://interactivebrokers.github.io/tws-api/tick_types.html) which afaik are also available to be used in their [advanced scanner](https://www1.interactivebrokers.com/en/software/tws/usersguidebook/technicalanalytics/market_scanner_types.htm) and its [API accessible params](https://interactivebrokers.github.io/tws-api/scanner_parameters.html).

We're currently accessing these ticks via the pre-packing which `ib_insync` does in their [`Ticker` type](https://ib-insync.readthedocs.io/api.html#ib_insync.ticker.Ticker.tradeRate).

For reference on what each metrics is onstensibly measuring:
- *Top Trade Rate*:  Contracts with the highest number of trades in the past 60 seconds (regardless of the sizes of those trades). Displays the trades/minute field.
- *Top Volume Rate*:  The top volume rate per minute
- both of these `ib` provided values appear to only update every 25s from my eye-balling of the curves.

---
TODO:
- [x] our own real-time, by bars period version of both of these rates
  - ~[ ] a `period:` control on the side pane? or can we wait for a next PR for this?~ -> #279
- [x] a $vlm version (though not sure that shows anything more useful?
- [ ] figure out how much more useful *trade* rates vs. vlm is at detecting HFT activity
- ~[ ] a legend which makes it more clear which curve is which since the vlm subchart is getting a little full now 😂~ -> #279