### PR TITLE
fix windows snap problem by removing maximum window size

### DIFF
--- a/piker/ui/_window.py
+++ b/piker/ui/_window.py
@@ -287,7 +287,6 @@ class MainWindow(QtGui.QMainWindow):
             app = QtGui.QApplication.instance()
             geo = self.current_screen().geometry()
             h, w = geo.height(), geo.width()
-            self.setMaximumSize(w, h)
             # use approx 1/3 of the area of the screen by default
             self._size = round(w * .666), round(h * .666)
 


### PR DESCRIPTION
removed maximum window sizing to fix problem with chart windows being incompatible with fancy zones on windows 11