### PR TITLE
No ib pps? Account names should still load.

### DIFF
--- a/piker/brokers/ib.py
+++ b/piker/brokers/ib.py
@@ -2143,6 +2143,19 @@ async def trades_dialogue(
                 accounts.add(msg.account)
                 all_positions.append(msg.dict())
 
+        # the account has no open positions (pps) so
+        # we just deliver the accounts def for now?
+        for value in client.ib.accountValues():
+            account = value.account
+            if account not in accounts_def.inverse:
+                log.warning(
+                    f'Client {client} defines an unknown account '
+                    '(not in brokers.toml):\n'
+                    f'{account}'
+                )
+            else:
+                accounts.add(accounts_def.inverse[account])
+
         await ctx.started((
             all_positions,
             tuple(name for name in accounts_def if name in accounts),


### PR DESCRIPTION
Fixes a bug found where `emsd` wasn't getting all `brokers.toml` defined account names if no pp existed in the account (and edge case bug).

We now only verify accounts from pp data and always send the full list loaded from a `Client` and error if an account is loaded that isn't defined in the user's `brokers.toml`.