### PR TITLE
Storage layer: initial `marketstore` tsdb support with async OHLCV history loading.

### DIFF
--- a/piker/brokers/_util.py
+++ b/piker/brokers/_util.py
@@ -33,7 +33,22 @@ class SymbolNotFound(BrokerError):
 
 
 class NoData(BrokerError):
-    "Symbol data not permitted"
+    '''
+    Symbol data not permitted or no data
+    for time range found.
+
+    '''
+    def __init__(
+        self,
+        *args,
+        frame_size: int = 1000,
+
+    ) -> None:
+        super().__init__(*args)
+
+        # when raised, machinery can check if the backend
+        # set a "frame size" for doing datetime calcs.
+        self.frame_size: int = 1000
 
 
 def resproc(
@@ -50,12 +65,12 @@ def resproc(
     if not resp.status_code == 200:
         raise BrokerError(resp.body)
     try:
-        json = resp.json()
+        msg = resp.json()
     except json.decoder.JSONDecodeError:
         log.exception(f"Failed to process {resp}:\n{resp.text}")
         raise BrokerError(resp.text)
 
     if log_resp:
-        log.debug(f"Received json contents:\n{colorize_json(json)}")
+        log.debug(f"Received json contents:\n{colorize_json(msg)}")
 
-    return json if return_json else resp
+    return msg if return_json else resp

--- a/piker/brokers/_util.py
+++ b/piker/brokers/_util.py
@@ -51,6 +51,25 @@ class NoData(BrokerError):
         self.frame_size: int = 1000
 
 
+class DataUnavailable(BrokerError):
+    '''
+    Signal storage requests to terminate.
+
+    '''
+    # TODO: add in a reason that can be displayed in the
+    # UI (for eg. `kraken` is bs and you should complain
+    # to them that you can't pull more OHLC data..)
+
+
+class DataThrottle(BrokerError):
+    '''
+    Broker throttled request rate for data.
+
+    '''
+    # TODO: add in throttle metrics/feedback
+
+
+
 def resproc(
     resp: asks.response_objects.Response,
     log: logging.Logger,

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -402,7 +402,7 @@ async def open_history_client(
             end_dt = pendulum.from_timestamp(array[-1]['time'])
             return array, start_dt, end_dt
 
-        yield get_ohlc, {'erlangs': 4, 'rate': 4}
+        yield get_ohlc, {'erlangs': 3, 'rate': 3}
 
 
 async def backfill_bars(

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -402,7 +402,7 @@ async def open_history_client(
             end_dt = pendulum.from_timestamp(array[-1]['time'])
             return array, start_dt, end_dt
 
-        yield get_ohlc
+        yield get_ohlc, {'erlangs': 4, 'rate': 4}
 
 
 async def backfill_bars(

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -295,6 +295,10 @@ class Client:
         global _enters
         # log.info(f'REQUESTING BARS {_enters} @ end={end_dt}')
         print(f'REQUESTING BARS {_enters} @ end={end_dt}')
+
+        if not end_dt:
+            end_dt = ''
+
         _enters += 1
 
         contract = await self.find_contract(fqsn)
@@ -1546,8 +1550,8 @@ async def open_history_client(
     async with open_client_proxy() as proxy:
 
         async def get_hist(
-            end_dt: str,
-            start_dt: str = '',
+            end_dt: Optional[datetime] = None,
+            start_dt: Optional[datetime] = None,
 
         ) -> tuple[np.ndarray, str]:
 

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -1482,7 +1482,9 @@ async def get_bars(
 
             if 'No market data permissions for' in msg:
                 # TODO: signalling for no permissions searches
-                raise NoData(f'Symbol: {fqsn}')
+                raise NoData(
+                    f'Symbol: {fqsn}',
+                )
                 break
 
             elif (
@@ -1562,7 +1564,10 @@ async def open_history_client(
             if out == (None, None):
                 # could be trying to retreive bars over weekend
                 log.error(f"Can't grab bars starting at {end_dt}!?!?")
-                raise NoData(f'{end_dt}')
+                raise NoData(
+                    f'{end_dt}',
+                    frame_size=2000,
+                )
 
             bars, bars_array, first_dt, last_dt = out
 

--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -57,6 +57,8 @@ from ib_insync.wrapper import Wrapper
 from ib_insync.client import Client as ib_Client
 from fuzzywuzzy import process as fuzzy
 import numpy as np
+import pendulum
+
 
 from .. import config
 from ..log import get_logger, get_console_log
@@ -1442,8 +1444,6 @@ async def get_bars(
     a ``MethoProxy``.
 
     '''
-    import pendulum
-
     fails = 0
     bars: Optional[list] = None
     first_dt: datetime = None
@@ -1471,7 +1471,9 @@ async def get_bars(
             time = bars_array['time']
             assert time[-1] == last_dt.timestamp()
             assert time[0] == first_dt.timestamp()
-            log.info(f'bars retreived for dts {first_dt}:{last_dt}')
+            log.info(
+                f'{len(bars)} bars retreived for {first_dt} -> {last_dt}'
+            )
 
             return (bars, bars_array, first_dt, last_dt), fails
 
@@ -1485,20 +1487,27 @@ async def get_bars(
                 raise NoData(
                     f'Symbol: {fqsn}',
                 )
-                break
 
             elif (
                 err.code == 162
                 and 'HMDS query returned no data' in err.message
             ):
-                # try to decrement start point and look further back
-                end_dt = last_dt = last_dt.subtract(seconds=2000)
+                # XXX: this is now done in the storage mgmt layer
+                # and we shouldn't implicitly decrement the frame dt
+                # index since the upper layer may be doing so
+                # concurrently and we don't want to be delivering frames
+                # that weren't asked for.
                 log.warning(
-                    f'No data found ending @ {end_dt}\n'
-                    f'Starting another request for {end_dt}'
+                    f'NO DATA found ending @ {end_dt}\n'
                 )
 
-                continue
+                # try to decrement start point and look further back
+                # end_dt = last_dt = last_dt.subtract(seconds=2000)
+
+                raise NoData(
+                    f'Symbol: {fqsn}',
+                    frame_size=2000,
+                )
 
             elif _pacing in msg:
 
@@ -1578,7 +1587,12 @@ async def open_history_client(
 
             return bars_array, first_dt, last_dt
 
-        yield get_hist
+        # TODO: it seems like we can do async queries for ohlc
+        # but getting the order right still isn't working and I'm not
+        # quite sure why.. needs some tinkering and probably
+        # a lookthrough of the ``ib_insync`` machinery, for eg. maybe
+        # we have to do the batch queries on the `asyncio` side?
+        yield get_hist, {'erlangs': 1, 'rate': 6}
 
 
 async def backfill_bars(
@@ -1840,6 +1854,7 @@ async def stream_quotes(
         symbol=sym,
     )
     first_quote = normalize(first_ticker)
+    # print(f'first quote: {first_quote}')
 
     def mk_init_msgs() -> dict[str, dict]:
         # pass back some symbol info like min_tick, trading_hours, etc.

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -1066,7 +1066,7 @@ async def open_history_client(
             end_dt = pendulum.from_timestamp(array[-1]['time'])
             return array, start_dt, end_dt
 
-        yield get_ohlc
+        yield get_ohlc, {'erlangs': 1, 'rate': 1}
 
 
 async def backfill_bars(

--- a/piker/brokers/kraken.py
+++ b/piker/brokers/kraken.py
@@ -20,7 +20,8 @@ Kraken backend.
 '''
 from contextlib import asynccontextmanager as acm
 from dataclasses import asdict, field
-from typing import Any, Optional, AsyncIterator, Callable
+from datetime import datetime
+from typing import Any, Optional, AsyncIterator, Callable, Union
 import time
 
 from trio_typing import TaskStatus
@@ -40,7 +41,13 @@ import base64
 
 from .. import config
 from .._cacheables import open_cached_client
-from ._util import resproc, SymbolNotFound, BrokerError
+from ._util import (
+    resproc,
+    SymbolNotFound,
+    BrokerError,
+    DataThrottle,
+    DataUnavailable,
+)
 from ..log import get_logger, get_console_log
 from ..data import ShmArray
 from ..data._web_bs import open_autorecon_ws, NoBsWs
@@ -305,7 +312,7 @@ class Client:
         action: str,
         size: float,
         reqid: str = None,
-        validate: bool = False # set True test call without a real submission
+        validate: bool = False  # set True test call without a real submission
     ) -> dict:
         '''
         Place an order and return integer request id provided by client.
@@ -391,17 +398,26 @@ class Client:
     async def bars(
         self,
         symbol: str = 'XBTUSD',
+
         # UTC 2017-07-02 12:53:20
-        since: int = None,
+        since: Optional[Union[int, datetime]] = None,
         count: int = 720,  # <- max allowed per query
         as_np: bool = True,
+
     ) -> dict:
+
         if since is None:
             since = pendulum.now('UTC').start_of('minute').subtract(
                 minutes=count).timestamp()
 
+        elif isinstance(since, int):
+            since = pendulum.from_timestamp(since).timestamp()
+
+        else:  # presumably a pendulum datetime
+            since = since.timestamp()
+
         # UTC 2017-07-02 12:53:20 is oldest seconds value
-        since = str(max(1499000000, since))
+        since = str(max(1499000000, int(since)))
         json = await self._public(
             'OHLC',
             data={
@@ -445,7 +461,16 @@ class Client:
             array = np.array(new_bars, dtype=_ohlc_dtype) if as_np else bars
             return array
         except KeyError:
-            raise SymbolNotFound(json['error'][0] + f': {symbol}')
+            errmsg = json['error'][0]
+
+            if 'not found' in errmsg:
+                raise SymbolNotFound(errmsg + f': {symbol}')
+
+            elif 'Too many requests' in errmsg:
+                raise DataThrottle(f'{symbol}')
+
+            else:
+                raise BrokerError(errmsg)
 
 
 @acm
@@ -668,8 +693,8 @@ async def handle_order_requests(
                                 oid=msg.oid,
                                 reqid=msg.reqid,
                                 symbol=msg.symbol,
-                                # TODO: maybe figure out if pending cancels will
-                                # eventually get cancelled
+                                # TODO: maybe figure out if pending
+                                # cancels will eventually get cancelled
                                 reason="Order cancel is still pending?",
                                 broker_details=resp
                             ).dict()
@@ -1003,7 +1028,45 @@ async def open_history_client(
 
     # TODO implement history getter for the new storage layer.
     async with open_cached_client('kraken') as client:
-        yield client
+
+        # lol, kraken won't send any more then the "last"
+        # 720 1m bars.. so we have to just ignore further
+        # requests of this type..
+        queries: int = 0
+
+        async def get_ohlc(
+            end_dt: Optional[datetime] = None,
+            start_dt: Optional[datetime] = None,
+
+        ) -> tuple[
+            np.ndarray,
+            datetime,  # start
+            datetime,  # end
+        ]:
+
+            nonlocal queries
+            if queries > 0:
+                raise DataUnavailable
+
+            count = 0
+            while count <= 3:
+                try:
+                    array = await client.bars(
+                        symbol,
+                        since=end_dt,
+                    )
+                    count += 1
+                    queries += 1
+                    break
+                except DataThrottle:
+                    log.warning(f'kraken OHLC throttle for {symbol}')
+                    await trio.sleep(1)
+
+            start_dt = pendulum.from_timestamp(array[0]['time'])
+            end_dt = pendulum.from_timestamp(array[-1]['time'])
+            return array, start_dt, end_dt
+
+        yield get_ohlc
 
 
 async def backfill_bars(

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -83,9 +83,10 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
 
                 )
                 log.info(
-                    f'`marketstored` up pid:{pid}\n'
-                    f'container up cid:{cid} live with config:\n'
-                    f'{pformat(config)}'
+                    f'`marketstore` up!\n'
+                    f'`marketstored` pid: {pid}\n'
+                    f'docker container id: {cid}\n'
+                    f'config: {pformat(config)}'
                 )
 
             await trio.sleep_forever()

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -72,14 +72,15 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
             trio.open_nursery() as n,
         ):
             if tsdb:
-                # TODO:
-                # async with maybe_open_marketstored():
-
                 from piker.data._ahab import start_ahab
+                from piker.data.marketstore import start_marketstore
+
                 log.info('Spawning `marketstore` supervisor')
                 ctn_ready, config, (cid, pid) = await n.start(
                     start_ahab,
                     'marketstored',
+                    start_marketstore,
+
                 )
                 log.info(
                     f'`marketstored` up pid:{pid}\n'

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -1,7 +1,25 @@
-"""
+# piker: trading gear for hackers
+# Copyright (C) 2018-present  Tyler Goodlet (in stewardship of pikers)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+'''
 CLI commons.
-"""
+
+'''
 import os
+from pprint import pformat
 
 import click
 import trio
@@ -59,12 +77,15 @@ def pikerd(loglevel, host, tl, pdb, tsdb):
 
                 from piker.data._ahab import start_ahab
                 log.info('Spawning `marketstore` supervisor')
-                ctn_ready = await n.start(
+                ctn_ready, config, (cid, pid) = await n.start(
                     start_ahab,
                     'marketstored',
                 )
-                await ctn_ready.wait()
-                log.info('`marketstore` container:{uid} up')
+                log.info(
+                    f'`marketstored` up pid:{pid}\n'
+                    f'container up cid:{cid} live with config:\n'
+                    f'{pformat(config)}'
+                )
 
             await trio.sleep_forever()
 

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -33,7 +33,10 @@ from tractor.msg import NamespacePath
 import docker
 import json
 from docker.models.containers import Container as DockerContainer
-from docker.errors import DockerException, APIError
+from docker.errors import (
+    DockerException,
+    APIError,
+)
 from requests.exceptions import ConnectionError, ReadTimeout
 
 from ..log import get_logger, get_console_log
@@ -44,6 +47,10 @@ log = get_logger(__name__)
 
 class DockerNotStarted(Exception):
     'Prolly you dint start da daemon bruh'
+
+
+class ContainerError(RuntimeError):
+    'Error reported via app-container logging level'
 
 
 @acm
@@ -147,6 +154,10 @@ class Container:
                         await tractor.breakpoint()
 
                     getattr(log, level, log.error)(f'{msg}')
+
+                    # print(f'level: {level}')
+                    if level in ('error', 'fatal'):
+                        raise ContainerError(msg)
 
                 if patt in msg:
                     return True

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -380,7 +380,12 @@ async def uniform_rate_send(
 
         if left_to_sleep > 0:
             with trio.move_on_after(left_to_sleep) as cs:
-                sym, last_quote = await quote_stream.receive()
+                try:
+                    sym, last_quote = await quote_stream.receive()
+                except trio.EndOfChannel:
+                    log.exception(f"feed for {stream} ended?")
+                    break
+
                 diff = time.time() - last_send
 
                 if not first_quote:

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -351,7 +351,7 @@ class ShmArray:
             # tries to access ``.array`` (which due to the index
             # overlap will be empty). Pretty sure we've fixed it now
             # but leaving this here as a reminder.
-            if prepend and update_first:
+            if prepend and update_first and length:
                 assert index < self._first.value
 
             if (

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -41,7 +41,7 @@ log = get_logger(__name__)
 # how  much is probably dependent on lifestyle
 _secs_in_day = int(60 * 60 * 24)
 # we try for 3 times but only on a run-every-other-day kinda week.
-_default_size = 10 * _secs_in_day
+_default_size = 20 * _secs_in_day
 # where to start the new data append index
 _rt_buffer_start = int(9*_secs_in_day)
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Any
 import decimal
 
+from bidict import bidict
 import numpy as np
 from pydantic import BaseModel
 # from numba import from_dtype
@@ -47,16 +48,16 @@ base_ohlc_dtype = np.dtype(ohlc_fields)
 # https://github.com/numba/numba/issues/4511
 # numba_ohlc_dtype = from_dtype(base_ohlc_dtype)
 
-# map time frame "keys" to minutes values
-tf_in_1m = {
-    '1m': 1,
-    '5m':  5,
-    '15m': 15,
-    '30m':  30,
-    '1h': 60,
-    '4h': 240,
-    '1d': 1440,
-}
+# map time frame "keys" to seconds values
+tf_in_1s = bidict({
+    1: '1s',
+    60: '1m',
+    60*5: '5m',
+    60*15: '15m',
+    60*30: '30m',
+    60*60: '1h',
+    60*60*24: '1d',
+})
 
 
 def mk_fqsn(

--- a/piker/data/cli.py
+++ b/piker/data/cli.py
@@ -148,7 +148,7 @@ def storesh(
             enable_modules=['piker.data._ahab'],
         ):
             symbol = symbols[0]
-            await tsdb_history_update(symbol)
+            await tsdb_history_update()
 
     trio.run(main)
 

--- a/piker/data/cli.py
+++ b/piker/data/cli.py
@@ -148,7 +148,7 @@ def storesh(
             enable_modules=['piker.data._ahab'],
         ):
             symbol = symbols[0]
-            await tsdb_history_update()
+            await tsdb_history_update(symbol)
 
     trio.run(main)
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -221,12 +221,19 @@ def diff_history(
         # write to shm.
         if (
             s_diff < 0
-            and abs(s_diff) < len(array)
         ):
-            # the + 1 is because ``last_tsdb_dt`` is pulled from
-            # the last row entry for the ``'time'`` field retreived
-            # from the tsdb.
-            to_push = array[abs(s_diff)+1:]
+            if abs(s_diff) < len(array):
+                # the + 1 is because ``last_tsdb_dt`` is pulled from
+                # the last row entry for the ``'time'`` field retreived
+                # from the tsdb.
+                to_push = array[abs(s_diff)+1:]
+
+            else:
+                # pass back only the portion of the array that is
+                # greater then the last time stamp in the tsdb.
+                time = array['time']
+                to_push = array[time >= last_tsdb_dt.timestamp()]
+
             log.info(
                 f'Pushing partial frame {to_push.size} to shm'
             )

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -192,6 +192,22 @@ async def _setup_persistent_brokerd(
         await trio.sleep_forever()
 
 
+async def start_backfill(
+    mod: ModuleType,
+    fqsn: str,
+    shm: ShmArray,
+
+    task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
+
+) -> int:
+
+    return await mod.backfill_bars(
+        fqsn,
+        shm,
+        task_status=task_status,
+    )
+
+
 async def manage_history(
     mod: ModuleType,
     bus: _FeedsBus,
@@ -222,7 +238,12 @@ async def manage_history(
     )
 
     log.info('Scanning for existing `marketstored`')
+
     is_up = await check_for_service('marketstored')
+
+    # for now only do backfilling if no tsdb can be found
+    do_backfill = not is_up and opened
+
     if is_up and opened:
         log.info('Found existing `marketstored`')
         from . import marketstore
@@ -230,6 +251,11 @@ async def manage_history(
         async with marketstore.open_storage_client(
             fqsn,
         ) as (storage, tsdb_arrays):
+
+            # TODO: get this shit workin
+            from tractor.trionics import ipython_embed
+            await ipython_embed()
+            # await ipython_embed(ns=locals())
 
             # TODO: history validation
             # assert opened, f'Persistent shm for {symbol} was already open?!'
@@ -272,16 +298,27 @@ async def manage_history(
 
                     last_dt = datetime.fromtimestamp(last_s)
                     array, next_dt = await hist(end_dt=last_dt)
+            else:
+                do_backfill = True
+
+                # await tractor.breakpoint()
 
             some_data_ready.set()
 
-    elif opened:
+    if do_backfill:
         log.info('No existing `marketstored` found..')
 
         # start history backfill task ``backfill_bars()`` is
         # a required backend func this must block until shm is
         # filled with first set of ohlc bars
-        _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
+        await bus.nursery.start(
+            start_backfill,
+            mod,
+            fqsn,
+            shm,
+        )
+
+        # _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
 
     # yield back after client connect with filled shm
     task_status.started(shm)
@@ -361,8 +398,10 @@ async def allocate_persistent_feed(
             loglevel=loglevel,
         )
     )
-    # the broker-specific fully qualified symbol name
-    bfqsn = init_msg[symbol]['fqsn']
+    # the broker-specific fully qualified symbol name,
+    # but ensure it is lower-cased for external use.
+    bfqsn = init_msg[symbol]['fqsn'].lower()
+    init_msg[symbol]['fqsn'] = bfqsn
 
     # HISTORY, run 2 tasks:
     # - a history loader / maintainer

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -308,10 +308,11 @@ async def start_backfill(
         frames = {}
 
         def iter_dts(start: datetime):
+
             while True:
 
                 hist_period = pendulum.period(
-                    start.subtract(seconds=step_size_s),
+                    start,
                     last_tsdb_dt,
                 )
                 dtrange = hist_period.range('seconds', frame_size_s)
@@ -323,8 +324,6 @@ async def start_backfill(
                     # if caller sends a new start date, reset to that
                     if start is not None:
                         log.warning(f'Resetting date range: {start}')
-                        # import pdbpp
-                        # pdbpp.set_trace()
                         break
                 else:
                     # from while

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -389,11 +389,13 @@ async def manage_history(
         # a required backend func this must block until shm is
         # filled with first set of ohlc bars
         await bus.nursery.start(
-            start_backfill,
-            mod,
-            bfqsn,
-            shm,
-            do_legacy=True,
+            partial(
+                start_backfill,
+                mod,
+                bfqsn,
+                shm,
+                do_legacy=True,
+            )
         )
 
         # yield back after client connect with filled shm

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -36,6 +36,7 @@ from trio.abc import ReceiveChannel
 from trio_typing import TaskStatus
 import tractor
 from pydantic import BaseModel
+import numpy as np
 
 from ..brokers import get_brokermod
 from .._cacheables import maybe_open_context
@@ -276,13 +277,38 @@ async def manage_history(
                 # TODO: this should be used verbatim for the pure
                 # shm backfiller approach below.
 
+                def diff_history(
+                    array,
+                    start_dt,
+                    end_dt,
+
+                ) -> np.ndarray:
+
+                    s_diff = (last_tsdb_dt - start_dt).seconds
+
+                    # if we detect a partial frame's worth of data
+                    # that is new, slice out only that history and
+                    # write to shm.
+                    if s_diff > 0:
+                        assert last_tsdb_dt > start_dt
+                        selected = array['time'] > last_tsdb_dt.timestamp()
+                        to_push = array[selected]
+                        log.info(
+                            f'Pushing partial frame {to_push.size} to shm'
+                        )
+                        return to_push
+
+                    else:
+                        return array
+
                 # start history anal and load missing new data via backend.
                 async with open_history_client(fqsn) as hist:
 
                     # get latest query's worth of history all the way
                     # back to what is recorded in the tsdb
                     array, start_dt, end_dt = await hist(end_dt='')
-                    shm.push(array)
+                    to_push = diff_history(array, start_dt, end_dt)
+                    shm.push(to_push)
 
                     # let caller unblock and deliver latest history frame
                     task_status.started(shm)
@@ -291,33 +317,13 @@ async def manage_history(
                     # pull new history frames until we hit latest
                     # already in the tsdb
                     while start_dt > last_tsdb_dt:
-
                         array, start_dt, end_dt = await hist(end_dt=start_dt)
-                        s_diff = (last_tsdb_dt - start_dt).seconds
-
-                        # if we detect a partial frame's worth of data
-                        # that is new, slice out only that history and
-                        # write to shm.
-                        if s_diff > 0:
-                            assert last_tsdb_dt > start_dt
-                            selected = array['time'] > last_tsdb_dt.timestamp()
-                            to_push = array[selected]
-                            log.info(
-                                f'Pushing partial frame {to_push.size} to shm'
-                            )
-                            shm.push(to_push, prepend=True)
-                            break
-
-                        else:
-                            # write to shm
-                            log.info(f'Pushing {array.size} datums to shm')
-                            shm.push(array, prepend=True)
+                        to_push = diff_history(array, start_dt, end_dt)
+                        shm.push(to_push, prepend=True)
 
                     # TODO: see if there's faster multi-field reads:
                     # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
                     # re-index  with a `time` and index field
-                    # await tractor.breakpoint()
-
                     shm.push(
                         fastest[-shm._first.value:],
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -394,7 +394,7 @@ async def manage_history(
                 mod,
                 bfqsn,
                 shm,
-                do_legacy=True,
+                # do_legacy=True,
             )
         )
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -249,7 +249,7 @@ async def start_backfill(
 
     last_tsdb_dt: Optional[datetime] = None,
     storage: Optional[Storage] = None,
-    write_tsdb: bool = False,
+    write_tsdb: bool = True,
 
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -22,7 +22,6 @@ This module is enabled for ``brokerd`` daemons.
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
-from datetime import datetime
 from contextlib import asynccontextmanager
 from functools import partial
 from types import ModuleType
@@ -49,7 +48,6 @@ from ._sharedmem import (
     maybe_open_shm_array,
     attach_shm_array,
     ShmArray,
-    _secs_in_day,
 )
 from .ingest import get_ingestormod
 from ._source import (
@@ -236,119 +234,137 @@ async def manage_history(
         # we expect the sub-actor to write
         readonly=False,
     )
+    # TODO: history validation
+    if not opened:
+        raise RuntimeError(
+            "Persistent shm for sym was already open?!"
+        )
 
     log.info('Scanning for existing `marketstored`')
 
     is_up = await check_for_service('marketstored')
 
     # for now only do backfilling if no tsdb can be found
-    do_backfill = not is_up and opened
+    do_legacy_backfill = not is_up and opened
 
-    if is_up and opened:
+    open_history_client = getattr(mod, 'open_history_client', None)
+
+    if is_up and opened and open_history_client:
+
         log.info('Found existing `marketstored`')
         from . import marketstore
 
         async with marketstore.open_storage_client(
             fqsn,
-        ) as (storage, tsdb_arrays):
+        ) as storage:
 
-            # TODO: get this shit workin
-            from tractor.trionics import ipython_embed
-            await ipython_embed()
-            # await ipython_embed(ns=locals())
+            tsdb_arrays = await storage.read_ohlcv(fqsn)
 
-            # TODO: history validation
-            # assert opened, f'Persistent shm for {symbol} was already open?!'
-            # if not opened:
-            #     raise RuntimeError(
-            #         "Persistent shm for sym was already open?!"
-            #     )
+            if not tsdb_arrays:
+                do_legacy_backfill = True
 
-            if tsdb_arrays:
+            else:
                 log.info(f'Loaded tsdb history {tsdb_arrays}')
-                fastest = list(tsdb_arrays[fqsn].values())[0]
-                last_s = fastest['Epoch'][-1]
 
-                # TODO: see if there's faster multi-field reads:
-                # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
-
-                # re-index  with a `time` and index field
-                shm.push(
-                    fastest[-3 * _secs_in_day:],
-
-                    # insert the history pre a "days worth" of samples
-                    # to leave some real-time buffer space at the end.
-                    prepend=True,
-                    start=shm._len - _secs_in_day,
-                    field_map={
-                        'Epoch': 'time',
-                        'Open': 'open',
-                        'High': 'high',
-                        'Low': 'low',
-                        'Close': 'close',
-                        'Volume': 'volume',
-                    },
+                fastest = list(tsdb_arrays.values())[0]
+                times = fastest['Epoch']
+                first, last = times[0], times[-1]
+                first_tsdb_dt, last_tsdb_dt = map(
+                    pendulum.from_timestamp, [first, last]
                 )
 
+                # TODO: this should be used verbatim for the pure
+                # shm backfiller approach below.
+
                 # start history anal and load missing new data via backend.
-                async with mod.open_history_client(fqsn) as hist:
+                async with open_history_client(fqsn) as hist:
 
-                    # get latest query's worth of history
-                    array, next_dt = await hist(end_dt='')
+                    # get latest query's worth of history all the way
+                    # back to what is recorded in the tsdb
+                    array, start_dt, end_dt = await hist(end_dt='')
+                    shm.push(array)
 
-                    last_dt = datetime.fromtimestamp(last_s)
-                    array, next_dt = await hist(end_dt=last_dt)
-            else:
-                do_backfill = True
+                    # let caller unblock and deliver latest history frame
+                    task_status.started(shm)
+                    some_data_ready.set()
 
-                # await tractor.breakpoint()
+                    # pull new history frames until we hit latest
+                    # already in the tsdb
+                    while start_dt > last_tsdb_dt:
 
-            some_data_ready.set()
+                        array, start_dt, end_dt = await hist(end_dt=start_dt)
+                        s_diff = (last_tsdb_dt - start_dt).seconds
 
-    if do_backfill:
+                        # if we detect a partial frame's worth of data
+                        # that is new, slice out only that history and
+                        # write to shm.
+                        if s_diff > 0:
+                            assert last_tsdb_dt > start_dt
+                            selected = array['time'] > last_tsdb_dt.timestamp()
+                            to_push = array[selected]
+                            log.info(
+                                f'Pushing partial frame {to_push.size} to shm'
+                            )
+                            shm.push(to_push, prepend=True)
+                            break
+
+                        else:
+                            # write to shm
+                            log.info(f'Pushing {array.size} datums to shm')
+                            shm.push(array, prepend=True)
+
+                    # TODO: see if there's faster multi-field reads:
+                    # https://numpy.org/doc/stable/user/basics.rec.html#accessing-multiple-fields
+                    # re-index  with a `time` and index field
+                    # await tractor.breakpoint()
+
+                    shm.push(
+                        fastest[-shm._first.value:],
+
+                        # insert the history pre a "days worth" of samples
+                        # to leave some real-time buffer space at the end.
+                        prepend=True,
+                        # start=shm._len - _secs_in_day,
+                        field_map={
+                            'Epoch': 'time',
+                            'Open': 'open',
+                            'High': 'high',
+                            'Low': 'low',
+                            'Close': 'close',
+                            'Volume': 'volume',
+                        },
+                    )
+
+                    # TODO: write new data to tsdb to be ready to for next
+                    # read.
+
+    if do_legacy_backfill:
+        # do a legacy incremental backfill from the provider.
         log.info('No existing `marketstored` found..')
 
+        bfqsn = fqsn.replace('.' + mod.name, '')
         # start history backfill task ``backfill_bars()`` is
         # a required backend func this must block until shm is
         # filled with first set of ohlc bars
         await bus.nursery.start(
             start_backfill,
             mod,
-            fqsn,
+            bfqsn,
             shm,
         )
 
-        # _ = await bus.nursery.start(mod.backfill_bars, fqsn, shm)
+        # yield back after client connect with filled shm
+        task_status.started(shm)
 
-    # yield back after client connect with filled shm
-    task_status.started(shm)
+        # indicate to caller that feed can be delivered to
+        # remote requesting client since we've loaded history
+        # data that can be used.
+        some_data_ready.set()
 
-    # indicate to caller that feed can be delivered to
-    # remote requesting client since we've loaded history
-    # data that can be used.
-    some_data_ready.set()
-
-    # detect sample step size for sampled historical data
-    times = shm.array['time']
-    delay_s = times[-1] - times[times != times[-1]][-1]
-
-    # begin real-time updates of shm and tsb once the feed
-    # goes live.
-    await feed_is_live.wait()
-
-    if opened:
-        sampler.ohlcv_shms.setdefault(delay_s, []).append(shm)
-
-        # start shm incrementing for OHLC sampling at the current
-        # detected sampling period if one dne.
-        if sampler.incrementers.get(delay_s) is None:
-            await bus.start_task(
-                increment_ohlc_buffer,
-                delay_s,
-            )
-
+    # history retreival loop depending on user interaction and thus
+    # a small RPC-prot for remotely controllinlg what data is loaded
+    # for viewing.
     await trio.sleep_forever()
-    # cs.cancel()
 
 
 async def allocate_persistent_feed(
@@ -416,7 +432,7 @@ async def allocate_persistent_feed(
         manage_history,
         mod,
         bus,
-        bfqsn,
+        '.'.join((bfqsn, brokername)),
         some_data_ready,
         feed_is_live,
     )
@@ -429,7 +445,6 @@ async def allocate_persistent_feed(
 
     # true fqsn
     fqsn = '.'.join((bfqsn, brokername))
-
     # add a fqsn entry that includes the ``.<broker>`` suffix
     init_msg[fqsn] = msg
 
@@ -464,8 +479,21 @@ async def allocate_persistent_feed(
     if not start_stream:
         await trio.sleep_forever()
 
-    # backend will indicate when real-time quotes have begun.
+    # begin real-time updates of shm and tsb once the feed goes live and
+    # the backend will indicate when real-time quotes have begun.
     await feed_is_live.wait()
+
+    # start shm incrementer task for OHLC style sampling
+    # at the current detected step period.
+    times = shm.array['time']
+    delay_s = times[-1] - times[times != times[-1]][-1]
+
+    sampler.ohlcv_shms.setdefault(delay_s, []).append(shm)
+    if sampler.incrementers.get(delay_s) is None:
+        await bus.start_task(
+            increment_ohlc_buffer,
+            delay_s,
+        )
 
     sum_tick_vlm: bool = init_msg.get(
         'shm_write_opts', {}
@@ -545,7 +573,7 @@ async def open_feed_bus(
     init_msg, first_quotes = bus.feeds[symbol]
 
     msg = init_msg[symbol]
-    bfqsn = msg['fqsn']
+    bfqsn = msg['fqsn'].lower()
 
     # true fqsn
     fqsn = '.'.join([bfqsn, brokername])
@@ -864,7 +892,10 @@ async def maybe_open_feed(
 
     **kwargs,
 
-) -> (Feed, ReceiveChannel[dict[str, Any]]):
+) -> (
+    Feed,
+    ReceiveChannel[dict[str, Any]],
+):
     '''
     Maybe open a data to a ``brokerd`` daemon only if there is no
     local one for the broker-symbol pair, if one is cached use it wrapped
@@ -885,6 +916,7 @@ async def maybe_open_feed(
             'start_stream': kwargs.get('start_stream', True),
         },
         key=fqsn,
+
     ) as (cache_hit, feed):
 
         if cache_hit:

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -323,7 +323,7 @@ async def start_backfill(
                 # broker is being a bish and we can't pull
                 # any more..
                 log.warning('backend halted on data deliver !?!?')
-                # break
+                return input_end_dt, None
 
             to_push = diff_history(
                 array,
@@ -361,6 +361,11 @@ async def start_backfill(
             # Then iterate over the return values, as they become available
             # (i.e., not necessarily in the original order)
             async for input_end_dt, outcome in outcomes:
+
+                # no data available case..
+                if outcome is None:
+                    break
+
                 try:
                     out = outcome.unwrap()
                 except Exception:

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -226,18 +226,18 @@ async def start_backfill(
     shm: ShmArray,
 
     last_tsdb_dt: Optional[datetime] = None,
-    do_legacy: bool = False,
+    # do_legacy: bool = False,
 
     task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
 
 ) -> int:
 
-    if do_legacy:
-        return await mod.backfill_bars(
-            bfqsn,
-            shm,
-            task_status=task_status,
-        )
+    # if do_legacy:
+    #     return await mod.backfill_bars(
+    #         bfqsn,
+    #         shm,
+    #         task_status=task_status,
+    #     )
 
     async with mod.open_history_client(bfqsn) as hist:
 
@@ -263,16 +263,16 @@ async def start_backfill(
 
         if last_tsdb_dt is None:
             # maybe a better default (they don't seem to define epoch?!)
-            last_tsdb_dt = pendulum.yesterday()
+            last_tsdb_dt = pendulum.now().subtract(days=1)
 
 
         # pull new history frames until we hit latest
-        # already in the tsdb
+        # already in the tsdb or a max count.
         mx_fills = 16
         count = 0
         while (
             start_dt > last_tsdb_dt
-            and count > mx_fills
+            # and count < mx_fills
         ):
         # while True:
             count += 1
@@ -286,6 +286,7 @@ async def start_backfill(
                 # XXX: hacky, just run indefinitely
                 last_tsdb_dt=None,
             )
+            print("fPULLING {count}")
             log.info(f'Pushing {to_push.size} to shm!')
 
             # bail on shm allocation overrun

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -494,7 +494,6 @@ async def tsdb_history_update(
     ):
         profiler(f'opened feed for {fqsn}')
 
-
         to_append = feed.shm.array
         to_prepend = None
 
@@ -511,6 +510,9 @@ async def tsdb_history_update(
             # hist diffing
             if tsdb_arrays:
                 onesec = tsdb_arrays[1]
+
+                # these aren't currently used but can be referenced from
+                # within the embedded ipython shell below.
                 to_append = ohlcv[ohlcv['time'] > onesec['Epoch'][-1]]
                 to_prepend = ohlcv[ohlcv['time'] < onesec['Epoch'][0]]
 

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -444,6 +444,9 @@ async def tsdb_history_update(
                 if err:
                     raise MarketStoreError(err)
 
+        from tractor.trionics import ipython_embed
+        await ipython_embed()
+
 
 async def ingest_quote_stream(
     symbols: list[str],

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -131,6 +131,16 @@ def start_marketstore(
 
     get_console_log('info', name=__name__)
 
+    yml_file = os.path.join(config._config_dir, 'mkts.yml')
+    if not os.path.isfile(yml_file):
+        log.warning(
+            f'No `marketstore` config exists?: {yml_file}\n'
+            'Generating new file from template:\n'
+            f'{_yaml_config}\n'
+        )
+        with open(yml_file, 'w') as yf:
+            yf.write(_yaml_config)
+
     # create a mount from user's local piker config dir into container
     config_dir_mnt = docker.types.Mount(
         target='/etc',

--- a/piker/fsp/_momo.py
+++ b/piker/fsp/_momo.py
@@ -167,6 +167,7 @@ def _wma(
 
     assert length == len(weights)
 
+    # lol, for long sequences this is nutso slow and expensive..
     return np.convolve(signal, weights, 'valid')
 
 

--- a/piker/fsp/_volume.py
+++ b/piker/fsp/_volume.py
@@ -309,7 +309,7 @@ async def flow_rates(
 
         if period > 1:
             trade_rate_wma = _wma(
-                dvlm_shm.array['trade_count'],
+                dvlm_shm.array['trade_count'][-period:],
                 period,
                 weights=weights,
             )
@@ -332,7 +332,7 @@ async def flow_rates(
 
         if period > 1:
             dark_trade_rate_wma = _wma(
-                dvlm_shm.array['dark_trade_count'],
+                dvlm_shm.array['dark_trade_count'][-period:],
                 period,
                 weights=weights,
             )

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -295,7 +295,8 @@ class ContentsLabels:
 
 
 class Cursor(pg.GraphicsObject):
-    '''Multi-plot cursor for use on a ``LinkedSplits`` chart (set).
+    '''
+    Multi-plot cursor for use on a ``LinkedSplits`` chart (set).
 
     '''
     def __init__(
@@ -310,7 +311,7 @@ class Cursor(pg.GraphicsObject):
 
         self.linked = linkedsplits
         self.graphics: dict[str, pg.GraphicsObject] = {}
-        self.plots: List['PlotChartWidget'] = []  # type: ignore # noqa
+        self.plots: list['PlotChartWidget'] = []  # type: ignore # noqa
         self.active_plot = None
         self.digits: int = digits
         self._datum_xy: tuple[int, float] = (0, 0)
@@ -439,7 +440,10 @@ class Cursor(pg.GraphicsObject):
         if plot.linked.xaxis_chart is plot:
             xlabel = self.xaxis_label = XAxisLabel(
                 parent=self.plots[plot_index].getAxis('bottom'),
-                # parent=self.plots[plot_index].pi_overlay.get_axis(plot.plotItem, 'bottom'),
+                # parent=self.plots[plot_index].pi_overlay.get_axis(
+                #     plot.plotItem, 'bottom'
+                # ),
+
                 opacity=_ch_label_opac,
                 bg_color=self.label_color,
             )

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -191,6 +191,9 @@ class ContentsLabel(pg.LabelItem):
 
         self.setText(
             "<b>i</b>:{index}<br/>"
+            # NB: these fields must be indexed in the correct order via
+            # the slice syntax below.
+            "<b>epoch</b>:{}<br/>"
             "<b>O</b>:{}<br/>"
             "<b>H</b>:{}<br/>"
             "<b>L</b>:{}<br/>"
@@ -198,7 +201,15 @@ class ContentsLabel(pg.LabelItem):
             "<b>V</b>:{}<br/>"
             "<b>wap</b>:{}".format(
                 *array[index - first][
-                    ['open', 'high', 'low', 'close', 'volume', 'bar_wap']
+                    [
+                        'time',
+                        'open',
+                        'high',
+                        'low',
+                        'close',
+                        'volume',
+                        'bar_wap',
+                    ]
                 ],
                 name=name,
                 index=index,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -29,6 +29,7 @@ from typing import Optional, Any, Callable
 import numpy as np
 import tractor
 import trio
+import pendulum
 import pyqtgraph as pg
 
 from .. import brokers
@@ -47,6 +48,7 @@ from ._fsp import (
     open_vlm_displays,
 )
 from ..data._sharedmem import ShmArray
+from ..data._source import tf_in_1s
 from ._forms import (
     FieldsForm,
     mk_order_pane_layout,
@@ -664,11 +666,17 @@ async def display_symbol_data(
         symbol = feed.symbols[sym]
         fqsn = symbol.front_fqsn()
 
+        times = bars['time']
+        end = pendulum.from_timestamp(times[-1])
+        start = pendulum.from_timestamp(times[times != times[-1]][-1])
+        step_size_s = (end - start).seconds
+        tf_key = tf_in_1s[step_size_s]
+
         # load in symbol's ohlc data
         godwidget.window.setWindowTitle(
             f'{fqsn} '
             f'tick:{symbol.tick_size} '
-            f'step:1s '
+            f'step:{tf_key} '
         )
 
         linked = godwidget.linkedsplits

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -398,9 +398,11 @@ def graphics_update_cycle(
             )
 
             if (
-                (xpx < update_uppx or i_diff > 0)
+                (
+                    xpx < update_uppx or i_diff > 0
+                    and liv
+                )
                 or trigger_all
-                and liv
             ):
                 # TODO: make it so this doesn't have to be called
                 # once the $vlm is up?
@@ -494,6 +496,7 @@ def graphics_update_cycle(
         if (
             xpx < update_uppx
             or i_diff > 0
+            or trigger_all
         ):
             chart.update_graphics_from_array(
                 chart.name,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -599,7 +599,7 @@ def graphics_update_cycle(
                     yrange=(mn, mx),
                 )
 
-        vars['last_mx'], vars['last_mn'] = mx, mn
+            vars['last_mx'], vars['last_mn'] = mx, mn
 
         # run synchronous update on all linked flows
         for curve_name, flow in chart._flows.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@
 # pin this to a dev branch that we have more control over especially
 # as more graphics stuff gets hashed out.
 -e git+https://github.com/pikers/pyqtgraph.git@piker_pin#egg=pyqtgraph
+
+
+# our async client for ``marketstore`` (the tsdb)
+-e git+https://github.com/pikers/anyio-marketstore.git@master#egg=anyio-marketstore

--- a/scripts/ib_data_reset.py
+++ b/scripts/ib_data_reset.py
@@ -54,7 +54,7 @@ for name in win_names:
         # disconnect?
         for key_combo, timeout in [
             # only required if we need a connection reset.
-            ('ctrl+alt+r', 12),
+            # ('ctrl+alt+r', 12),
             # data feed reset.
             ('ctrl+alt+f', 6)
         ]:

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,14 @@ setup(
         # tsdbs
         'pymarketstore',
     ],
+    extras_require={
+
+        # serialization
+        'tsdb': [
+            'docker',
+        ],
+
+    },
     tests_require=['pytest'],
     python_requires=">=3.9",  # literally for ``datetime.datetime.fromisoformat``...
     keywords=["async", "trading", "finance", "quant", "charting"],


### PR DESCRIPTION
Replaces #247 and #305 (merging history from both) and instead adds a more formal "storage layer" for retrieving and storing large ohlcv series from all major backends. The work here is best experienced with the new incremental update patchset from #302 in order to see the new graphics performance improvements at work though this should work moderately well as is.

---
#### TL;DR:
- adds a `marketstore` docker container supervisor actor which allows spawning by passing `pikerd --tsdb` -> this closes https://github.com/pikers/piker/issues/143
  - this command **must** be run as root, but the root perms will be dropped (in `pikerd`) shortly after `marketstored` (the container super) is started
- adds working `async with open_history_client()` support to `ib`, `binance`, `kraken` which allows pulling in and storing a large amount of history in the tsdb, `marketstore`.
  - this API expects the async cntx mngr endpoint to deliver an awaitable that can be called with an input `datetime` range, new special exception signals can be used (`NoData`, `DataUnavailable`) to signal that the backend can't deliver data for a given range (or at all). 
- async "batch" fetching of OHLC history using `trimeter` in the backends that can handle it (currently only `binance`).
  - includes a history "frame generator" system which delivers `datetime` ranges that are passed to the `trimeter` request scheduler and which dynamically adjusts the request-time index when a gap is detected.
- adds a `piker.data.marketstore.Storage` api/layer which allows async, high level operations. the intention is to eventually have this layer support more tsdb providers like `arctic`, `techtonicdb`. Currently the only backend is `marketstore` with client-side operations implemented using our [`anyio-marketstore` library](https://github.com/pikers/anyio-marketstore):
  - loading / reading existing ohlc time series by `fqsn` with appropriate request size limiting with `.read_ohlcv()`
  - writing ohlcv series by `fqsn` with appropriate limits with `.write_ohlcv()`
  - deleting time series entries via `Storage.delete_ts()`

---
#### What this **does (yet) not** introduce:
- real-time ingest from tick feeds to `marketstore`
  - this was originally planned but the shorter path to get graphics downsampling methods up and running was to first start with OHLC history ingest and display
- a full `storesh` interactive repl for managing the tsdb, there is a minimal `ipython` embedding at the moment but it is nowhere complete and we need a follow up task-issue to finish this.

---
#### TODO:
- `._ahab.py` supervisor:
  - [x] probably deliver back net-socket info over the `ctx.started()` call?
    - [x] grprc socket
    - [x] ws addr
  - [x] figure out what to do with the `mkts.yaml` config?
    - we could push a template from code to the user dir?
    - or should we just always gen it from python?
  - [x] cli support for running `pikerd` with the tsdb stuff spawned?
    - [x] maybe a `--tsdb` or `--data` or something?
  - [x] step by step `pikerd --tsdb` test list:
    - [x] `pikerd --tsdb` should raise `DockerNotStarted` and appropriate perms error on no `sudo` (for now)
    - [x] ctrl-c should kill container instance
- general `marketstore` config and operation:
  - [x] should we always push newly received history from backends which is not yet in the tsdb to it?
    - we could also just offer this as a config option? eventually the UI should offer manual controls for such things..
  
 to be done as #313 
  - [ ] what docs should we offer regarding saving / deleting history?

---    
#### follow up (to be written in new task-issues and implemented in coming PRs)

 moved to #314
- [ ] tick ingest support and an accompanying feed-style inter-actor API to pull feeds from ingestor re-broadcast system(s):
  - [ ] tick ingest to `marketstore` from `brokerd` feeds and experiment with `techtonicdb` schema (some tinkering was already done in this patchset by @guilledk but is unfinished).
  - [ ] tick-to-ohlcv sampling if it can be done with the [aggregator plugin](https://github.com/alpacahq/marketstore/tree/master/contrib/ondiskagg) (got a feeling we'll need to write at least a `1Sec` bucket in order for this to work looking at the code:
      - [`aggregate()` calls into `model.FromTrades()`](https://github.com/alpacahq/marketstore/pull/399/files#diff-392952832ca30145443aff46786de412b7b5876a33e5dbcbb34dde20637c6370R285) and [`FromTrades()` only accepts a min step of `1Sec`](https://github.com/alpacahq/marketstore/pull/399/files#diff-cf7320bc8ecabe28fa6f7712d8df43143d3fa8577667f777c792db773ea5fbdbR192-R205)
      - we might be able to either write a golang plugin/extension to do it from pure tick data or we can make this part of a piker actor?

these moved to https://github.com/pikers/piker/issues/312
- [ ] we need a timeseries diffing and syncing system to validate new captured histories from real-time runs (which almost always are slightly different then the history provided by the providers dbs 🙄) as well as for catching history mis-writes / gaps which need to be edited / corrected when bugs
- [ ] a REPL (with `ipython`) that allows interaction, edit, and general management of the tsdb for both the purposes of research and just plain old data mgmt.