### PR TITLE
Drop `arrow` add `pendulum`

### DIFF
--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -27,7 +27,7 @@ import time
 
 import trio
 from trio_typing import TaskStatus
-import arrow
+import pendulum
 import asks
 from fuzzywuzzy import process as fuzzy
 import numpy as np
@@ -132,7 +132,7 @@ class OHLC:
     bar_wap: float = 0.0
 
 
-# convert arrow timestamp to unixtime in miliseconds
+# convert datetime obj timestamp to unixtime in milliseconds
 def binance_timestamp(when):
     return int((when.timestamp() * 1000) + (when.microsecond / 1000))
 
@@ -230,11 +230,11 @@ class Client:
 
         if start_time is None:
             start_time = binance_timestamp(
-                arrow.utcnow().floor('minute').shift(minutes=-limit)
+                pendulum.now('UTC').start_of('minute').subtract(minutes=limit)
             )
 
         if end_time is None:
-            end_time = binance_timestamp(arrow.utcnow())
+            end_time = binance_timestamp(pendulum.now('UTC'))
 
         # https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-data
         bars = await self._api(

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1519,13 +1519,13 @@ async def get_bars(
                     ('history', hist_ev),
                     # ('live', live_ev),
                 ]:
-                    with trio.move_on_after(22) as cs:
-                        await ev.wait()
-                        log.info(f"{name} DATA RESET")
+                    # with trio.move_on_after(22) as cs:
+                    await ev.wait()
+                    log.info(f"{name} DATA RESET")
 
-                    if cs.cancelled_caught:
-                        log.warning("reset hack failed on first try?")
-                        # await tractor.breakpoint()
+                    # if cs.cancelled_caught:
+                    #     log.warning("reset hack failed on first try?")
+                    #     await tractor.breakpoint()
 
                 fails += 1
                 continue
@@ -1583,7 +1583,7 @@ async def backfill_bars(
     # on that until we have the `marketstore` daemon in place in which
     # case the shm size will be driven by user config and available sys
     # memory.
-    count: int = 16,
+    count: int = 100,
 
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
 

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -25,7 +25,7 @@ import time
 
 from trio_typing import TaskStatus
 import trio
-import arrow
+import pendulum
 import asks
 from fuzzywuzzy import process as fuzzy
 import numpy as np
@@ -401,8 +401,8 @@ class Client:
         as_np: bool = True,
     ) -> dict:
         if since is None:
-            since = arrow.utcnow().floor('minute').shift(
-                minutes=-count).timestamp()
+            since = pendulum.now('UTC').start_of('minute').subtract(
+                minutes=count).timestamp()
 
         # UTC 2017-07-02 12:53:20 is oldest seconds value
         since = str(max(1499000000, since))

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'ib_insync',
 
         # numerics
-        'arrow',  # better datetimes
+        'pendulum', # easier datetimes
         'bidict',  # 2 way map
         'cython',
         'numpy',


### PR DESCRIPTION
I found `pendulum` to be a lot friendlier and easier to get stuff done so I think switching wholesale is ideal (kinda like how we should with `httpx` 😂).

Still have to remove the rest of the arrow stuff but just putting this up for peeps that find master is broke when using `ib` 😂 

- [x] remove `arrow` and port to equivalent `pendulum` apis!