### PR TITLE
Async hist loading

### DIFF
--- a/piker/__init__.py
+++ b/piker/__init__.py
@@ -18,10 +18,3 @@
 piker: trading gear for hackers.
 
 """
-import msgpack  # noqa
-
-# TODO: remove this now right?
-import msgpack_numpy
-
-# patch msgpack for numpy arrays
-msgpack_numpy.patch()

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -386,7 +386,6 @@ async def stream_quotes(
 
     send_chan: trio.abc.SendChannel,
     symbols: List[str],
-    shm: ShmArray,
     feed_is_live: trio.Event,
     loglevel: str = None,
 

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -517,11 +517,11 @@ class Client:
         contract, ticker, details = await self.get_sym_details(symbol)
 
         # ensure a last price gets filled in before we deliver quote
-        for _ in range(2):
+        for _ in range(1):
             if isnan(ticker.last):
+                await asyncio.sleep(0.1)
                 log.warning(f'Quote for {symbol} timed out: market is closed?')
                 ticker = await ticker.updateEvent
-                await asyncio.sleep(0.1)
             else:
                 log.info(f'Got first quote for {symbol}')
                 break
@@ -1201,12 +1201,13 @@ async def backfill_bars(
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:
-    """Fill historical bars into shared mem / storage afap.
+    '''
+    Fill historical bars into shared mem / storage afap.
 
     TODO: avoid pacing constraints:
     https://github.com/pikers/piker/issues/128
 
-    """
+    '''
     if platform.system() == 'Windows':
         log.warning(
             'Decreasing history query count to 4 since, windows...')
@@ -1411,7 +1412,6 @@ async def stream_quotes(
 
     send_chan: trio.abc.SendChannel,
     symbols: list[str],
-    shm: ShmArray,
     feed_is_live: trio.Event,
     loglevel: str = None,
 

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -406,7 +406,6 @@ async def stream_quotes(
 
     send_chan: trio.abc.SendChannel,
     symbols: List[str],
-    shm: ShmArray,
     feed_is_live: trio.Event,
     loglevel: str = None,
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -59,6 +59,19 @@ tf_in_1m = {
 }
 
 
+def mk_fqsn(
+    provider: str,
+    symbol: str,
+
+) -> str:
+    '''
+    Generate a "fully qualified symbol name" which is
+    a reverse-hierarchical cross broker/provider symbol
+
+    '''
+    return '.'.join([symbol, provider]).lower()
+
+
 def float_digits(
     value: float,
 ) -> int:
@@ -118,6 +131,12 @@ class Symbol(BaseModel):
             self.key,
         )
 
+    def iterfqsns(self) -> list[str]:
+        return [
+            mk_fqsn(self.key, broker)
+            for broker in self.broker_info.keys()
+        ]
+
 
 @validate_arguments
 def mk_symbol(
@@ -129,7 +148,8 @@ def mk_symbol(
     broker_info: dict[str, Any] = {},
 
 ) -> Symbol:
-    '''Create and return an instrument description for the
+    '''
+    Create and return an instrument description for the
     "symbol" named as ``key``.
 
     '''

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -17,7 +17,7 @@
 """
 numpy data source coversion helpers.
 """
-from typing import Dict, Any, List
+from typing import Any
 import decimal
 
 import numpy as np
@@ -103,13 +103,13 @@ class Symbol(BaseModel):
     lot_tick_size: float  # "volume" precision as min step value
     tick_size_digits: int
     lot_size_digits: int
-    broker_info: Dict[str, Dict[str, Any]] = {}
+    broker_info: dict[str, dict[str, Any]] = {}
 
     # specifies a "class" of financial instrument
     # ex. stock, futer, option, bond etc.
 
     @property
-    def brokers(self) -> List[str]:
+    def brokers(self) -> list[str]:
         return list(self.broker_info.keys())
 
     def nearest_tick(self, value: float) -> float:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -818,11 +818,18 @@ class ChartPlotWidget(pg.PlotWidget):
     def default_view(
         self,
         index: int = -1,
-    ) -> None:
-        """Set the view box to the "default" startup view of the scene.
 
-        """
-        xlast = self._arrays[self.name][index]['index']
+    ) -> None:
+        '''
+        Set the view box to the "default" startup view of the scene.
+
+        '''
+        try:
+            xlast = self._arrays[self.name][index]['index']
+        except IndexError:
+            log.warning(f'array for {self.name} not loaded yet?')
+            return
+
         begin = xlast - _bars_to_left_in_follow_mode
         end = xlast + _bars_from_right_in_follow_mode
 
@@ -840,6 +847,8 @@ class ChartPlotWidget(pg.PlotWidget):
 
     def increment_view(
         self,
+        steps: int = 1,
+
     ) -> None:
         """
         Increment the data view one step to the right thus "following"
@@ -848,8 +857,8 @@ class ChartPlotWidget(pg.PlotWidget):
         """
         l, r = self.view_range()
         self.view.setXRange(
-            min=l + 1,
-            max=r + 1,
+            min=l + steps,
+            max=r + steps,
 
             # TODO: holy shit, wtf dude... why tf would this not be 0 by
             # default... speechless.
@@ -858,7 +867,6 @@ class ChartPlotWidget(pg.PlotWidget):
 
     def draw_ohlc(
         self,
-
         name: str,
         data: np.ndarray,
 

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -108,7 +108,6 @@ class FastAppendCurve(pg.PlotCurveItem):
     path redraw.
 
     '''
-
     def __init__(
         self,
         *args,
@@ -167,7 +166,13 @@ class FastAppendCurve(pg.PlotCurveItem):
         y: np.ndarray,
 
     ) -> QtGui.QPainterPath:
+        '''
+        Update curve from input 2-d data.
 
+        Compare with a cached "x-range" state and (pre/a)ppend based on
+        a length diff.
+
+        '''
         profiler = pg.debug.Profiler(disabled=not pg_profile_enabled())
         flip_cache = False
 
@@ -316,12 +321,19 @@ class FastAppendCurve(pg.PlotCurveItem):
             self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
 
     def disable_cache(self) -> None:
+        '''
+        Disable the use of the pixel coordinate cache and trigger a geo event.
+
+        '''
         # XXX: pretty annoying but, without this there's little
         # artefacts on the append updates to the curve...
         self.setCacheMode(QtWidgets.QGraphicsItem.NoCache)
         self.prepareGeometryChange()
 
     def boundingRect(self):
+        '''
+        Compute and then cache our rect.
+        '''
         if self.path is None:
             return QtGui.QPainterPath().boundingRect()
         else:
@@ -331,9 +343,10 @@ class FastAppendCurve(pg.PlotCurveItem):
             return self._br()
 
     def _br(self):
-        """Post init ``.boundingRect()```.
+        '''
+        Post init ``.boundingRect()```.
 
-        """
+        '''
         hb = self.path.controlPointRect()
         hb_size = hb.size()
         # print(f'hb_size: {hb_size}')

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -93,6 +93,7 @@ def chart_maxmin(
     if not in_view.size:
         log.warning('Resetting chart to data')
         chart.default_view()
+        return (last_bars_range, 0, 0, 0)
 
     mx, mn = np.nanmax(in_view['high']), np.nanmin(in_view['low'])
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -131,6 +131,7 @@ async def graphics_update_loop(
     #   of copying it from last bar's close
     # - 1-5 sec bar lookback-autocorrection like tws does?
     #   (would require a background history checker task)
+    display_rate = linked.godwidget.window.current_screen().refreshRate()
 
     chart = linked.chart
 
@@ -215,7 +216,8 @@ async def graphics_update_loop(
 
             # in the absolute worst case we shouldn't see more then
             # twice the expected throttle rate right!?
-            and quote_rate >= _quote_throttle_rate * 1.5
+            # and quote_rate >= _quote_throttle_rate * 2
+            and quote_rate >= display_rate
         ):
             log.warning(f'High quote rate {symbol.key}: {quote_rate}')
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -550,7 +550,8 @@ async def display_symbol_data(
         # load in symbol's ohlc data
         godwidget.window.setWindowTitle(
             f'{symbol.key}@{symbol.brokers} '
-            f'tick:{symbol.tick_size}'
+            f'tick:{symbol.tick_size} '
+            f'step:1s '
         )
 
         linkedsplits = godwidget.linkedsplits

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -813,7 +813,7 @@ async def open_vlm_displays(
                 flow_rates,
                 {  # fsp engine conf
                     'func_name': 'flow_rates',
-                    'zero_on_step': True,
+                    'zero_on_step': False,
                 },
                 # loglevel,
             )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         'numpy',
         'numba',
         'pandas',
-        'msgpack-numpy',
 
         # UI
         'PyQt5',


### PR DESCRIPTION
Re-work of the `piker.data.feed` machinery to do async loading of both real-time and historical data for faster chart startup and a better setup to get the work from #93 landed.

Part of this work discovered the unexpected behavior that is https://github.com/python-trio/trio/issues/2258.

Included are a bunch of other changes summarized by "topic":

---
#### miscellaneous fixups
- docs strings added to curve graphics code
- changed display loop throttle warnings to only fire on >= display rate cycles
- dropped stale deps on `msgpack` and `msgpack-numpy`
- place the sample period (aka "time frame") in the window header
- add an `open_piker_runtime()` to make it easy to write a client that uses all the `tractor` apis correctly

---
#### data feed rework
- drop passing `ShmArray`s to the backend `stream_quotes()` endpoints since they don't manually write themselves
- allow using `open_feed()` without requiring a real-time quote stream (eg. just for accessing shm / history)
- drop the dedicated task to update graphics on sample period steps, instead just let the display loop detect new samples and update on the next event
- expect fsps to request the sample period for incrementing shm history based on calculating the step size from source data
- don't crash (just warn) on a double remove of a sampled fee subscription

---
#### misc graphics
- make `ChartPlotWidget.increment_view()` take a `steps: int`
- don't zero clearing rate fsp curves on a new sample step
- fix the display loop's `mamin()` range calcer to not crash on no-data-in-view