### PR TITLE
"Big data" lines

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -35,10 +35,10 @@ log = get_logger(__name__)
 
 _root_dname = 'pikerd'
 
-_registry_addr = ('127.0.0.1', 6116)
+_registry_addr = ('127.0.0.1', 1616)
 _tractor_kwargs: dict[str, Any] = {
     # use a different registry addr then tractor's default
-    'arbiter_addr':  _registry_addr
+    'arbiter_addr': _registry_addr
 }
 _root_modules = [
     __name__,
@@ -91,14 +91,18 @@ class Services(BaseModel):
                     log.info(
                         f'`pikerd` service {name} started with value {first}'
                     )
-                    # wait on any context's return value
-                    ctx_res = await ctx.result()
-
-                # wait on any error from the sub-actor
-                # NOTE: this will block indefinitely until cancelled
-                # either by error from the target context function or by
-                # being cancelled here by the surrounding cancel scope
-                return (await portal.result(), ctx_res)
+                    try:
+                        # wait on any context's return value
+                        ctx_res = await ctx.result()
+                    except tractor.ContextCancelled:
+                        return await self.cancel_service(name)
+                    else:
+                        # wait on any error from the sub-actor
+                        # NOTE: this will block indefinitely until
+                        # cancelled either by error from the target
+                        # context function or by being cancelled here by
+                        # the surrounding cancel scope
+                        return (await portal.result(), ctx_res)
 
         cs, first = await self.service_n.start(open_context_in_task)
 
@@ -110,14 +114,17 @@ class Services(BaseModel):
 
     # TODO: per service cancellation by scope, we aren't using this
     # anywhere right?
-    # async def cancel_service(
-    #     self,
-    #     name: str,
-    # ) -> Any:
-    #     log.info(f'Cancelling `pikerd` service {name}')
-    #     cs, portal = self.service_tasks[name]
-    #     cs.cancel()
-    #     return await portal.cancel_actor()
+    async def cancel_service(
+        self,
+        name: str,
+    ) -> Any:
+        log.info(f'Cancelling `pikerd` service {name}')
+        cs, portal = self.service_tasks[name]
+        # XXX: not entirely sure why this is required,
+        # and should probably be better fine tuned in
+        # ``tractor``?
+        cs.cancel()
+        return await portal.cancel_actor()
 
 
 _services: Optional[Services] = None
@@ -372,6 +379,7 @@ async def maybe_spawn_daemon(
         async with tractor.wait_for_actor(service_name) as portal:
             lock.release()
             yield portal
+            await portal.cancel_actor()
 
 
 async def spawn_brokerd(

--- a/piker/_profile.py
+++ b/piker/_profile.py
@@ -24,6 +24,7 @@ from functools import wraps
 # NOTE: you can pass a flag to enable this:
 # ``piker chart <args> --profile``.
 _pg_profile: bool = False
+ms_slower_then: float = 10
 
 
 def pg_profile_enabled() -> bool:

--- a/piker/_profile.py
+++ b/piker/_profile.py
@@ -24,7 +24,7 @@ from functools import wraps
 # NOTE: you can pass a flag to enable this:
 # ``piker chart <args> --profile``.
 _pg_profile: bool = False
-ms_slower_then: float = 10
+ms_slower_then: float = 0
 
 
 def pg_profile_enabled() -> bool:

--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -284,6 +284,14 @@ class Allocator(BaseModel):
         return round(prop * self.slots)
 
 
+_derivs = (
+    'future',
+    'continuous_future',
+    'option',
+    'futures_option',
+)
+
+
 def mk_allocator(
 
     symbol: Symbol,
@@ -322,12 +330,7 @@ def mk_allocator(
 
     # specific configs by asset class / type
 
-    if asset_type in (
-        'future',
-        'continuous_future',
-        'option',
-        'futures_option',
-    ):
+    if asset_type in _derivs:
         # since it's harder to know how currency "applies" in this case
         # given leverage properties
         alloc.size_unit = '# units'
@@ -350,7 +353,7 @@ def mk_allocator(
         if startup_size > alloc.units_limit:
             alloc.units_limit = startup_size
 
-            if asset_type in ('future', 'option', 'futures_option'):
+            if asset_type in _derivs:
                 alloc.slots = alloc.units_limit
 
     return alloc

--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -178,7 +178,9 @@ class Allocator(BaseModel):
             l_sub_pp = (self.currency_limit - live_cost_basis) / price
 
         else:
-            raise ValueError(f"Not valid size unit '{size}'")
+            raise ValueError(
+                f"Not valid size unit '{size_unit}'"
+            )
 
         # an entry (adding-to or starting a pp)
         if (
@@ -290,7 +292,7 @@ def mk_allocator(
     # default allocation settings
     defaults: dict[str, float] = {
         'account': None,  # select paper by default
-        'size_unit': 'currency', #_size_units['currency'],
+        'size_unit': 'currency',
         'units_limit': 400,
         'currency_limit': 5e3,
         'slots': 4,
@@ -318,11 +320,14 @@ def mk_allocator(
 
     asset_type = symbol.type_key
 
-
     # specific configs by asset class / type
 
-    if asset_type in ('future', 'option', 'futures_option'):
-
+    if asset_type in (
+        'future',
+        'continuous_future',
+        'option',
+        'futures_option',
+    ):
         # since it's harder to know how currency "applies" in this case
         # given leverage properties
         alloc.size_unit = '# units'

--- a/piker/ui/_anchors.py
+++ b/piker/ui/_anchors.py
@@ -29,34 +29,6 @@ if TYPE_CHECKING:
     from ._label import Label
 
 
-def marker_right_points(
-    chart: ChartPlotWidget,  # noqa
-    marker_size: int = 20,
-
-) -> (float, float, float):
-    '''
-    Return x-dimension, y-axis-aware, level-line marker oriented scene
-    values.
-
-    X values correspond to set the end of a level line, end of
-    a paried level line marker, and the right most side of the "right"
-    axis respectively.
-
-    '''
-    # TODO: compute some sensible maximum value here
-    # and use a humanized scheme to limit to that length.
-    l1_len = chart._max_l1_line_len
-    ryaxis = chart.getAxis('right')
-
-    r_axis_x = ryaxis.pos().x()
-    up_to_l1_sc = r_axis_x - l1_len - 10
-
-    marker_right = up_to_l1_sc - (1.375 * 2 * marker_size)
-    line_end = marker_right - (6/16 * marker_size)
-
-    return line_end, marker_right, r_axis_x
-
-
 def vbr_left(
     label: Label,
 

--- a/piker/ui/_anchors.py
+++ b/piker/ui/_anchors.py
@@ -25,7 +25,6 @@ from PyQt5.QtCore import QPointF
 from PyQt5.QtWidgets import QGraphicsPathItem
 
 if TYPE_CHECKING:
-    from ._axes import PriceAxis
     from ._chart import ChartPlotWidget
     from ._label import Label
 

--- a/piker/ui/_annotate.py
+++ b/piker/ui/_annotate.py
@@ -26,8 +26,6 @@ from PyQt5.QtWidgets import QGraphicsPathItem
 from pyqtgraph import Point, functions as fn, Color
 import numpy as np
 
-from ._anchors import marker_right_points
-
 
 def mk_marker_path(
 
@@ -116,7 +114,7 @@ class LevelMarker(QGraphicsPathItem):
 
         self.get_level = get_level
         self._on_paint = on_paint
-        self.scene_x = lambda: marker_right_points(chart)[1]
+        self.scene_x = lambda: chart.marker_right_points()[1]
         self.level: float = 0
         self.keep_in_view = keep_in_view
 
@@ -169,7 +167,7 @@ class LevelMarker(QGraphicsPathItem):
         vr = view.state['viewRange']
         ymn, ymx = vr[1]
 
-        # _, marker_right, _ = marker_right_points(line._chart)
+        # _, marker_right, _ = line._chart.marker_right_points()
         x = self.scene_x()
 
         if self.style == '>|':  # short style, points "down-to" line

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1221,7 +1221,7 @@ class ChartPlotWidget(pg.PlotWidget):
 
         # TODO: we could do it this way as well no?
         # to_draw = array[lbar - ifirst:(rbar - ifirst) + 1]
-        in_view = array[lbar_i: rbar_i]
+        in_view = array[lbar_i: rbar_i + 1]
 
         if not in_view.size:
             return graphics

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1,5 +1,5 @@
 # piker: trading gear for hackers
-# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+# Copyright (C) Tyler Goodlet (in stewardship for pikers)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -22,7 +22,11 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from PyQt5 import QtCore, QtWidgets
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import (
+    Qt,
+    QLineF,
+    QPointF,
+)
 from PyQt5.QtWidgets import (
     QFrame,
     QWidget,
@@ -824,13 +828,23 @@ class ChartPlotWidget(pg.PlotWidget):
         return int(vr.left()), int(vr.right())
 
     def bars_range(self) -> tuple[int, int, int, int]:
-        """Return a range tuple for the bars present in view.
-        """
+        '''
+        Return a range tuple for the bars present in view.
+
+        '''
         l, r = self.view_range()
         array = self._arrays[self.name]
         lbar = max(l, array[0]['index'])
         rbar = min(r, array[-1]['index'])
         return l, lbar, rbar, r
+
+    def curve_width_pxs(
+        self,
+    ) -> float:
+        _, lbar, rbar, _ = self.bars_range()
+        return self.view.mapViewToDevice(
+            QLineF(lbar, 0, rbar, 0)
+        ).length()
 
     def default_view(
         self,
@@ -864,7 +878,7 @@ class ChartPlotWidget(pg.PlotWidget):
         self.view.maybe_downsample_graphics()
         try:
             self.linked.graphics_cycle()
-        except:
+        except IndexError:
             pass
 
     def increment_view(

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -915,6 +915,7 @@ class ChartPlotWidget(pg.PlotWidget):
         if (
             rbar < 0
             or l < xfirst
+            or (rbar - lbar) < 6
         ):
             # set fixed bars count on screen that approx includes as
             # many bars as possible before a downsample line is shown.

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -240,6 +240,12 @@ class GodWidget(QWidget):
             # resume feeds *after* rendering chart view asap
             chart.resume_all_feeds()
 
+            # TODO: we need a check to see if the chart
+            # last had the xlast in view, if so then shift so it's
+            # still in view, if the user was viewing history then
+            # do nothing yah?
+            chart.default_view()
+
         self.linkedsplits = linkedsplits
         symbol = linkedsplits.symbol
         if symbol is not None:
@@ -904,7 +910,7 @@ class ChartPlotWidget(pg.PlotWidget):
         brange = l, lbar, rbar, r = self.bars_range()
 
         marker_pos, l1_len = self.pre_l1_xs()
-        end = xlast + l1_len
+        end = xlast + l1_len + 1
 
         if (
             rbar < 0

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -958,6 +958,7 @@ class ChartPlotWidget(pg.PlotWidget):
     def increment_view(
         self,
         steps: int = 1,
+        vb: Optional[ChartView] = None,
 
     ) -> None:
         """
@@ -966,7 +967,8 @@ class ChartPlotWidget(pg.PlotWidget):
 
         """
         l, r = self.view_range()
-        self.view.setXRange(
+        view = vb or self.view
+        view.setXRange(
             min=l + steps,
             max=r + steps,
 
@@ -1043,6 +1045,7 @@ class ChartPlotWidget(pg.PlotWidget):
         )
         pi.hideButtons()
 
+        # cv.enable_auto_yrange(self.view)
         cv.enable_auto_yrange()
 
         # compose this new plot's graphics with the current chart's
@@ -1187,6 +1190,9 @@ class ChartPlotWidget(pg.PlotWidget):
         array: Optional[np.ndarray] = None,
         array_key: Optional[str] = None,
 
+        use_vr: bool = True,
+        render: bool = True,
+
         **kwargs,
 
     ) -> pg.GraphicsObject:
@@ -1223,14 +1229,17 @@ class ChartPlotWidget(pg.PlotWidget):
         # to_draw = array[lbar - ifirst:(rbar - ifirst) + 1]
         in_view = array[lbar_i: rbar_i + 1]
 
-        if not in_view.size:
+        if (
+            not in_view.size
+            or not render
+        ):
             return graphics
 
         if isinstance(graphics, BarItems):
             graphics.update_from_array(
                 array,
                 in_view,
-                view_range=(lbar_i, rbar_i),
+                view_range=(lbar_i, rbar_i) if use_vr else None,
 
                 **kwargs,
             )
@@ -1242,7 +1251,7 @@ class ChartPlotWidget(pg.PlotWidget):
 
                 x_iv=in_view['index'],
                 y_iv=in_view[data_key],
-                view_range=(lbar_i, rbar_i),
+                view_range=(lbar_i, rbar_i) if use_vr else None,
 
                 **kwargs
             )

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -155,7 +155,7 @@ def downsample(
 
 def ohlc_flatten(
     ohlc: np.ndarray,
-    use_mxmn: bool = False,
+    use_mxmn: bool = True,
 
 ) -> tuple[np.ndarray, np.ndarray]:
     '''
@@ -167,7 +167,11 @@ def ohlc_flatten(
     index = ohlc['index']
 
     if use_mxmn:
+        # traces a line optimally over highs to lows
+        # using numba. NOTE: pretty sure this is faster
+        # and looks about the same as the below output.
         flat, x = hl2mxmn(ohlc)
+
     else:
         flat = rfn.structured_to_unstructured(
             ohlc[['open', 'high', 'low', 'close']]

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -106,53 +106,6 @@ def trace_hl(
     return out
 
 
-def downsample(
-    x: np.ndarray,
-    y: np.ndarray,
-    bins: int = 2,
-
-    method: str = 'peak',
-
-    **kwargs,
-
-) -> tuple[np.ndarray, np.ndarray]:
-    '''
-    Downsample x/y data for lesser curve graphics gen.
-
-    The "peak" method is originally copied verbatim from
-    ``pyqtgraph.PlotDataItem.getDisplayDataset()`` which gets
-    all credit, though we will likely drop this in favor of the M4
-    algo below.
-
-    '''
-    # py3.10 syntax
-    match method:
-        case 'peak':
-            if bins < 2:
-                log.warning('No downsampling taking place?')
-
-            ds = bins
-            n = len(x) // ds
-            x1 = np.empty((n, 2))
-
-            # start of x-values; try to select a somewhat centered point
-            stx = ds // 2
-            x1[:] = x[stx:stx+n*ds:ds, np.newaxis]
-            x = x1.reshape(n*2)
-
-            y1 = np.empty((n, 2))
-            y2 = y[:n*ds].reshape((n, ds))
-
-            y1[:, 0] = y2.max(axis=1)
-            y1[:, 1] = y2.min(axis=1)
-            y = y1.reshape(n*2)
-
-            return x, y
-
-        case 'm4':
-            return ds_m4(x, y, kwargs['px_width'])
-
-
 def ohlc_flatten(
     ohlc: np.ndarray,
     use_mxmn: bool = True,

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -207,7 +207,7 @@ def ohlc_to_m4_line(
                 # NOTE: found that a 16x px width brought greater
                 # detail, likely due to dpi scaling?
                 # px_width=px_width * 16,
-                64 / (1 + math.log(uppx, 2)),
+                128 / (1 + math.log(uppx, 2)),
                 1
             )
         )

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -260,12 +260,13 @@ def ds_m4(
     if log_scale:
         assert uppx, 'You must provide a `uppx` value to use log scaling!'
 
+        # scaler = 2**7 / (1 + math.log(uppx, 2))
         scaler = round(
             max(
                 # NOTE: found that a 16x px width brought greater
                 # detail, likely due to dpi scaling?
                 # px_width=px_width * 16,
-                2**6 / (1 + math.log(uppx, 2)),
+                2**7 / (1 + math.log(uppx, 2)),
                 1
             )
         )

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -185,14 +185,19 @@ def ohlc_to_m4_line(
     ohlc: np.ndarray,
     px_width: int,
 
+    downsample: bool = False,
     uppx: Optional[float] = None,
+    pretrace: bool = False,
 
 ) -> tuple[np.ndarray, np.ndarray]:
     '''
     Convert an OHLC struct-array to a m4 downsampled 1-d array.
 
     '''
-    xpts, flat = ohlc_flatten(ohlc)
+    xpts, flat = ohlc_flatten(
+        ohlc,
+        use_mxmn=pretrace,
+    )
 
     if uppx:
         # optionally log-scale down the "supposed pxs on screen"
@@ -208,15 +213,19 @@ def ohlc_to_m4_line(
         )
         px_width *= scaler
 
-    bins, x, y = ds_m4(
-        xpts,
-        flat,
-        px_width=px_width,
-    )
-    x = np.broadcast_to(x[:, None], y.shape)
-    x = (x + np.array([-0.43, 0, 0, 0.43])).flatten()
-    y = y.flatten()
-    return x, y
+    if downsample:
+        bins, x, y = ds_m4(
+            xpts,
+            flat,
+            px_width=px_width,
+        )
+        x = np.broadcast_to(x[:, None], y.shape)
+        x = (x + np.array([-0.43, 0, 0, 0.43])).flatten()
+        y = y.flatten()
+
+        return x, y
+    else:
+        return xpts, flat
 
 
 def ds_m4(

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -95,22 +95,24 @@ class LineDot(pg.CurvePoint):
 
     def event(
         self,
-
         ev: QtCore.QEvent,
 
-    ) -> None:
+    ) -> bool:
         if not isinstance(
             ev, QtCore.QDynamicPropertyChangeEvent
         ) or self.curve() is None:
             return False
 
+        # TODO: get rid of this ``.getData()`` and
+        # make a more pythonic api to retreive backing
+        # numpy arrays...
         (x, y) = self.curve().getData()
         index = self.property('index')
         # first = self._plot._arrays['ohlc'][0]['index']
         # first = x[0]
         # i = index - first
         if index:
-            i = index - x[0]
+            i = round(index - x[0])
             if i > 0 and i < len(y):
                 newPos = (index, y[i])
                 QtWidgets.QGraphicsItem.setPos(self, *newPos)
@@ -405,6 +407,7 @@ class Cursor(pg.GraphicsObject):
             slot=self.mouseMoved,
             delay=_debounce_delay,
         )
+
         px_enter = pg.SignalProxy(
             plot.sig_mouse_enter,
             rateLimit=_mouse_rate_limit,

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -408,7 +408,7 @@ class FastAppendCurve(pg.GraphicsObject):
 
                 self._in_ds = False
 
-            elif should_ds:
+            elif should_ds and px_width:
                 x_out, y_out = self.downsample(
                     x_out,
                     y_out,

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -466,9 +466,8 @@ class FastAppendCurve(pg.GraphicsObject):
     ) -> None:
 
         profiler = pg.debug.Profiler(
-            # disabled=False, #not pg_profile_enabled(),
+            disabled=not pg_profile_enabled(),
         )
-        # p.setRenderHint(p.Antialiasing, True)
 
         if (
             self._step_mode
@@ -486,13 +485,14 @@ class FastAppendCurve(pg.GraphicsObject):
             profiler('.drawLine()')
             p.setPen(self._pen)
 
-        # else:
+        path = self.path
         if self._use_poly:
             assert self.poly
             p.drawPolyline(self.poly)
             profiler('.drawPolyline()')
-        else:
-            p.drawPath(self.path)
+
+        elif path:
+            p.drawPath(path)
             profiler('.drawPath()')
 
         # TODO: try out new work from `pyqtgraph` main which should

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -265,6 +265,7 @@ class FastAppendCurve(pg.GraphicsObject):
         y_iv: np.ndarray,
 
         view_range: Optional[tuple[int, int]] = None,
+        profiler: Optional[pg.debug.Profiler] = None,
 
     ) -> QtGui.QPainterPath:
         '''
@@ -274,7 +275,7 @@ class FastAppendCurve(pg.GraphicsObject):
         a length diff.
 
         '''
-        profiler = pg.debug.Profiler(
+        profiler = profiler or pg.debug.Profiler(
             msg=f'FastAppendCurve.update_from_array(): `{self._name}`',
             disabled=not pg_profile_enabled(),
             gt=ms_slower_then,

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -381,7 +381,6 @@ class FastAppendCurve(pg.PlotCurveItem):
         self._mouseShape = None
         self._mouseBounds = None
         self._boundsCache = [None, None]
-        #del self.xData, self.yData, self.xDisp, self.yDisp, self.path
 
         # path reservation aware non-mem de-alloc cleaning
         if self.path:

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -341,7 +341,8 @@ class FastAppendCurve(pg.GraphicsObject):
         # check for downsampling conditions
         if (
             # std m4 downsample conditions
-            uppx_diff >= 2
+            px_width
+            and uppx_diff >= 2
             or uppx_diff <= -2
             or self._step_mode and abs(uppx_diff) >= 2
 
@@ -350,7 +351,7 @@ class FastAppendCurve(pg.GraphicsObject):
                 f'{self._name} sampler change: {self._last_uppx} -> {uppx}'
             )
             self._last_uppx = uppx
-            should_ds = {'px_width': px_width, 'uppx': uppx}
+            should_ds = True
 
         elif (
             uppx <= 2
@@ -410,7 +411,8 @@ class FastAppendCurve(pg.GraphicsObject):
                 x_out, y_out = self.downsample(
                     x_out,
                     y_out,
-                    **should_ds,
+                    px_width,
+                    uppx,
                 )
                 profiler(f'FULL PATH downsample redraw={should_ds}')
                 self._in_ds = True

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -342,9 +342,9 @@ class FastAppendCurve(pg.GraphicsObject):
         if (
             # std m4 downsample conditions
             px_width
-            and uppx_diff >= 2
-            or uppx_diff <= -2
-            or self._step_mode and abs(uppx_diff) >= 2
+            and uppx_diff >= 4
+            or uppx_diff <= -3
+            or self._step_mode and abs(uppx_diff) >= 4
 
         ):
             log.info(

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -376,7 +376,6 @@ class FastAppendCurve(pg.PlotCurveItem):
         self.xData = None  ## raw values
         self.yData = None
         self._renderSegmentList = None
-        # self.path = None
         self.fillPath = None
         self._fillPathList = None
         self._mouseShape = None
@@ -388,6 +387,10 @@ class FastAppendCurve(pg.PlotCurveItem):
         if self.path:
             self.path.clear()
             self._redraw = True
+
+            # XXX: if not trying to leverage `.reserve()` allocs
+            # then you might as well create a new one..
+            # self.path = None
 
     def disable_cache(self) -> None:
         '''

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -299,7 +299,7 @@ def graphics_update_cycle(
     # hopefully XD
 
     profiler = pg.debug.Profiler(
-        disabled=False,  # not pg_profile_enabled(),
+        disabled=True,  # not pg_profile_enabled(),
         delayed=False,
     )
     # unpack multi-referenced components
@@ -396,7 +396,6 @@ def graphics_update_cycle(
             #         f' x: {x}\n'
             #         f' y: {y}\n'
             #     )
-            # breakpoint()
 
         # assert y.size == mxmn.size
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -382,6 +382,7 @@ def graphics_update_cycle(
                 i_diff > 0  # no new sample step
                 and xpx < 4  # chart is zoomed out very far
                 and r >= i_step  # the last datum isn't in view
+                and liv
             )
             or trigger_all
         ):
@@ -399,7 +400,7 @@ def graphics_update_cycle(
             if (
                 (xpx < update_uppx or i_diff > 0)
                 or trigger_all
-                and r >= i_step
+                and liv
             ):
                 # TODO: make it so this doesn't have to be called
                 # once the $vlm is up?
@@ -549,7 +550,10 @@ def graphics_update_cycle(
                     l1.bid_label.fields['level']: l1.bid_label,
                 }.get(price)
 
-                if label is not None:
+                if (
+                    label is not None
+                    # and liv
+                ):
                     label.update_fields(
                         {'level': price, 'size': size}
                     )
@@ -558,19 +562,27 @@ def graphics_update_cycle(
                     # the relevant L1 queue?
                     # label.size -= size
 
-            # elif ticktype in ('ask', 'asize'):
-            elif typ in _tick_groups['asks']:
+            elif (
+                typ in _tick_groups['asks']
+                # TODO: instead we could check if the price is in the
+                # y-view-range?
+                # and liv
+            ):
                 l1.ask_label.update_fields({'level': price, 'size': size})
 
-            # elif ticktype in ('bid', 'bsize'):
-            elif typ in _tick_groups['bids']:
+            elif (
+                typ in _tick_groups['bids']
+                # TODO: instead we could check if the price is in the
+                # y-view-range?
+                # and liv
+            ):
                 l1.bid_label.update_fields({'level': price, 'size': size})
 
         # check for y-range re-size
         if (
             (mx > vars['last_mx']) or (mn < vars['last_mn'])
             and not chart._static_yrange == 'axis'
-            and r > i_step  # the last datum is in view
+            and liv
         ):
             main_vb = chart.view
             if (

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -30,7 +30,6 @@ import numpy as np
 import tractor
 import trio
 import pyqtgraph as pg
-from PyQt5.QtCore import QLineF
 
 from .. import brokers
 from ..data.feed import open_feed
@@ -73,13 +72,20 @@ _tick_groups = {
 }
 
 
+# TODO: delegate this to each `Flow.maxmin()` which includes
+# caching and further we should implement the following stream based
+# approach, likely with ``numba``:
+# https://arxiv.org/abs/cs/0610046
+# https://github.com/lemire/pythonmaxmin
 def chart_maxmin(
     chart: ChartPlotWidget,
     ohlcv_shm: ShmArray,
     vlm_chart: Optional[ChartPlotWidget] = None,
 
 ) -> tuple[
+
     tuple[int, int, int, int],
+
     float,
     float,
     float,
@@ -88,11 +94,6 @@ def chart_maxmin(
     Compute max and min datums "in view" for range limits.
 
     '''
-    # TODO: implement this
-    # https://arxiv.org/abs/cs/0610046
-    # https://github.com/lemire/pythonmaxmin
-
-    # array = chart._arrays[chart.name]
     array = ohlcv_shm.array
     ifirst = array[0]['index']
 
@@ -105,18 +106,23 @@ def chart_maxmin(
         chart.default_view()
         return (last_bars_range, 0, 0, 0)
 
-    mx, mn = np.nanmax(in_view['high']), np.nanmin(in_view['low'])
-
-    # TODO: when we start using line charts, probably want to make
-    # this an overloaded call on our `DataView
-    # sym = chart.name
-    # mx, mn = np.nanmax(in_view[sym]), np.nanmin(in_view[sym])
+    mx, mn = (
+        np.nanmax(in_view['high']),
+        np.nanmin(in_view['low'],)
+    )
 
     mx_vlm_in_view = 0
     if vlm_chart:
-        mx_vlm_in_view = np.max(in_view['volume'])
+        mx_vlm_in_view = np.max(
+            in_view['volume']
+        )
 
-    return last_bars_range, mx, max(mn, 0), mx_vlm_in_view
+    return (
+        last_bars_range,
+        mx,
+        max(mn, 0),  # presuming price can't be negative?
+        mx_vlm_in_view,
+    )
 
 
 @dataclass
@@ -272,8 +278,9 @@ async def graphics_update_loop(
 
     chart.default_view()
 
-    # main loop
+    # main real-time quotes update loop
     async for quotes in stream:
+
         ds.quotes = quotes
         quote_period = time.time() - last_quote
         quote_rate = round(
@@ -311,28 +318,32 @@ def graphics_update_cycle(
     trigger_all: bool = False,  # flag used by prepend history updates
 
 ) -> None:
-
     # TODO: eventually optimize this whole graphics stack with ``numba``
     # hopefully XD
 
+    chart = ds.chart
+
     profiler = pg.debug.Profiler(
+        msg=f'Graphics loop cycle for: `{chart.name}`',
         disabled=True,  # not pg_profile_enabled(),
         gt=1/12 * 1e3,
+        # gt=ms_slower_then,
     )
 
     # unpack multi-referenced components
-    chart = ds.chart
     vlm_chart = ds.vlm_chart
     l1 = ds.l1
-
     ohlcv = ds.ohlcv
     array = ohlcv.array
     vars = ds.vars
     tick_margin = vars['tick_margin']
 
-    update_uppx = 5
+    update_uppx = 6
 
     for sym, quote in ds.quotes.items():
+
+        # compute the first available graphic's x-units-per-pixel
+        xpx = vlm_chart.view.x_uppx()
 
         # NOTE: vlm may be written by the ``brokerd`` backend
         # event though a tick sample is not emitted.
@@ -340,7 +351,7 @@ def graphics_update_cycle(
         # https://github.com/pikers/piker/issues/116
 
         # NOTE: this used to be implemented in a dedicated
-        # "increment tas": ``check_for_new_bars()`` but it doesn't
+        # "increment task": ``check_for_new_bars()`` but it doesn't
         # make sense to do a whole task switch when we can just do
         # this simple index-diff and all the fsp sub-curve graphics
         # are diffed on each draw cycle anyway; so updates to the
@@ -364,60 +375,6 @@ def graphics_update_cycle(
         profiler('maxmin call')
         liv = r > i_step  # the last datum is in view
 
-        # compute the first available graphic's x-units-per-pixel
-        xpx = vlm_chart.view.xs_in_px()
-        # print(f'vlm xpx {xpx}')
-
-        in_view = chart.in_view(ohlcv.array)
-
-        if lbar != rbar:
-            # view box width in pxs
-            w = chart.view.boundingRect().width()
-
-            # TODO: a better way to get this?
-            # i would guess the esiest way is to just
-            # get the ``.boundingRect()`` of the curve
-            # in view but maybe there's something smarter?
-            # Currently we're just mapping the rbar, lbar to
-            # pixels via:
-            cw = chart.view.mapViewToDevice(QLineF(lbar, 0, rbar, 0)).length()
-            # is this faster?
-            # cw = chart.mapFromView(QLineF(lbar, 0 , rbar, 0)).length()
-
-            profiler(
-                f'view width pxs: {w}\n'
-                f'curve width pxs: {cw}\n'
-                f'sliced in view: {in_view.size}'
-            )
-
-            # compress bars to m4 line(s) if uppx is high enough
-            # if in_view.size > cw:
-            #     from ._compression import ds_m4, hl2mxmn
-
-            #     mxmn, x = hl2mxmn(in_view)
-            #     profiler('hl tracer')
-
-            #     nb, x, y = ds_m4(
-            #         x=x,
-            #         y=mxmn,
-            #         # TODO: this needs to actually be the width
-            #         # in pixels of the visible curve since we don't
-            #         # want to downsample any 'zeros' around the curve,
-            #         # just the values that make up the curve graphic,
-            #         # i think?
-            #         px_width=cw,
-            #     )
-            #     profiler(
-            #         'm4 downsampled\n'
-            #         f' ds bins: {nb}\n'
-            #         f' x.shape: {x.shape}\n'
-            #         f' y.shape: {y.shape}\n'
-            #         f' x: {x}\n'
-            #         f' y: {y}\n'
-            #     )
-
-        # assert y.size == mxmn.size
-
         # don't real-time "shift" the curve to the
         # left unless we get one of the following:
         if (
@@ -435,7 +392,9 @@ def graphics_update_cycle(
 
         if vlm_chart:
             # always update y-label
-            ds.vlm_sticky.update_from_data(*array[-1][['index', 'volume']])
+            ds.vlm_sticky.update_from_data(
+                *array[-1][['index', 'volume']]
+            )
 
             if (
                 (xpx < update_uppx or i_diff > 0)
@@ -464,17 +423,17 @@ def graphics_update_cycle(
                 if (
                     mx_vlm_in_view != vars['last_mx_vlm']
                 ):
-                    # print(f'mx vlm: {last_mx_vlm} -> {mx_vlm_in_view}')
                     yrange = (0, mx_vlm_in_view * 1.375)
                     vlm_chart.view._set_yrange(
                         yrange=yrange,
                     )
+                    # print(f'mx vlm: {last_mx_vlm} -> {mx_vlm_in_view}')
                     vars['last_mx_vlm'] = mx_vlm_in_view
 
                 for curve_name, flow in vlm_chart._flows.items():
                     update_fsp_chart(
                         vlm_chart,
-                        flow.shm,
+                        flow,
                         curve_name,
                         array_key=curve_name,
                     )
@@ -529,7 +488,6 @@ def graphics_update_cycle(
         # current) tick first order as an optimization where we only
         # update from the last tick from each type class.
         # last_clear_updated: bool = False
-        # for typ, tick in reversed(lasts.items()):
 
         # update ohlc sampled price bars
         if (
@@ -541,7 +499,7 @@ def graphics_update_cycle(
                 array,
             )
 
-        # iterate in FIFO order per frame
+        # iterate in FIFO order per tick-frame
         for typ, tick in lasts.items():
 
             price = tick.get('price')
@@ -612,42 +570,34 @@ def graphics_update_cycle(
         if (
             (mx > vars['last_mx']) or (mn < vars['last_mn'])
             and not chart._static_yrange == 'axis'
+            and r > i_step  # the last datum is in view
         ):
-            # print(f'new y range: {(mn, mx)}')
-            chart.view._set_yrange(
-                yrange=(mn, mx),
-                # TODO: we should probably scale
-                # the view margin based on the size
-                # of the true range? This way you can
-                # slap in orders outside the current
-                # L1 (only) book range.
-                # range_margin=0.1,
-            )
+            main_vb = chart.view
+            if (
+                main_vb._ic is None
+                or not main_vb._ic.is_set()
+            ):
+                main_vb._set_yrange(
+                    # TODO: we should probably scale
+                    # the view margin based on the size
+                    # of the true range? This way you can
+                    # slap in orders outside the current
+                    # L1 (only) book range.
+                    # range_margin=0.1,
+                    yrange=(mn, mx),
+                )
 
         vars['last_mx'], vars['last_mn'] = mx, mn
 
-        # run synchronous update on all derived fsp subplots
-        for name, subchart in ds.linked.subplots.items():
-            if name == 'volume':
+        # run synchronous update on all linked flows
+        for curve_name, flow in chart._flows.items():
+            # TODO: should the "main" (aka source) flow be special?
+            if curve_name == chart.data_key:
                 continue
 
             update_fsp_chart(
-                subchart,
-                subchart._shm,
-
-                # XXX: do we really needs seperate names here?
-                name,
-                array_key=name,
-            )
-            subchart.cv._set_yrange()
-
-            # TODO: all overlays on all subplots..
-
-        # run synchronous update on all derived overlays
-        for curve_name, flow in chart._flows.items():
-            update_fsp_chart(
                 chart,
-                flow.shm,
+                flow,
                 curve_name,
                 array_key=curve_name,
             )
@@ -743,6 +693,7 @@ async def display_symbol_data(
 
         # TODO: a data view api that makes this less shit
         chart._shm = ohlcv
+        chart._flows[chart.data_key].shm = ohlcv
 
         # NOTE: we must immediately tell Qt to show the OHLC chart
         # to avoid a race where the subplots get added/shown to
@@ -799,7 +750,7 @@ async def display_symbol_data(
                 # that it isn't double rendered in the display loop
                 # above since we do a maxmin calc on the volume data to
                 # determine if auto-range adjustements should be made.
-                linked.subplots.pop('volume', None)
+                # linked.subplots.pop('volume', None)
 
                 # TODO: make this not so shit XD
                 # close group status

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -53,6 +53,10 @@ from ._forms import (
     mk_order_pane_layout,
 )
 from .order_mode import open_order_mode
+# from .._profile import (
+#     pg_profile_enabled,
+#     ms_slower_then,
+# )
 from ..log import get_logger
 
 log = get_logger(__name__)
@@ -284,6 +288,12 @@ async def graphics_update_loop(
             chart.pause_all_feeds()
             continue
 
+        ic = chart.view._ic
+        if ic:
+            chart.pause_all_feeds()
+            await ic.wait()
+            chart.resume_all_feeds()
+
         # sync call to update all graphics/UX components.
         graphics_update_cycle(ds)
 
@@ -300,8 +310,9 @@ def graphics_update_cycle(
 
     profiler = pg.debug.Profiler(
         disabled=True,  # not pg_profile_enabled(),
-        delayed=False,
+        gt=1/12 * 1e3,
     )
+
     # unpack multi-referenced components
     chart = ds.chart
     vlm_chart = ds.vlm_chart
@@ -421,8 +432,11 @@ def graphics_update_cycle(
             if (
                 (xpx < update_uppx or i_diff > 0)
                 or trigger_all
+                and r >= i_step
             ):
-                vlm_chart.update_curve_from_array('volume', array)
+                # TODO: make it so this doesn't have to be called
+                # once the $vlm is up?
+                vlm_chart.update_graphics_from_array('volume', array)
 
                 if (
                     mx_vlm_in_view != vars['last_mx_vlm']
@@ -495,7 +509,8 @@ def graphics_update_cycle(
             xpx < update_uppx
             or i_diff > 0
         ):
-            chart.update_ohlc_from_array(
+            # chart.update_ohlc_from_array(
+            chart.update_graphics_from_array(
                 chart.name,
                 array,
             )
@@ -534,7 +549,7 @@ def graphics_update_cycle(
 
                 if wap_in_history:
                     # update vwap overlay line
-                    chart.update_curve_from_array(
+                    chart.update_graphics_from_array(
                         'bar_wap',
                         array,
                     )

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -75,6 +75,7 @@ _tick_groups = {
 
 def chart_maxmin(
     chart: ChartPlotWidget,
+    ohlcv_shm: ShmArray,
     vlm_chart: Optional[ChartPlotWidget] = None,
 
 ) -> tuple[
@@ -91,7 +92,8 @@ def chart_maxmin(
     # https://arxiv.org/abs/cs/0610046
     # https://github.com/lemire/pythonmaxmin
 
-    array = chart._arrays[chart.name]
+    # array = chart._arrays[chart.name]
+    array = ohlcv_shm.array
     ifirst = array[0]['index']
 
     last_bars_range = chart.bars_range()
@@ -183,7 +185,12 @@ async def graphics_update_loop(
     if vlm_chart:
         vlm_sticky = vlm_chart._ysticks['volume']
 
-    maxmin = partial(chart_maxmin, chart, vlm_chart)
+    maxmin = partial(
+        chart_maxmin,
+        chart,
+        ohlcv,
+        vlm_chart,
+    )
     last_bars_range: tuple[float, float]
     (
         last_bars_range,
@@ -359,6 +366,7 @@ def graphics_update_cycle(
 
         # compute the first available graphic's x-units-per-pixel
         xpx = vlm_chart.view.xs_in_px()
+        # print(f'vlm xpx {xpx}')
 
         in_view = chart.in_view(ohlcv.array)
 
@@ -436,14 +444,30 @@ def graphics_update_cycle(
             ):
                 # TODO: make it so this doesn't have to be called
                 # once the $vlm is up?
-                vlm_chart.update_graphics_from_array('volume', array)
+                vlm_chart.update_graphics_from_array(
+                    'volume',
+                    array,
+
+                    # UGGGh, see ``maxmin()`` impl in `._fsp` for
+                    # the overlayed plotitems... we need a better
+                    # bay to invoke a maxmin per overlay..
+                    render=False,
+                    # XXX: ^^^^ THIS IS SUPER IMPORTANT! ^^^^
+                    # without this, since we disable the
+                    # 'volume' (units) chart after the $vlm starts
+                    # up we need to be sure to enable this
+                    # auto-ranging otherwise there will be no handler
+                    # connected to update accompanying overlay
+                    # graphics..
+                )
 
                 if (
                     mx_vlm_in_view != vars['last_mx_vlm']
                 ):
                     # print(f'mx vlm: {last_mx_vlm} -> {mx_vlm_in_view}')
+                    yrange = (0, mx_vlm_in_view * 1.375)
                     vlm_chart.view._set_yrange(
-                        yrange=(0, mx_vlm_in_view * 1.375)
+                        yrange=yrange,
                     )
                     vars['last_mx_vlm'] = mx_vlm_in_view
 
@@ -455,7 +479,10 @@ def graphics_update_cycle(
                         array_key=curve_name,
                     )
                     # is this even doing anything?
-                    flow.plot.vb._set_yrange(
+                    # (pretty sure it's the real-time
+                    # resizing from last quote?)
+                    fvb = flow.plot.vb
+                    fvb._set_yrange(
                         autoscale_linked_plots=False,
                         name=curve_name,
                     )
@@ -601,6 +628,9 @@ def graphics_update_cycle(
 
         # run synchronous update on all derived fsp subplots
         for name, subchart in ds.linked.subplots.items():
+            if name == 'volume':
+                continue
+
             update_fsp_chart(
                 subchart,
                 subchart._shm,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -509,7 +509,6 @@ def graphics_update_cycle(
             xpx < update_uppx
             or i_diff > 0
         ):
-            # chart.update_ohlc_from_array(
             chart.update_graphics_from_array(
                 chart.name,
                 array,

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -246,7 +246,6 @@ async def run_fsp_ui(
                 overlay=True,
                 color='default_light',
                 array_key=name,
-                separate_axes=conf.get('separate_axes', False),
                 **conf.get('chart_kwargs', {})
             )
             # specially store ref to shm for lookup in display loop
@@ -769,6 +768,7 @@ async def open_vlm_displays(
             # displayed and the curves are effectively the same minus
             # liquidity events (well at least on low OHLC periods - 1s).
             vlm_curve.hide()
+            chart.removeItem(vlm_curve)
 
             # use slightly less light (then bracket) gray
             # for volume from "main exchange" and a more "bluey"

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -89,7 +89,7 @@ def update_fsp_chart(
     # update graphics
     # NOTE: this does a length check internally which allows it
     # staying above the last row check below..
-    chart.update_curve_from_array(
+    chart.update_graphics_from_array(
         graphics_name,
         array,
         array_key=array_key or graphics_name,
@@ -425,6 +425,7 @@ class FspAdmin:
             ) as (ctx, last_index),
             ctx.open_stream() as stream,
         ):
+
             # register output data
             self._registry[
                 (fqsn, ns_path)
@@ -678,7 +679,7 @@ async def open_vlm_displays(
 
         last_val_sticky.update_from_data(-1, value)
 
-        vlm_curve = chart.update_curve_from_array(
+        vlm_curve = chart.update_graphics_from_array(
             'volume',
             shm.array,
         )

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -756,20 +756,14 @@ async def open_vlm_displays(
                 'dark_trade_rate',
             ]
 
-            # add custom auto range handler
-            dvlm_pi.vb._maxmin = partial(
+            group_mxmn = partial(
                 maxmin,
                 # keep both regular and dark vlm in view
                 names=fields + dvlm_rate_fields,
             )
 
-            # TODO: is there a way to "sync" the dual axes such that only
-            # one curve is needed?
-            # hide the original vlm curve since the $vlm one is now
-            # displayed and the curves are effectively the same minus
-            # liquidity events (well at least on low OHLC periods - 1s).
-            vlm_curve.hide()
-            chart.removeItem(vlm_curve)
+            # add custom auto range handler
+            dvlm_pi.vb._maxmin = group_mxmn
 
             # use slightly less light (then bracket) gray
             # for volume from "main exchange" and a more "bluey"
@@ -836,6 +830,14 @@ async def open_vlm_displays(
                 dvlm_pi,
                 fr_shm,
             )
+
+            # TODO: is there a way to "sync" the dual axes such that only
+            # one curve is needed?
+            # hide the original vlm curve since the $vlm one is now
+            # displayed and the curves are effectively the same minus
+            # liquidity events (well at least on low OHLC periods - 1s).
+            vlm_curve.hide()
+            chart.removeItem(vlm_curve)
 
             # Trade rate overlay
             # XXX: requires an additional overlay for

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -72,11 +72,15 @@ def has_vlm(ohlcv: ShmArray) -> bool:
 
 def update_fsp_chart(
     chart: ChartPlotWidget,
-    shm: ShmArray,
+    flow,
     graphics_name: str,
     array_key: Optional[str],
 
 ) -> None:
+
+    shm = flow.shm
+    if not shm:
+        return
 
     array = shm.array
     last_row = try_read(array)
@@ -271,6 +275,7 @@ async def run_fsp_ui(
             # data looked up from the chart's internal array set.
             # TODO: we must get a data view api going STAT!!
             chart._shm = shm
+            chart._flows[chart.data_key].shm = shm
 
             # should **not** be the same sub-chart widget
             assert chart.name != linkedsplits.chart.name
@@ -282,7 +287,7 @@ async def run_fsp_ui(
         # first UI update, usually from shm pushed history
         update_fsp_chart(
             chart,
-            shm,
+            chart._flows[array_key],
             name,
             array_key=array_key,
         )
@@ -634,6 +639,7 @@ async def open_vlm_displays(
             # the curve item internals are pretty convoluted.
             style='step',
         )
+        chart._flows['volume'].shm = ohlcv
 
         # force 0 to always be in view
         def maxmin(
@@ -797,13 +803,16 @@ async def open_vlm_displays(
                         color=color,
                         step_mode=step_mode,
                         style=style,
+                        pi=pi,
                     )
 
                     # TODO: we need a better API to do this..
                     # specially store ref to shm for lookup in display loop
                     # since only a placeholder of `None` is entered in
                     # ``.draw_curve()``.
-                    chart._flows[name].shm = shm
+                    flow = chart._flows[name]
+                    assert flow.plot is pi
+                    flow.shm = shm
 
             chart_curves(
                 fields,
@@ -838,6 +847,9 @@ async def open_vlm_displays(
             # liquidity events (well at least on low OHLC periods - 1s).
             vlm_curve.hide()
             chart.removeItem(vlm_curve)
+            chart._flows.pop('volume')
+            # avoid range sorting on volume once disabled
+            chart.view.disable_auto_yrange()
 
             # Trade rate overlay
             # XXX: requires an additional overlay for
@@ -878,7 +890,10 @@ async def open_vlm_displays(
                 style='dash',
             )
 
-            for pi in (dvlm_pi, tr_pi):
+            for pi in (
+                dvlm_pi,
+                tr_pi,
+            ):
                 for name, axis_info in pi.axes.items():
                     # lol this sux XD
                     axis = axis_info['item']

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -393,6 +393,11 @@ class ChartView(ViewBox):
     def start_ic(
         self,
     ) -> None:
+        '''
+        Signal the beginning of a click-drag interaction
+        to any interested task waiters.
+
+        '''
         if self._ic is None:
             self.chart.pause_all_feeds()
             self._ic = trio.Event()
@@ -400,13 +405,13 @@ class ChartView(ViewBox):
     def signal_ic(
         self,
         *args,
-        # ev = None,
-    ) -> None:
-        if args:
-            print(f'range change dun: {args}')
-        else:
-            print('proxy called')
 
+    ) -> None:
+        '''
+        Signal the end of a click-drag interaction
+        to any waiters.
+
+        '''
         if self._ic:
             self._ic.set()
             self._ic = None
@@ -674,7 +679,6 @@ class ChartView(ViewBox):
                 self.sigRangeChangedManually.emit(self.state['mouseEnabled'])
 
                 if ev.isFinish():
-                    print('DRAG FINISH')
                     self.signal_ic()
                     # self._ic.set()
                     # self._ic = None

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -869,10 +869,10 @@ class ChartView(ViewBox):
         if not graphics:
             return 0
 
-        graphic = graphics[0]
-        xvec = graphic.pixelVectors()[0]
-        if xvec:
-            return xvec.x()
+        for graphic in graphics:
+            xvec = graphic.pixelVectors()[0]
+            if xvec:
+                return xvec.x()
         else:
             return 0
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -798,9 +798,14 @@ class ChartView(ViewBox):
 
         if set_range:
 
-            yrange = self._maxmin()
-            if yrange is None:
-                return
+            if not yrange:
+                # XXX: only compute the mxmn range
+                # if none is provided as input!
+                yrange = self._maxmin()
+
+                if yrange is None:
+                    log.warning(f'No yrange provided for {self.name}!?')
+                    return
 
             ylow, yhigh = yrange
 

--- a/piker/ui/_lines.py
+++ b/piker/ui/_lines.py
@@ -29,7 +29,6 @@ from PyQt5.QtCore import QPointF
 
 from ._annotate import qgo_draw_markers, LevelMarker
 from ._anchors import (
-    marker_right_points,
     vbr_left,
     right_axis,
     gpath_pin,
@@ -333,7 +332,7 @@ class LevelLine(pg.InfiniteLine):
         vb_left, vb_right = self._endPoints
         vb = self.getViewBox()
 
-        line_end, marker_right, r_axis_x = marker_right_points(self._chart)
+        line_end, marker_right, r_axis_x = self._chart.marker_right_points()
 
         if self.show_markers and self.markers:
 
@@ -399,7 +398,7 @@ class LevelLine(pg.InfiniteLine):
     def scene_endpoint(self) -> QPointF:
 
         if not self._right_end_sc:
-            line_end, _, _ = marker_right_points(self._chart)
+            line_end, _, _ = self._chart.marker_right_points()
             self._right_end_sc = line_end - 10
 
         return QPointF(self._right_end_sc, self.scene_y())
@@ -417,7 +416,7 @@ class LevelLine(pg.InfiniteLine):
         self.getViewBox().scene().addItem(path)
 
         # place to just-left of L1 labels
-        rsc = self._chart.pre_l1_x()[0]
+        rsc = self._chart.pre_l1_xs()[0]
         path.setPos(QPointF(rsc, self.scene_y()))
 
         return path

--- a/piker/ui/_lines.py
+++ b/piker/ui/_lines.py
@@ -20,7 +20,7 @@ Lines for orders, alerts, L2.
 """
 from functools import partial
 from math import floor
-from typing import Tuple, Optional, List, Callable
+from typing import Optional, Callable
 
 import pyqtgraph as pg
 from pyqtgraph import Point, functions as fn
@@ -32,7 +32,6 @@ from ._anchors import (
     marker_right_points,
     vbr_left,
     right_axis,
-    # pp_tight_and_right,  # wanna keep it straight in the long run
     gpath_pin,
 )
 from ..calc import humanize
@@ -104,8 +103,8 @@ class LevelLine(pg.InfiniteLine):
 
         # list of labels anchored at one of the 2 line endpoints
         # inside the viewbox
-        self._labels: List[Label] = []
-        self._markers: List[(int, Label)] = []
+        self._labels: list[Label] = []
+        self._markers: list[(int, Label)] = []
 
         # whenever this line is moved trigger label updates
         self.sigPositionChanged.connect(self.on_pos_change)
@@ -124,7 +123,7 @@ class LevelLine(pg.InfiniteLine):
         self._y_incr_mult = 1 / chart.linked.symbol.tick_size
         self._right_end_sc: float = 0
 
-    def txt_offsets(self) -> Tuple[int, int]:
+    def txt_offsets(self) -> tuple[int, int]:
         return 0, 0
 
     @property
@@ -315,17 +314,6 @@ class LevelLine(pg.InfiniteLine):
         # TODO: enter labels edit mode
         print(f'double click {ev}')
 
-    def right_point(
-        self,
-    ) -> float:
-
-        chart = self._chart
-        l1_len = chart._max_l1_line_len
-        ryaxis = chart.getAxis('right')
-        up_to_l1_sc = ryaxis.pos().x() - l1_len
-
-        return up_to_l1_sc
-
     def paint(
         self,
 
@@ -422,23 +410,23 @@ class LevelLine(pg.InfiniteLine):
 
     ) -> QtWidgets.QGraphicsPathItem:
 
+        self._marker = path
+        self._marker.setPen(self.currentPen)
+        self._marker.setBrush(fn.mkBrush(self.currentPen.color()))
         # add path to scene
         self.getViewBox().scene().addItem(path)
 
-        self._marker = path
-
-        rsc = self.right_point()
-
-        self._marker.setPen(self.currentPen)
-        self._marker.setBrush(fn.mkBrush(self.currentPen.color()))
+        # place to just-left of L1 labels
+        rsc = self._chart.pre_l1_x()[0]
         path.setPos(QPointF(rsc, self.scene_y()))
 
         return path
 
     def hoverEvent(self, ev):
-        """Mouse hover callback.
+        '''
+        Mouse hover callback.
 
-        """
+        '''
         cur = self._chart.linked.cursor
 
         # hovered
@@ -614,7 +602,8 @@ def order_line(
     **line_kwargs,
 
 ) -> LevelLine:
-    '''Convenience routine to add a line graphic representing an order
+    '''
+    Convenience routine to add a line graphic representing an order
     execution submitted to the EMS via the chart's "order mode".
 
     '''
@@ -688,7 +677,6 @@ def order_line(
                 return ''
 
             return f'{account}: '
-
 
         label.fields = {
             'size': size,

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -599,8 +599,10 @@ class BarItems(pg.GraphicsObject):
             self._pi.removeItem(self)
 
             curve, ds = self.get_ds_line(ds=0)
+
             last_curve = self._ds_line
             assert last_curve is curve
+
             self._pi.addItem(curve)
             curve.show()
             curve.update()
@@ -619,6 +621,7 @@ class BarItems(pg.GraphicsObject):
             last_curve = self._ds_line
             assert last_curve is curve
             curve.hide()
+            curve.clear()
             self._pi.removeItem(curve)
 
             # XXX: is this actually any faster?

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -318,6 +318,13 @@ class BarItems(pg.GraphicsObject):
 
         return self.path
 
+
+    def x_uppx(self) -> int:
+        if self._ds_line:
+            return self._ds_line.x_uppx()
+        else:
+            return 0
+
     def update_from_array(
         self,
 
@@ -346,6 +353,7 @@ class BarItems(pg.GraphicsObject):
         profiler = pg.debug.Profiler(
             disabled=not pg_profile_enabled(),
             gt=ms_slower_then,
+            delayed=True,
         )
 
         # index = self.start_index
@@ -364,7 +372,7 @@ class BarItems(pg.GraphicsObject):
 
         flip_cache = False
 
-        x_gt = 8
+        x_gt = 16
         if self._ds_line:
             uppx = self._ds_line.x_uppx()
         else:
@@ -383,6 +391,8 @@ class BarItems(pg.GraphicsObject):
         ):
             should_line = True
 
+        profiler('ds logic complete')
+
         if (
             should_line
         ):
@@ -391,6 +401,7 @@ class BarItems(pg.GraphicsObject):
             x, y = self._ds_line_xy = ohlc_flatten(ohlc)
             x_iv, y_iv = self._ds_line_xy = ohlc_flatten(ohlc_iv)
             profiler('flattening bars to line')
+            print(f'rendering linesc')
 
             # TODO: we should be diffing the amount of new data which
             # needs to be downsampled. Ideally we actually are just
@@ -427,6 +438,7 @@ class BarItems(pg.GraphicsObject):
             # stop here since we don't need to update bars path any more
             # as we delegate to the downsample line with updates.
             profiler.finish()
+            print('terminating early')
             return
 
         elif (
@@ -597,6 +609,8 @@ class BarItems(pg.GraphicsObject):
 
         if flip_cache:
             self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
+
+        profiler.finish()
 
     def boundingRect(self):
         # Qt docs: https://doc.qt.io/qt-5/qgraphicsitem.html#boundingRect

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -364,7 +364,7 @@ class BarItems(pg.GraphicsObject):
 
         flip_cache = False
 
-        x_gt = 2
+        x_gt = 8
         if self._ds_line:
             uppx = self._ds_line.x_uppx()
         else:
@@ -404,9 +404,9 @@ class BarItems(pg.GraphicsObject):
                 y=y,
                 x_iv=x_iv,
                 y_iv=y_iv,
-                view_range=view_range,  # hack
+                view_range=None,  # hack
             )
-            profiler('udated ds line')
+            profiler('updated ds line')
 
             if not self._in_ds:
                 # hide bars and show line
@@ -426,6 +426,7 @@ class BarItems(pg.GraphicsObject):
 
             # stop here since we don't need to update bars path any more
             # as we delegate to the downsample line with updates.
+            profiler.finish()
             return
 
         elif (

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -14,9 +14,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
+'''
 Qt UI styling.
-"""
+
+'''
 from typing import Optional, Dict
 import math
 
@@ -202,8 +203,6 @@ _xaxis_at = 'bottom'
 # charting config
 CHART_MARGINS = (0, 0, 2, 2)
 _min_points_to_show = 6
-_bars_to_left_in_follow_mode = int(61*6)
-_bars_from_right_in_follow_mode = round(0.16 * _bars_to_left_in_follow_mode)
 _tina_mode = False
 
 

--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -122,7 +122,8 @@ def optschain(config, symbol, date, rate, test):
 @cli.command()
 @click.option(
     '--profile',
-    is_flag=True,
+    '-p',
+    default=None,
     help='Enable pyqtgraph profiling'
 )
 @click.option(
@@ -133,9 +134,16 @@ def optschain(config, symbol, date, rate, test):
 @click.argument('symbol', required=True)
 @click.pass_obj
 def chart(config, symbol, profile, pdb):
-    """Start a real-time chartng UI
-    """
-    from .. import _profile
+    '''
+    Start a real-time chartng UI
+
+    '''
+    # eg. ``--profile 3`` reports profiling for anything slower then 3 ms.
+    if profile is not None:
+        from .. import _profile
+        _profile._pg_profile = True
+        _profile.ms_slower_then = float(profile)
+
     from ._app import _main
 
     if '.' not in symbol:
@@ -145,8 +153,6 @@ def chart(config, symbol, profile, pdb):
         ))
         return
 
-    # toggle to enable profiling
-    _profile._pg_profile = profile
 
     # global opts
     brokernames = config['brokers']


### PR DESCRIPTION
Pertains to the beginning of more "serious" work toward #109.

A bunch of fancy stuff added to reduce latency on drawing larger data sets as well as some general UX changes to aid with it.

- add a `BarItems` downsampling to `FastAppendCurve` when the uppx (units-per-pixel) on screen is > 2
  - the curve generated here is an "outline" or "tracing" of the HL parts of each bar such that the "peak" are shown as a line when zoomed out far enough to not be able to see a single OHLC bar
-  this changeset was moved into #304.
~factor the "graphics draw cycle" steps into a sync function that can be triggered (remotely) to update on certain types of events~
  - ~for example when an fsp running in a subactor makes an update but the market is not open - it needs to tell the chart app to update graphics~
- factor out the "peak" downsampling code from `pyqtgraph`'s `PlotDataItem` and stick in a new `piker.ui._compression` mod
- display loop now only updates real-time on quotes when not in "big data" viewing mode
  - don't be updating line curves rt when we're zoomed out @ uppx > 4 except when the sample step updates (i.e. we still show new datums appended just not on every change to the last value)
  - don't shift the curves if the last datum isn't in view (i.e. the user is viewing history) or we're zoomed out uppx > 4
  
This is all obviously very nascent and we're going to introduce a bunch of fancy downsampling algo stuff to the tracer curves, but it's a start and needs some serious scrutiny and testing 🏄🏼 


---
## UPDATE
a ton more was added to get the m4 downsampling algo working but the stip is that this PR now further requries the history from #294 as well as a cusom patch to the profiler on our `pyqtgraph` fork (links coming soon).

ToDo:
- [x] get a PR up for the `pg.debug.Profiler` and hopefully we don't have to fork it into the project (yet again 😂)
  - https://github.com/pyqtgraph/pyqtgraph/pull/2281
- [ ] ~lotsa testing by lurkerz on possibly an out-of-band data set~ all the public ones are lazy af apparently..
- [x] thorough testing that none of this broke crypto$ backends..
- [x] update the above PR summary to reflect latest changes..

