### PR TITLE
Allow `None` for `BrokerdError.reqid`

### DIFF
--- a/piker/clearing/_messages.py
+++ b/piker/clearing/_messages.py
@@ -242,7 +242,7 @@ class BrokerdError(BaseModel):
 
     # if no brokerd order request was actually submitted (eg. we errored
     # at the ``pikerd`` layer) then there will be ``reqid`` allocated.
-    reqid: Union[int, str] = ''
+    reqid: Optional[Union[int, str]] = None
 
     symbol: str
     reason: str


### PR DESCRIPTION
Found this caused breakage on `kraken` orders which triggered the
"insufficient funds" error response. Makes sense since they won't
generate an order id if the order can't ever be submitted.