### PR TITLE
Offline history loading

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -37,7 +37,6 @@ import asyncio
 from pprint import pformat
 import inspect
 import logging
-import platform
 from random import randint
 import time
 
@@ -1583,7 +1582,7 @@ async def backfill_bars(
     # on that until we have the `marketstore` daemon in place in which
     # case the shm size will be driven by user config and available sys
     # memory.
-    count: int = 100,
+    count: int = 16,
 
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
 
@@ -1602,11 +1601,6 @@ async def backfill_bars(
 
         # async with open_history_client(fqsn) as proxy:
         async with open_client_proxy() as proxy:
-
-            if platform.system() == 'Windows':
-                log.warning(
-                    'Decreasing history query count to 4 since, windows...')
-                count = 4
 
             out, fails = await get_bars(proxy, fqsn)
 

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -213,7 +213,7 @@ async def fsp_compute(
                 # always trigger UI refresh after history update,
                 # see ``piker.ui._fsp.FspAdmin.open_chain()`` and
                 # ``piker.ui._display.trigger_update()``.
-                await stream.send(index)
+                await stream.send('update')
 
                 async for processed in out_stream:
 

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -76,7 +76,6 @@ async def filter_quotes_by_sym(
 
 async def fsp_compute(
 
-    ctx: tractor.Context,
     symbol: Symbol,
     feed: Feed,
     quote_stream: trio.abc.ReceiveChannel,
@@ -86,7 +85,7 @@ async def fsp_compute(
 
     func: Callable,
 
-    attach_stream: bool = False,
+    # attach_stream: bool = False,
     task_status: TaskStatus[None] = trio.TASK_STATUS_IGNORED,
 
 ) -> None:
@@ -193,46 +192,47 @@ async def fsp_compute(
     profiler(f'{func_name} pushed history')
     profiler.finish()
 
-    # TODO: UGH, what is the right way to do something like this?
-    if not ctx._started_called:
-        await ctx.started(index)
-
     # setup a respawn handle
     with trio.CancelScope() as cs:
+
+        # TODO: might be better to just make a "restart" method where
+        # the target task is spawned implicitly and then the event is
+        # set via some higher level api? At that poing we might as well
+        # be writing a one-cancels-one nursery though right?
         tracker = TaskTracker(trio.Event(), cs)
         task_status.started((tracker, index))
+
         profiler(f'{func_name} yield last index')
 
         # import time
         # last = time.time()
 
         try:
-            # rt stream
-            async with ctx.open_stream() as stream:
 
-                # always trigger UI refresh after history update,
-                # see ``piker.ui._fsp.FspAdmin.open_chain()`` and
-                # ``piker.ui._display.trigger_update()``.
-                await stream.send('update')
+            async for processed in out_stream:
 
-                async for processed in out_stream:
+                log.debug(f"{func_name}: {processed}")
+                key, output = processed
+                index = src.index
+                dst.array[-1][key] = output
 
-                    log.debug(f"{func_name}: {processed}")
-                    key, output = processed
-                    index = src.index
-                    dst.array[-1][key] = output
+                # NOTE: for now we aren't streaming this to the consumer
+                # stream latest array index entry which basically just acts
+                # as trigger msg to tell the consumer to read from shm
+                # TODO: further this should likely be implemented much
+                # like our `Feed` api where there is one background
+                # "service" task which computes output and then sends to
+                # N-consumers who subscribe for the real-time output,
+                # which we'll likely want to implement using local-mem
+                # chans for the fan out?
+                # if attach_stream:
+                #     await client_stream.send(index)
 
-                    # NOTE: for now we aren't streaming this to the consumer
-                    # stream latest array index entry which basically just acts
-                    # as trigger msg to tell the consumer to read from shm
-                    if attach_stream:
-                        await stream.send(index)
-
-                    # period = time.time() - last
-                    # hz = 1/period if period else float('nan')
-                    # if hz > 60:
-                    #     log.info(f'FSP quote too fast: {hz}')
-                    # last = time.time()
+                # period = time.time() - last
+                # hz = 1/period if period else float('nan')
+                # if hz > 60:
+                #     log.info(f'FSP quote too fast: {hz}')
+                # last = time.time()
         finally:
             tracker.complete.set()
 
@@ -320,7 +320,6 @@ async def cascade(
             fsp_target = partial(
 
                 fsp_compute,
-                ctx=ctx,
                 symbol=symbol,
                 feed=feed,
                 quote_stream=quote_stream,
@@ -329,7 +328,7 @@ async def cascade(
                 src=src,
                 dst=dst,
 
-                # func_name=func_name,
+                # target
                 func=func
             )
 
@@ -341,90 +340,113 @@ async def cascade(
 
             profiler(f'{func_name}: fsp up')
 
-            async def resync(tracker: TaskTracker) -> tuple[TaskTracker, int]:
-                # TODO: adopt an incremental update engine/approach
-                # where possible here eventually!
-                log.warning(f're-syncing fsp {func_name} to source')
-                tracker.cs.cancel()
-                await tracker.complete.wait()
-                return await n.start(fsp_target)
+            # sync client
+            await ctx.started(index)
 
-            def is_synced(
-                src: ShmArray,
-                dst: ShmArray
-            ) -> tuple[bool, int, int]:
-                '''Predicate to dertmine if a destination FSP
-                output array is aligned to its source array.
+            # XXX:  rt stream with client which we MUST
+            # open here (and keep it open) in order to make
+            # incremental "updates" as history prepends take
+            # place.
+            async with ctx.open_stream() as client_stream:
 
-                '''
-                step_diff = src.index - dst.index
-                len_diff = abs(len(src.array) - len(dst.array))
-                return not (
-                    # the source is likely backfilling and we must
-                    # sync history calculations
-                    len_diff > 2 or
+                # TODO: these likely should all become
+                # methods of this ``TaskLifetime`` or wtv
+                # abstraction..
+                async def resync(
+                    tracker: TaskTracker,
 
-                    # we aren't step synced to the source and may be
-                    # leading/lagging by a step
-                    step_diff > 1 or
-                    step_diff < 0
-                ), step_diff, len_diff
+                ) -> tuple[TaskTracker, int]:
+                    # TODO: adopt an incremental update engine/approach
+                    # where possible here eventually!
+                    log.warning(f're-syncing fsp {func_name} to source')
+                    tracker.cs.cancel()
+                    await tracker.complete.wait()
+                    tracker, index = await n.start(fsp_target)
 
-            async def poll_and_sync_to_step(
+                    # always trigger UI refresh after history update,
+                    # see ``piker.ui._fsp.FspAdmin.open_chain()`` and
+                    # ``piker.ui._display.trigger_update()``.
+                    await client_stream.send('update')
+                    return tracker, index
 
-                tracker: TaskTracker,
-                src: ShmArray,
-                dst: ShmArray,
+                def is_synced(
+                    src: ShmArray,
+                    dst: ShmArray
+                ) -> tuple[bool, int, int]:
+                    '''Predicate to dertmine if a destination FSP
+                    output array is aligned to its source array.
 
-            ) -> tuple[TaskTracker, int]:
+                    '''
+                    step_diff = src.index - dst.index
+                    len_diff = abs(len(src.array) - len(dst.array))
+                    return not (
+                        # the source is likely backfilling and we must
+                        # sync history calculations
+                        len_diff > 2 or
 
-                synced, step_diff, _ = is_synced(src, dst)
-                while not synced:
-                    tracker, index = await resync(tracker)
+                        # we aren't step synced to the source and may be
+                        # leading/lagging by a step
+                        step_diff > 1 or
+                        step_diff < 0
+                    ), step_diff, len_diff
+
+                async def poll_and_sync_to_step(
+
+                    tracker: TaskTracker,
+                    src: ShmArray,
+                    dst: ShmArray,
+
+                ) -> tuple[TaskTracker, int]:
+
                     synced, step_diff, _ = is_synced(src, dst)
+                    while not synced:
+                        tracker, index = await resync(tracker)
+                        synced, step_diff, _ = is_synced(src, dst)
 
-                return tracker, step_diff
+                    return tracker, step_diff
 
-            s, step, ld = is_synced(src, dst)
+                s, step, ld = is_synced(src, dst)
 
-            # detect sample period step for subscription to increment
-            # signal
-            times = src.array['time']
-            delay_s = times[-1] - times[times != times[-1]][-1]
+                # detect sample period step for subscription to increment
+                # signal
+                times = src.array['time']
+                delay_s = times[-1] - times[times != times[-1]][-1]
 
-            # Increment the underlying shared memory buffer on every
-            # "increment" msg received from the underlying data feed.
-            async with feed.index_stream(int(delay_s)) as istream:
+                # Increment the underlying shared memory buffer on every
+                # "increment" msg received from the underlying data feed.
+                async with feed.index_stream(
+                    int(delay_s)
+                ) as istream:
 
-                profiler(f'{func_name}: sample stream up')
-                profiler.finish()
+                    profiler(f'{func_name}: sample stream up')
+                    profiler.finish()
 
-                async for _ in istream:
+                    async for _ in istream:
 
-                    # respawn the compute task if the source
-                    # array has been updated such that we compute
-                    # new history from the (prepended) source.
-                    synced, step_diff, _ = is_synced(src, dst)
-                    if not synced:
-                        tracker, step_diff = await poll_and_sync_to_step(
-                            tracker,
-                            src,
-                            dst,
-                        )
+                        # respawn the compute task if the source
+                        # array has been updated such that we compute
+                        # new history from the (prepended) source.
+                        synced, step_diff, _ = is_synced(src, dst)
+                        if not synced:
+                            tracker, step_diff = await poll_and_sync_to_step(
+                                tracker,
+                                src,
+                                dst,
+                            )
 
-                        # skip adding a last bar since we should already
-                        # be step alinged
-                        if step_diff == 0:
-                            continue
+                            # skip adding a last bar since we should already
+                            # be step alinged
+                            if step_diff == 0:
+                                continue
 
-                    # read out last shm row, copy and write new row
-                    array = dst.array
+                        # read out last shm row, copy and write new row
+                        array = dst.array
 
-                    # some metrics like vlm should be reset
-                    # to zero every step.
-                    if zero_on_step:
-                        last = zeroed
-                    else:
-                        last = array[-1:].copy()
+                        # some metrics like vlm should be reset
+                        # to zero every step.
+                        if zero_on_step:
+                            last = zeroed
+                        else:
+                            last = array[-1:].copy()
 
-                    dst.push(last)
+                        dst.push(last)

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -127,8 +127,8 @@ async def fsp_compute(
     # each respective field.
     fields = getattr(dst.array.dtype, 'fields', None).copy()
     fields.pop('index')
-    # TODO: nptyping here!
-    history: Optional[np.ndarray] = None
+    history: Optional[np.ndarray] = None  # TODO: nptyping here!
+
     if fields and len(fields) > 1 and fields:
         if not isinstance(history_output, dict):
             raise ValueError(
@@ -209,6 +209,12 @@ async def fsp_compute(
         try:
             # rt stream
             async with ctx.open_stream() as stream:
+
+                # always trigger UI refresh after history update,
+                # see ``piker.ui._fsp.FspAdmin.open_chain()`` and
+                # ``piker.ui._display.trigger_update()``.
+                await stream.send(index)
+
                 async for processed in out_stream:
 
                     log.debug(f"{func_name}: {processed}")

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -356,9 +356,11 @@ class LinkedSplits(QWidget):
 
         self._symbol: Symbol = None
 
-    def graphics_cycle(self) -> None:
+    def graphics_cycle(self, **kwargs) -> None:
         from . import _display
-        return _display.graphics_update_cycle(self.display_state)
+        ds = self.display_state
+        if ds:
+            return _display.graphics_update_cycle(ds, **kwargs)
 
     @property
     def symbol(self) -> Symbol:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -346,6 +346,11 @@ class LinkedSplits(QWidget):
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layout.addWidget(self.splitter)
 
+        # chart-local graphics state that can be passed to
+        # a ``graphic_update_cycle()`` call by any task wishing to
+        # update the UI for a given "chart instance".
+        self.display_state: dict[str, dict] = {}
+
         self._symbol: Symbol = None
 
     @property

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -260,9 +260,7 @@ async def graphics_update_loop(
 
     # main loop
     async for quotes in stream:
-
         ds.quotes = quotes
-
         quote_period = time.time() - last_quote
         quote_rate = round(
             1/quote_period, 1) if quote_period > 0 else float('inf')
@@ -572,24 +570,25 @@ async def display_symbol_data(
     #     clear_on_next=True,
     #     group_key=loading_sym_key,
     # )
+    fqsn = '.'.join((sym, provider))
 
     async with open_feed(
-            provider,
-            [sym],
-            loglevel=loglevel,
+        [fqsn],
+        loglevel=loglevel,
 
-            # limit to at least display's FPS
-            # avoiding needless Qt-in-guest-mode context switches
-            tick_throttle=_quote_throttle_rate,
+        # limit to at least display's FPS
+        # avoiding needless Qt-in-guest-mode context switches
+        tick_throttle=_quote_throttle_rate,
 
     ) as feed:
         ohlcv: ShmArray = feed.shm
         bars = ohlcv.array
         symbol = feed.symbols[sym]
+        fqsn = symbol.front_fqsn()
 
         # load in symbol's ohlc data
         godwidget.window.setWindowTitle(
-            f'{symbol.key}@{symbol.brokers} '
+            f'{fqsn} '
             f'tick:{symbol.tick_size} '
             f'step:1s '
         )
@@ -674,8 +673,7 @@ async def display_symbol_data(
                 open_order_mode(
                     feed,
                     chart,
-                    symbol,
-                    provider,
+                    fqsn,
                     order_mode_started
                 )
             ):

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -50,6 +50,7 @@ from ._forms import (
     mk_form,
     open_form_input_handling,
 )
+from . import _display
 from ..fsp._api import maybe_mk_fsp_shm, Fsp
 from ..fsp import cascade
 from ..fsp._volume import (
@@ -437,12 +438,11 @@ class FspAdmin:
 
             started.set()
 
-            from ._display import trigger_update
-
             # wait for graceful shutdown signal
             async with stream.subscribe() as stream:
                 async for msg in stream:
-                    trigger_update()
+                    if msg == 'update':
+                        _display.trigger_update(self.linked)
 
             await complete.wait()
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -50,7 +50,6 @@ from ._forms import (
     mk_form,
     open_form_input_handling,
 )
-from . import _display
 from ..fsp._api import maybe_mk_fsp_shm, Fsp
 from ..fsp import cascade
 from ..fsp._volume import (
@@ -442,7 +441,13 @@ class FspAdmin:
             async with stream.subscribe() as stream:
                 async for msg in stream:
                     if msg == 'update':
-                        self.linked.graphics_cycle()
+                        # if the chart isn't hidden try to update
+                        # the data on screen.
+                        if not self.linked.isHidden():
+                            log.info(f'Re-syncing graphics for fsp: {ns_path}')
+                            self.linked.graphics_cycle(trigger_all=True)
+                    else:
+                        log.info(f'recved unexpected fsp engine msg: {msg}')
 
             await complete.wait()
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -437,7 +437,13 @@ class FspAdmin:
 
             started.set()
 
+            from ._display import trigger_update
+
             # wait for graceful shutdown signal
+            async with stream.subscribe() as stream:
+                async for msg in stream:
+                    trigger_update()
+
             await complete.wait()
 
     async def start_engine_task(

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -442,7 +442,7 @@ class FspAdmin:
             async with stream.subscribe() as stream:
                 async for msg in stream:
                     if msg == 'update':
-                        _display.trigger_update(self.linked)
+                        self.linked.graphics_cycle()
 
             await complete.wait()
 


### PR DESCRIPTION
Adds `ib` offline (market is currently closed - rt quotes aren't happening) history loading.
This brings in a bunch of commits factored out of #289 and some manual work for windows.

Please feel free to test for those users that are on this backend.


---
Oh, right because we depended on it, the factored commits also included display loop re-works from #289 which allows manually triggering and update cycle with the original motivation being for historical prepends when the market is not open (so updates from rt quotes aren't triggering updates).

> factor the "graphics draw cycle" steps into a sync function that can be triggered (remotely) to update on certain types of events for example when an fsp running in a subactor makes an update but the market is not open - it needs to tell the chart app to update graphics



 