### PR TITLE
Fqsns

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1472,6 +1472,7 @@ async def stream_quotes(
         return init_msgs
 
     init_msgs = mk_init_msgs()
+
     con = first_ticker.contract
 
     # should be real volume for this contract by default
@@ -1496,8 +1497,11 @@ async def stream_quotes(
     topic = '.'.join((con['symbol'], suffix)).lower()
     quote['symbol'] = topic
 
+    # for compat with upcoming fqsn based derivs search
+    init_msgs[sym]['fqsn'] = topic
+
     # pass first quote asap
-    first_quote = {topic: quote}
+    first_quote = quote
 
     # it might be outside regular trading hours so see if we can at
     # least grab history.

--- a/piker/clearing/_client.py
+++ b/piker/clearing/_client.py
@@ -201,8 +201,8 @@ async def open_ems(
     # ready for order commands
     book = get_orders()
 
-    from ..data._source import uncons_fqsn
-    broker, symbol, suffix = uncons_fqsn(fqsn)
+    from ..data._source import unpack_fqsn
+    broker, symbol, suffix = unpack_fqsn(fqsn)
 
     async with maybe_open_emsd(broker) as portal:
 

--- a/piker/clearing/_client.py
+++ b/piker/clearing/_client.py
@@ -18,7 +18,7 @@
 Orders and execution client API.
 
 """
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager as acm
 from typing import Dict
 from pprint import pformat
 from dataclasses import dataclass, field
@@ -27,7 +27,6 @@ import trio
 import tractor
 from tractor.trionics import broadcast_receiver
 
-from ..data._source import Symbol
 from ..log import get_logger
 from ._ems import _emsd_main
 from .._daemon import maybe_open_emsd
@@ -156,15 +155,18 @@ async def relay_order_cmds_from_sync_code(
                 await to_ems_stream.send(cmd)
 
 
-@asynccontextmanager
+@acm
 async def open_ems(
-    broker: str,
-    symbol: Symbol,
+    fqsn: str,
 
-) -> (OrderBook, tractor.MsgStream, dict):
-    """Spawn an EMS daemon and begin sending orders and receiving
+) -> (
+    OrderBook,
+    tractor.MsgStream,
+    dict,
+):
+    '''
+    Spawn an EMS daemon and begin sending orders and receiving
     alerts.
-
 
     This EMS tries to reduce most broker's terrible order entry apis to
     a very simple protocol built on a few easy to grok and/or
@@ -194,21 +196,22 @@ async def open_ems(
     - 'dark_executed', 'broker_executed'
     - 'broker_filled'
 
-    """
+    '''
     # wait for service to connect back to us signalling
     # ready for order commands
     book = get_orders()
 
+    from ..data._source import uncons_fqsn
+    broker, symbol, suffix = uncons_fqsn(fqsn)
+
     async with maybe_open_emsd(broker) as portal:
 
         async with (
-
             # connect to emsd
             portal.open_context(
 
                 _emsd_main,
-                broker=broker,
-                symbol=symbol.key,
+                fqsn=fqsn,
 
             ) as (ctx, (positions, accounts)),
 
@@ -218,7 +221,7 @@ async def open_ems(
             async with trio.open_nursery() as n:
                 n.start_soon(
                     relay_order_cmds_from_sync_code,
-                    symbol.key,
+                    fqsn,
                     trades_stream
                 )
 

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -20,7 +20,6 @@ In da suit parlances: "Execution management systems"
 """
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-# from math import isnan
 from pprint import pformat
 import time
 from typing import AsyncIterator, Callable
@@ -491,8 +490,9 @@ async def open_brokerd_trades_dialogue(
         finally:
             # parent context must have been closed
             # remove from cache so next client will respawn if needed
-            ## TODO: Maybe add a warning
-            _router.relays.pop(broker, None)
+            relay = _router.relays.pop(broker, None)
+            if not relay:
+                log.warning(f'Relay for {broker} was already removed!?')
 
 
 @tractor.context
@@ -1035,11 +1035,6 @@ async def _emsd_main(
 
         book = _router.get_dark_book(broker)
         book.lasts[fqsn] = first_quote['last']
-
-        # XXX: ib is a cucker but we've fixed avoiding receiving any
-        # `Nan`s in the backend during market hours (right?). this was
-        # here previously as a sanity check during market hours.
-        # assert not isnan(last)
 
         # open a stream with the brokerd backend for order
         # flow dialogue

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -417,8 +417,7 @@ async def open_brokerd_trades_dialogue(
             # actor to simulate the real IPC load it'll have when also
             # pulling data from feeds
             open_trades_endpoint = paper.open_paperboi(
-                broker=broker,
-                symbol=symbol,
+                fqsn='.'.join([symbol, broker]),
                 loglevel=loglevel,
             )
 

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -1011,8 +1011,8 @@ async def _emsd_main(
     global _router
     assert _router
 
-    from ..data._source import uncons_fqsn
-    broker, symbol, suffix = uncons_fqsn(fqsn)
+    from ..data._source import unpack_fqsn
+    broker, symbol, suffix = unpack_fqsn(fqsn)
     dark_book = _router.get_dark_book(broker)
 
     # TODO: would be nice if in tractor we can require either a ctx arg,

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -20,7 +20,7 @@ In da suit parlances: "Execution management systems"
 """
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from math import isnan
+# from math import isnan
 from pprint import pformat
 import time
 from typing import AsyncIterator, Callable
@@ -113,8 +113,8 @@ class _DarkBook:
 
     # tracks most recent values per symbol each from data feed
     lasts: dict[
-        tuple[str, str],
-        float
+        str,
+        float,
     ] = field(default_factory=dict)
 
     # mapping of piker ems order ids to current brokerd order flow message
@@ -135,7 +135,7 @@ async def clear_dark_triggers(
     ems_client_order_stream: tractor.MsgStream,
     quote_stream: tractor.ReceiveMsgStream,  # noqa
     broker: str,
-    symbol: str,
+    fqsn: str,
 
     book: _DarkBook,
 
@@ -155,7 +155,6 @@ async def clear_dark_triggers(
         # start = time.time()
         for sym, quote in quotes.items():
             execs = book.orders.get(sym, {})
-
             for tick in iterticks(
                 quote,
                 # dark order price filter(s)
@@ -171,7 +170,7 @@ async def clear_dark_triggers(
                 ttype = tick['type']
 
                 # update to keep new cmds informed
-                book.lasts[(broker, symbol)] = price
+                book.lasts[sym] = price
 
                 for oid, (
                     pred,
@@ -196,6 +195,7 @@ async def clear_dark_triggers(
 
                     action: str = cmd['action']
                     symbol: str = cmd['symbol']
+                    bfqsn: str = symbol.replace(f'.{broker}', '')
 
                     if action == 'alert':
                         # nothing to do but relay a status
@@ -225,7 +225,7 @@ async def clear_dark_triggers(
                             # order-request and instead create a new one.
                             reqid=None,
 
-                            symbol=sym,
+                            symbol=bfqsn,
                             price=submit_price,
                             size=cmd['size'],
                         )
@@ -247,12 +247,9 @@ async def clear_dark_triggers(
                         oid=oid,  # ems order id
                         resp=resp,
                         time_ns=time.time_ns(),
-
-                        symbol=symbol,
+                        symbol=fqsn,
                         trigger_price=price,
-
                         broker_details={'name': broker},
-
                         cmd=cmd,  # original request message
 
                     ).dict()
@@ -270,7 +267,7 @@ async def clear_dark_triggers(
                 else:  # condition scan loop complete
                     log.debug(f'execs are {execs}')
                     if execs:
-                        book.orders[symbol] = execs
+                        book.orders[fqsn] = execs
 
         # print(f'execs scan took: {time.time() - start}')
 
@@ -382,7 +379,8 @@ async def open_brokerd_trades_dialogue(
     task_status: TaskStatus[TradesRelay] = trio.TASK_STATUS_IGNORED,
 
 ) -> tuple[dict, tractor.MsgStream]:
-    '''Open and yield ``brokerd`` trades dialogue context-stream if none
+    '''
+    Open and yield ``brokerd`` trades dialogue context-stream if none
     already exists.
 
     '''
@@ -458,12 +456,13 @@ async def open_brokerd_trades_dialogue(
                 # locally cache and track positions per account.
                 pps = {}
                 for msg in positions:
+                    log.info(f'loading pp: {msg}')
 
                     account = msg['account']
                     assert account in accounts
 
                     pps.setdefault(
-                        msg['symbol'],
+                        f'{msg["symbol"]}.{broker}',
                         {}
                     )[account] = msg
 
@@ -563,7 +562,13 @@ async def translate_and_relay_brokerd_events(
 
             # XXX: this will be useful for automatic strats yah?
             # keep pps per account up to date locally in ``emsd`` mem
-            relay.positions.setdefault(pos_msg['symbol'], {}).setdefault(
+            sym, broker = pos_msg['symbol'], pos_msg['broker']
+
+            relay.positions.setdefault(
+                # NOTE: translate to a FQSN!
+                f'{sym}.{broker}',
+                {}
+            ).setdefault(
                 pos_msg['account'], {}
             ).update(pos_msg)
 
@@ -840,11 +845,15 @@ async def process_client_order_cmds(
 
             msg = Order(**cmd)
 
-            sym = msg.symbol
+            fqsn = msg.symbol
             trigger_price = msg.price
             size = msg.size
             exec_mode = msg.exec_mode
             broker = msg.brokers[0]
+            # remove the broker part before creating a message
+            # to send to the specific broker since they probably
+            # aren't expectig their own name, but should they?
+            sym = fqsn.replace(f'.{broker}', '')
 
             if exec_mode == 'live' and action in ('buy', 'sell',):
 
@@ -902,7 +911,7 @@ async def process_client_order_cmds(
                 # price received from the feed, instead of being
                 # like every other shitty tina platform that makes
                 # the user choose the predicate operator.
-                last = dark_book.lasts[(broker, sym)]
+                last = dark_book.lasts[fqsn]
                 pred = mk_check(trigger_price, last, action)
 
                 spread_slap: float = 5
@@ -933,7 +942,7 @@ async def process_client_order_cmds(
                 # dark book entry if the order id already exists
 
                 dark_book.orders.setdefault(
-                    sym, {}
+                    fqsn, {}
                 )[oid] = (
                     pred,
                     tickfilter,
@@ -960,8 +969,8 @@ async def process_client_order_cmds(
 async def _emsd_main(
 
     ctx: tractor.Context,
-    broker: str,
-    symbol: str,
+    fqsn: str,
+
     _exec_mode: str = 'dark',  # ('paper', 'dark', 'live')
     loglevel: str = 'info',
 
@@ -1003,6 +1012,8 @@ async def _emsd_main(
     global _router
     assert _router
 
+    from ..data._source import uncons_fqsn
+    broker, symbol, suffix = uncons_fqsn(fqsn)
     dark_book = _router.get_dark_book(broker)
 
     # TODO: would be nice if in tractor we can require either a ctx arg,
@@ -1015,17 +1026,16 @@ async def _emsd_main(
     # spawn one task per broker feed
     async with (
         maybe_open_feed(
-            broker,
-            [symbol],
+            [fqsn],
             loglevel=loglevel,
-        ) as (feed, stream),
+        ) as (feed, quote_stream),
     ):
 
         # XXX: this should be initial price quote from target provider
-        first_quote = feed.first_quotes[symbol]
+        first_quote = feed.first_quotes[fqsn]
 
         book = _router.get_dark_book(broker)
-        last = book.lasts[(broker, symbol)] = first_quote['last']
+        book.lasts[fqsn] = first_quote['last']
 
         # XXX: ib is a cucker but we've fixed avoiding receiving any
         # `Nan`s in the backend during market hours (right?). this was
@@ -1054,8 +1064,8 @@ async def _emsd_main(
 
             # flatten out collected pps from brokerd for delivery
             pp_msgs = {
-                sym: list(pps.values())
-                for sym, pps in relay.positions.items()
+                fqsn: list(pps.values())
+                for fqsn, pps in relay.positions.items()
             }
 
             # signal to client that we're started and deliver
@@ -1072,9 +1082,9 @@ async def _emsd_main(
 
                     brokerd_stream,
                     ems_client_order_stream,
-                    stream,
+                    quote_stream,
                     broker,
-                    symbol,
+                    fqsn,  # form: <name>.<venue>.<suffix>.<broker>
                     book
                 )
 
@@ -1090,7 +1100,7 @@ async def _emsd_main(
                         # relay.brokerd_dialogue,
                         brokerd_stream,
 
-                        symbol,
+                        fqsn,
                         feed,
                         dark_book,
                         _router,

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 
 from .. import data
 from ..data._normalize import iterticks
-from ..data._source import uncons_fqsn
+from ..data._source import unpack_fqsn
 from ..log import get_logger
 from ._messages import (
     BrokerdCancel, BrokerdOrder, BrokerdOrderAck, BrokerdStatus,
@@ -500,7 +500,7 @@ async def open_paperboi(
     its context.
 
     '''
-    broker, symbol, expiry = uncons_fqsn(fqsn)
+    broker, symbol, expiry = unpack_fqsn(fqsn)
     service_name = f'paperboi.{broker}'
 
     async with (

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -19,6 +19,8 @@ Sampling and broadcast machinery for (soft) real-time delivery of
 financial data flows.
 
 """
+from __future__ import annotations
+from collections import Counter
 import time
 
 import tractor
@@ -188,6 +190,8 @@ async def sample_and_broadcast(
 
     log.info("Started shared mem bar writer")
 
+    overruns = Counter()
+
     # iterate stream delivered by broker
     async for quotes in quote_stream:
         # TODO: ``numba`` this!
@@ -262,8 +266,8 @@ async def sample_and_broadcast(
             # should?) so we have to manually generate the correct
             # key here.
             bsym = f'{broker_symbol}.{brokername}'
+            lags: int = 0
 
-            lags = 0
             for (stream, tick_throttle) in subs:
 
                 try:
@@ -283,10 +287,18 @@ async def sample_and_broadcast(
                                         f'{ctx.channel.uid} !!!'
                                     )
                                 else:
+                                    key = id(stream)
+                                    overruns[key] += 1
                                     log.warning(
                                         f'Feed overrun {bus.brokername} -> '
                                         f'feed @ {tick_throttle} Hz'
                                     )
+                                    if overruns[key] > 6:
+                                        log.warning(
+                                            f'Dropping consumer {stream}'
+                                        )
+                                        await stream.aclose()
+                                        raise trio.BrokenResourceError
                         else:
                             await stream.send(
                                 {bsym: quote}
@@ -309,7 +321,7 @@ async def sample_and_broadcast(
                             '`brokerd`-quotes-feed connection'
                         )
                     if tick_throttle:
-                        assert stream.closed()
+                        assert stream._closed
 
                     # XXX: do we need to deregister here
                     # if it's done in the fee bus code?

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -1,5 +1,5 @@
 # piker: trading gear for hackers
-# Copyright (C) 2018-present  Tyler Goodlet (in stewardship of piker0)
+# Copyright (C) 2018-present  Tyler Goodlet (in stewardship of pikers)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -403,7 +403,16 @@ async def uniform_rate_send(
         # rate timing exactly lul
         try:
             await stream.send({sym: first_quote})
-        except trio.ClosedResourceError:
+        except (
+            # NOTE: any of these can be raised by ``tractor``'s IPC
+            # transport-layer and we want to be highly resilient
+            # to consumers which crash or lose network connection.
+            # I.e. we **DO NOT** want to crash and propagate up to
+            # ``pikerd`` these kinds of errors!
+            trio.ClosedResourceError,
+            trio.BrokenResourceError,
+            ConnectionResetError,
+        ):
             # if the feed consumer goes down then drop
             # out of this rate limiter
             log.warning(f'{stream} closed')

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -258,7 +258,7 @@ class ShmArray:
             if index < 0:
                 raise ValueError(
                     f'Array size of {self._len} was overrun during prepend.\n'
-                    'You have passed {abs(index)} too many datums.'
+                    f'You have passed {abs(index)} too many datums.'
                 )
 
         end = index + length

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -92,7 +92,7 @@ def ohlc_zeros(length: int) -> np.ndarray:
     return np.zeros(length, dtype=base_ohlc_dtype)
 
 
-def uncons_fqsn(fqsn: str) -> tuple[str, str, str]:
+def unpack_fqsn(fqsn: str) -> tuple[str, str, str]:
     '''
     Unpack a fully-qualified-symbol-name to ``tuple``.
 
@@ -178,7 +178,7 @@ class Symbol(BaseModel):
     # XXX: like wtf..
     # ) -> 'Symbol':
     ) -> None:
-        broker, key, suffix = uncons_fqsn(fqsn)
+        broker, key, suffix = unpack_fqsn(fqsn)
         return cls.from_broker_info(
             broker,
             key,

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -214,13 +214,15 @@ class Symbol(BaseModel):
             self.key,
         )
 
-    def front_fqsn(self) -> str:
+    def tokens(self) -> tuple[str]:
         broker, key = self.front_feed()
         if self.suffix:
-            tokens = (key, self.suffix, broker)
+            return (key, self.suffix, broker)
         else:
-            tokens = (key, broker)
+            return (key, broker)
 
+    def front_fqsn(self) -> str:
+        tokens = self.tokens()
         fqsn = '.'.join(tokens)
         return fqsn
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -92,6 +92,28 @@ def ohlc_zeros(length: int) -> np.ndarray:
     return np.zeros(length, dtype=base_ohlc_dtype)
 
 
+def uncons_fqsn(fqsn: str) -> tuple[str, str, str]:
+    '''
+    Unpack a fully-qualified-symbol-name to ``tuple``.
+
+    '''
+    # TODO: probably reverse the order of all this XD
+    tokens = fqsn.split('.')
+    if len(tokens) > 3:
+        symbol, venue, suffix, broker = tokens
+    else:
+        symbol, venue, broker = tokens
+        suffix = ''
+
+    # head, _, broker = fqsn.rpartition('.')
+    # symbol, _, suffix = head.rpartition('.')
+    return (
+        broker,
+        '.'.join([symbol, venue]),
+        suffix,
+    )
+
+
 class Symbol(BaseModel):
     """I guess this is some kinda container thing for dealing with
     all the different meta-data formats from brokers?
@@ -103,6 +125,7 @@ class Symbol(BaseModel):
     lot_tick_size: float = 0.0  # "volume" precision as min step value
     tick_size_digits: int = 2
     lot_size_digits: int = 0
+    suffix: str = ''
     broker_info: dict[str, dict[str, Any]] = {}
 
     # specifies a "class" of financial instrument
@@ -115,6 +138,7 @@ class Symbol(BaseModel):
         broker: str,
         symbol: str,
         info: dict[str, Any],
+        suffix: str = '',
 
     # XXX: like wtf..
     # ) -> 'Symbol':
@@ -129,7 +153,25 @@ class Symbol(BaseModel):
             lot_tick_size=lot_tick_size,
             tick_size_digits=float_digits(tick_size),
             lot_size_digits=float_digits(lot_tick_size),
+            suffix=suffix,
             broker_info={broker: info},
+        )
+
+    @classmethod
+    def from_fqsn(
+        cls,
+        fqsn: str,
+        info: dict[str, Any],
+
+    # XXX: like wtf..
+    # ) -> 'Symbol':
+    ) -> None:
+        broker, key, suffix = uncons_fqsn(fqsn)
+        return cls.from_broker_info(
+            broker,
+            key,
+            info=info,
+            suffix=suffix,
         )
 
     @property
@@ -141,9 +183,10 @@ class Symbol(BaseModel):
         return list(self.broker_info.keys())
 
     def nearest_tick(self, value: float) -> float:
-        """Return the nearest tick value based on mininum increment.
+        '''
+        Return the nearest tick value based on mininum increment.
 
-        """
+        '''
         mult = 1 / self.tick_size
         return round(value * mult) / mult
 
@@ -159,11 +202,25 @@ class Symbol(BaseModel):
             self.key,
         )
 
+    def front_fqsn(self) -> str:
+        broker, key = self.front_feed()
+        if self.suffix:
+            tokens = (key, self.suffix, broker)
+        else:
+            tokens = (key, broker)
+
+        fqsn = '.'.join(tokens)
+        return fqsn
+
     def iterfqsns(self) -> list[str]:
-        return [
-            mk_fqsn(self.key, broker)
-            for broker in self.broker_info.keys()
-        ]
+        keys = []
+        for broker in self.broker_info.keys():
+            fqsn = mk_fqsn(self.key, broker)
+            if self.suffix:
+                fqsn += f'.{self.suffix}'
+            keys.append(fqsn)
+
+        return keys
 
 
 def from_df(

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -97,9 +97,21 @@ def uncons_fqsn(fqsn: str) -> tuple[str, str, str]:
     Unpack a fully-qualified-symbol-name to ``tuple``.
 
     '''
+    venue = ''
+    suffix = ''
+
     # TODO: probably reverse the order of all this XD
     tokens = fqsn.split('.')
-    if len(tokens) > 3:
+    if len(tokens) < 3:
+        # probably crypto
+        symbol, broker = tokens
+        return (
+            broker,
+            symbol,
+            '',
+        )
+
+    elif len(tokens) > 3:
         symbol, venue, suffix, broker = tokens
     else:
         symbol, venue, broker = tokens

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -222,6 +222,23 @@ class Symbol(BaseModel):
             return (key, broker)
 
     def front_fqsn(self) -> str:
+        '''
+        fqsn = "fully qualified symbol name"
+
+        Basically the idea here is for all client-ish code (aka programs/actors
+        that ask the provider agnostic layers in the stack for data) should be
+        able to tell which backend / venue / derivative each data feed/flow is
+        from by an explicit string key of the current form:
+
+        <instrumentname>.<venue>.<suffixwithmetadata>.<brokerbackendname>
+
+        TODO: I have thoughts that we should actually change this to be
+        more like an "attr lookup" (like how the web should have done
+        urls, but marketting peeps ruined it etc. etc.):
+
+        <broker>.<venue>.<instrumentname>.<suffixwithmetadata>
+
+        '''
         tokens = self.tokens()
         fqsn = '.'.join(tokens)
         return fqsn

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -519,19 +519,20 @@ async def open_sample_step_stream(
     # created for all practical purposes
     async with maybe_open_context(
         acm_func=partial(
-            portal.open_stream_from,
+            portal.open_context,
             iter_ohlc_periods,
         ),
         kwargs={'delay_s': delay_s},
 
-    ) as (cache_hit, istream):
-        if cache_hit:
-            # add a new broadcast subscription for the quote stream
-            # if this feed is likely already in use
-            async with istream.subscribe() as bistream:
-                yield bistream
-        else:
-            yield istream
+    ) as (cache_hit, (ctx, first)):
+        async with ctx.open_stream() as istream:
+            if cache_hit:
+                # add a new broadcast subscription for the quote stream
+                # if this feed is likely already in use
+                async with istream.subscribe() as bistream:
+                    yield bistream
+            else:
+                yield istream
 
 
 @dataclass

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -51,7 +51,7 @@ from .ingest import get_ingestormod
 from ._source import (
     base_iohlc_dtype,
     Symbol,
-    uncons_fqsn,
+    unpack_fqsn,
 )
 from ..ui import _search
 from ._sampling import (
@@ -672,7 +672,7 @@ async def open_feed(
     '''
     fqsn = fqsns[0].lower()
 
-    brokername, key, suffix = uncons_fqsn(fqsn)
+    brokername, key, suffix = unpack_fqsn(fqsn)
     bfqsn = fqsn.replace('.' + brokername, '')
 
     try:

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -306,7 +306,6 @@ async def allocate_persistent_feed(
     bfqsn = init_msg[symbol]['fqsn'].lower()
     init_msg[symbol]['fqsn'] = bfqsn
 
-
     # HISTORY, run 2 tasks:
     # - a history loader / maintainer
     # - a real-time streamer which consumers and sends new data to any

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -301,8 +301,11 @@ async def allocate_persistent_feed(
             loglevel=loglevel,
         )
     )
-    # the broker-specific fully qualified symbol name
-    bfqsn = init_msg[symbol]['fqsn']
+    # the broker-specific fully qualified symbol name,
+    # but ensure it is lower-cased for external use.
+    bfqsn = init_msg[symbol]['fqsn'].lower()
+    init_msg[symbol]['fqsn'] = bfqsn
+
 
     # HISTORY, run 2 tasks:
     # - a history loader / maintainer
@@ -330,7 +333,6 @@ async def allocate_persistent_feed(
 
     # true fqsn
     fqsn = '.'.join((bfqsn, brokername))
-
     # add a fqsn entry that includes the ``.<broker>`` suffix
     init_msg[fqsn] = msg
 
@@ -444,7 +446,7 @@ async def open_feed_bus(
     init_msg, first_quotes = bus.feeds[symbol]
 
     msg = init_msg[symbol]
-    bfqsn = msg['fqsn']
+    bfqsn = msg['fqsn'].lower()
 
     # true fqsn
     fqsn = '.'.join([bfqsn, brokername])
@@ -763,7 +765,10 @@ async def maybe_open_feed(
 
     **kwargs,
 
-) -> (Feed, ReceiveChannel[dict[str, Any]]):
+) -> (
+    Feed,
+    ReceiveChannel[dict[str, Any]],
+):
     '''
     Maybe open a data to a ``brokerd`` daemon only if there is no
     local one for the broker-symbol pair, if one is cached use it wrapped
@@ -784,6 +789,7 @@ async def maybe_open_feed(
             'start_stream': kwargs.get('start_stream', True),
         },
         key=fqsn,
+
     ) as (cache_hit, feed):
 
         if cache_hit:

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -37,6 +37,7 @@ from .. import data
 from ..data import attach_shm_array
 from ..data.feed import Feed
 from ..data._sharedmem import ShmArray
+from ..data._source import Symbol
 from ._api import (
     Fsp,
     _load_builtins,
@@ -76,7 +77,7 @@ async def filter_quotes_by_sym(
 async def fsp_compute(
 
     ctx: tractor.Context,
-    symbol: str,
+    symbol: Symbol,
     feed: Feed,
     quote_stream: trio.abc.ReceiveChannel,
 
@@ -95,13 +96,14 @@ async def fsp_compute(
         disabled=True
     )
 
+    fqsn = symbol.front_fqsn()
     out_stream = func(
 
         # TODO: do we even need this if we do the feed api right?
         # shouldn't a local stream do this before we get a handle
         # to the async iterable? it's that or we do some kinda
         # async itertools style?
-        filter_quotes_by_sym(symbol, quote_stream),
+        filter_quotes_by_sym(fqsn, quote_stream),
 
         # XXX: currently the ``ohlcv`` arg
         feed.shm,
@@ -235,8 +237,7 @@ async def cascade(
     ctx: tractor.Context,
 
     # data feed key
-    brokername: str,
-    symbol: str,
+    fqsn: str,
 
     src_shm_token: dict,
     dst_shm_token: tuple[str, np.dtype],
@@ -289,8 +290,7 @@ async def cascade(
 
     # open a data feed stream with requested broker
     async with data.feed.maybe_open_feed(
-        brokername,
-        [symbol],
+        [fqsn],
 
         # TODO throttle tick outputs from *this* daemon since
         # it'll emit tons of ticks due to the throttle only
@@ -299,6 +299,7 @@ async def cascade(
         # tick_throttle=60,
 
     ) as (feed, quote_stream):
+        symbol = feed.symbols[fqsn]
 
         profiler(f'{func}: feed up')
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -239,7 +239,7 @@ class GodWidget(QWidget):
         symbol = linkedsplits.symbol
         if symbol is not None:
             self.window.setWindowTitle(
-                f'{symbol.key}@{symbol.brokers} '
+                f'{symbol.front_fqsn()} '
                 f'tick:{symbol.tick_size}'
             )
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -479,10 +479,8 @@ async def display_symbol_data(
     #     clear_on_next=True,
     #     group_key=loading_sym_key,
     # )
-    fqsn = '.'.join((sym, provider))
-
     async with open_feed(
-        [fqsn],
+        ['.'.join((sym, provider))],
         loglevel=loglevel,
 
         # limit to at least display's FPS

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -211,7 +211,6 @@ async def graphics_update_loop(
     # async for quotes in iter_drain_quotes():
 
     async for quotes in stream:
-
         quote_period = time.time() - last_quote
         quote_rate = round(
             1/quote_period, 1) if quote_period > 0 else float('inf')
@@ -480,24 +479,25 @@ async def display_symbol_data(
     #     clear_on_next=True,
     #     group_key=loading_sym_key,
     # )
+    fqsn = '.'.join((sym, provider))
 
     async with open_feed(
-            provider,
-            [sym],
-            loglevel=loglevel,
+        [fqsn],
+        loglevel=loglevel,
 
-            # limit to at least display's FPS
-            # avoiding needless Qt-in-guest-mode context switches
-            tick_throttle=_quote_throttle_rate,
+        # limit to at least display's FPS
+        # avoiding needless Qt-in-guest-mode context switches
+        tick_throttle=_quote_throttle_rate,
 
     ) as feed:
         ohlcv: ShmArray = feed.shm
         bars = ohlcv.array
         symbol = feed.symbols[sym]
+        fqsn = symbol.front_fqsn()
 
         # load in symbol's ohlc data
         godwidget.window.setWindowTitle(
-            f'{symbol.key}@{symbol.brokers} '
+            f'{fqsn} '
             f'tick:{symbol.tick_size} '
             f'step:1s '
         )
@@ -582,8 +582,7 @@ async def display_symbol_data(
                 open_order_mode(
                     feed,
                     chart,
-                    symbol,
-                    provider,
+                    fqsn,
                     order_mode_started
                 )
             ):

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -816,10 +816,18 @@ async def process_trades_and_update_ui(
             'position',
         ):
             sym = mode.chart.linked.symbol
-            symbol = msg['symbol'].lower()
+            pp_msg_symbol = msg['symbol'].lower()
             fqsn = sym.front_fqsn()
+            broker, key = sym.front_feed()
+            # print(
+            #     f'pp msg symbol: {pp_msg_symbol}\n',
+            #     f'fqsn: {fqsn}\n',
+            #     f'front key: {key}\n',
+            # )
 
-            if symbol in fqsn:
+            if (
+                pp_msg_symbol == fqsn.replace(f'.{broker}', '')
+            ):
                 tracker = mode.trackers[msg['account']]
                 tracker.live_pp.update_from_msg(msg)
                 # update order pane widgets

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -268,13 +268,14 @@ class OrderMode:
 
         '''
         staged = self._staged_order
-        symbol = staged.symbol
+        symbol: Symbol = staged.symbol
         oid = str(uuid.uuid4())
 
         # format order data for ems
+        fqsn = symbol.front_fqsn()
         order = staged.copy(
             update={
-                'symbol': symbol.key,
+                'symbol': fqsn,
                 'oid': oid,
             }
         )
@@ -519,8 +520,7 @@ async def open_order_mode(
 
     feed: Feed,
     chart: 'ChartPlotWidget',  # noqa
-    symbol: Symbol,
-    brokername: str,
+    fqsn: str,
     started: trio.Event,
 
 ) -> None:
@@ -546,8 +546,7 @@ async def open_order_mode(
 
     # spawn EMS actor-service
     async with (
-
-        open_ems(brokername, symbol) as (
+        open_ems(fqsn) as (
             book,
             trades_stream,
             position_msgs,
@@ -556,8 +555,7 @@ async def open_order_mode(
         trio.open_nursery() as tn,
 
     ):
-        log.info(f'Opening order mode for {brokername}.{symbol.key}')
-
+        log.info(f'Opening order mode for {fqsn}')
         view = chart.view
 
         # annotations editors
@@ -566,7 +564,7 @@ async def open_order_mode(
 
         # symbol id
         symbol = chart.linked.symbol
-        symkey = symbol.key
+        symkey = symbol.front_fqsn()
 
         # map of per-provider account keys to position tracker instances
         trackers: dict[str, PositionTracker] = {}
@@ -610,7 +608,7 @@ async def open_order_mode(
                 log.info(f'Loading pp for {symkey}:\n{pformat(msg)}')
                 startup_pp.update_from_msg(msg)
 
-            # allocator
+            # allocator config
             alloc = mk_allocator(
                 symbol=symbol,
                 account=account_name,
@@ -818,8 +816,10 @@ async def process_trades_and_update_ui(
             'position',
         ):
             sym = mode.chart.linked.symbol
-            if msg['symbol'].lower() in sym.key:
+            symbol = msg['symbol'].lower()
+            fqsn = sym.front_fqsn()
 
+            if symbol in fqsn:
                 tracker = mode.trackers[msg['account']]
                 tracker.live_pp.update_from_msg(msg)
                 # update order pane widgets


### PR DESCRIPTION
`fqsn` = "fully qualified symbol name"

Basically the idea here is for all client-ish code (aka programs/actors that ask the provider agnostic layers in the stack for data) should be able to tell which backend / venue / derivative each data feed/flow is from by an explicit string key of the current form `<instrumentname>.<venue>.<suffixwithmetadata>.<brokerbackendname>`.

I have thoughts that we should actually change this to be more like an "attr lookup" (like how the web should have done urls, but marketting peeps ruined it etc. etc.):

`<broker>.<venue>.<instrumentname>.<suffixwithmetadata>`

This preps for new derivatives search support in the `ib` backend coming in #294 (which will get rebased and likely renamed after this).


----
Moar,

- there's some fixes to the data (feed) layer to be more tolerant to IPC failures
- there might be some dependency custom fork changes i have to include, gotta dig through what's missing - CI and all..