### PR TITLE
Uppx slice fix

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -35,7 +35,7 @@ log = get_logger(__name__)
 
 _root_dname = 'pikerd'
 
-_registry_addr = ('127.0.0.1', 1616)
+_registry_addr = ('127.0.0.1', 6116)
 _tractor_kwargs: dict[str, Any] = {
     # use a different registry addr then tractor's default
     'arbiter_addr': _registry_addr

--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -361,7 +361,7 @@ async def cascade(
                 ) -> tuple[TaskTracker, int]:
                     # TODO: adopt an incremental update engine/approach
                     # where possible here eventually!
-                    log.warning(f're-syncing fsp {func_name} to source')
+                    log.debug(f're-syncing fsp {func_name} to source')
                     tracker.cs.cancel()
                     await tracker.complete.wait()
                     tracker, index = await n.start(fsp_target)

--- a/piker/ui/_flows.py
+++ b/piker/ui/_flows.py
@@ -750,8 +750,13 @@ class Flow(msgspec.Struct):  # , frozen=True):
             y = y[-uppx:]
             ymn, ymx = y.min(), y.max()
             # print(f'drawing uppx={uppx} mxmn line: {ymn}, {ymx}')
+            try:
+                iuppx = x[-uppx]
+            except IndexError:
+                iuppx = x
+
             dsg._last_line = QLineF(
-                x[-uppx], ymn,
+                iuppx, ymn,
                 x[-1], ymx,
             )
             # print(f'updating DS curve {self.name}')

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -440,7 +440,7 @@ class FspAdmin:
                         # if the chart isn't hidden try to update
                         # the data on screen.
                         if not self.linked.isHidden():
-                            log.info(f'Re-syncing graphics for fsp: {ns_path}')
+                            log.debug(f'Re-syncing graphics for fsp: {ns_path}')
                             self.linked.graphics_cycle(
                                 trigger_all=True,
                                 prepend_update_index=info['first'],


### PR DESCRIPTION
Bug fix for slicing source data to the `uppx` size when the data hasn't loaded enough or still backfilling - so fixes a race on the array size more or less.

Also lowers the log levels for resync msgs from the fsp engine and goes back to the original `pikerd` socket addr.