### PR TITLE
Mxmn from m4

### DIFF
--- a/piker/fsp/_engine.py
+++ b/piker/fsp/_engine.py
@@ -114,7 +114,7 @@ async def fsp_compute(
         dict[str, np.ndarray],  # multi-output case
         np.ndarray,  # single output case
     ]
-    history_output = await out_stream.__anext__()
+    history_output = await anext(out_stream)
 
     func_name = func.__name__
     profiler(f'{func_name} generated history')
@@ -374,7 +374,8 @@ async def cascade(
                             'key': dst_shm_token,
                             'first': dst._first.value,
                             'last': dst._last.value,
-                    }})
+                        }
+                    })
                     return tracker, index
 
                 def is_synced(

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1292,11 +1292,16 @@ class ChartPlotWidget(pg.PlotWidget):
 
             key = round(lbar), round(rbar)
             res = flow.maxmin(*key)
-            if res == (None, None):
+
+            if (
+                res is None or
+                res == (None, None)
+            ):
                 log.error(
                     f"{flow_key} no mxmn for bars_range => {key} !?"
                 )
                 res = 0, 0
 
         profiler(f'yrange mxmn: {key} -> {res}')
+        # print(f'{flow_key} yrange mxmn: {key} -> {res}')
         return res

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -761,6 +761,11 @@ class ChartPlotWidget(pg.PlotWidget):
 
         self.pi_overlay: PlotItemOverlay = PlotItemOverlay(self.plotItem)
 
+        # indempotent startup flag for auto-yrange subsys
+        # to detect the "first time" y-domain graphics begin
+        # to be shown in the (main) graphics view.
+        self._on_screen: bool = False
+
     def resume_all_feeds(self):
         try:
             for feed in self._feeds.values():
@@ -864,7 +869,8 @@ class ChartPlotWidget(pg.PlotWidget):
 
     def default_view(
         self,
-        bars_from_y: int = 3000,
+        bars_from_y: int = 616,
+        do_ds: bool = True,
 
     ) -> None:
         '''
@@ -925,8 +931,11 @@ class ChartPlotWidget(pg.PlotWidget):
             max=end,
             padding=0,
         )
-        self.view.maybe_downsample_graphics()
-        view._set_yrange()
+
+        if do_ds:
+            self.view.maybe_downsample_graphics()
+            view._set_yrange()
+
         try:
             self.linked.graphics_cycle()
         except IndexError:
@@ -1260,7 +1269,6 @@ class ChartPlotWidget(pg.PlotWidget):
         If ``bars_range`` is provided use that range.
 
         '''
-        # print(f'Chart[{self.name}].maxmin()')
         profiler = pg.debug.Profiler(
             msg=f'`{str(self)}.maxmin(name={name})`: `{self.name}`',
             disabled=not pg_profile_enabled(),
@@ -1294,13 +1302,15 @@ class ChartPlotWidget(pg.PlotWidget):
             res = flow.maxmin(*key)
 
             if (
-                res is None or
-                res == (None, None)
+                res is None
             ):
-                log.error(
+                log.warning(
                     f"{flow_key} no mxmn for bars_range => {key} !?"
                 )
                 res = 0, 0
+                if not self._on_screen:
+                    self.default_view(do_ds=False)
+                    self._on_screen = True
 
         profiler(f'yrange mxmn: {key} -> {res}')
         # print(f'{flow_key} yrange mxmn: {key} -> {res}')

--- a/piker/ui/_compression.py
+++ b/piker/ui/_compression.py
@@ -314,7 +314,8 @@ def _m4(
     # set all y-values to the first value passed in.
     y_out[bincount] = ys[0]
 
-    mx: float = 0
+    # full input y-data mx and mn
+    mx: float = -np.inf
     mn: float = np.inf
 
     # compute OHLC style max / min values per window sized x-frame.

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -226,32 +226,8 @@ async def graphics_update_loop(
     tick_margin = 3 * tick_size
 
     chart.show()
-    # view = chart.view
     last_quote = time.time()
     i_last = ohlcv.index
-
-    # async def iter_drain_quotes():
-    #     # NOTE: all code below this loop is expected to be synchronous
-    #     # and thus draw instructions are not picked up jntil the next
-    #     # wait / iteration.
-    #     async for quotes in stream:
-    #         while True:
-    #             try:
-    #                 moar = stream.receive_nowait()
-    #             except trio.WouldBlock:
-    #                 yield quotes
-    #                 break
-    #             else:
-    #                 for sym, quote in moar.items():
-    #                     ticks_frame = quote.get('ticks')
-    #                     if ticks_frame:
-    #                         quotes[sym].setdefault(
-    #                             'ticks', []).extend(ticks_frame)
-    #                     print('pulled extra')
-
-    #                 yield quotes
-
-    # async for quotes in iter_drain_quotes():
 
     ds = linked.display_state = DisplayState(**{
         'quotes': {},
@@ -297,6 +273,7 @@ async def graphics_update_loop(
 
         # chart isn't active/shown so skip render cycle and pause feed(s)
         if chart.linked.isHidden():
+            print('skipping update')
             chart.pause_all_feeds()
             continue
 
@@ -479,7 +456,6 @@ def graphics_update_cycle(
         ):
             chart.update_graphics_from_flow(
                 chart.name,
-                # do_append=uppx < update_uppx,
                 do_append=do_append,
             )
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -416,10 +416,8 @@ def graphics_update_cycle(
             )
             or trigger_all
         ):
-            # TODO: we should track and compute whether the last
-            # pixel in a curve should show new data based on uppx
-            # and then iff update curves and shift?
             chart.increment_view(steps=i_diff)
+            # chart.increment_view(steps=i_diff + round(append_diff - uppx))
 
             if vlm_chart:
                 vlm_chart.increment_view(steps=i_diff)

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -105,6 +105,10 @@ def chart_maxmin(
     mn, mx = out
 
     mx_vlm_in_view = 0
+
+    # TODO: we need to NOT call this to avoid a manual
+    # np.max/min trigger and especially on the vlm_chart
+    # flows which aren't shown.. like vlm?
     if vlm_chart:
         out = vlm_chart.maxmin()
         if out:

--- a/piker/ui/_flows.py
+++ b/piker/ui/_flows.py
@@ -418,12 +418,10 @@ class Flow(msgspec.Struct):  # , frozen=True):
                 mxmn = None
 
             elif self.yrange:
-                # print(f'{self.name} using yrange: {self.yrange}')
                 mxmn = self.yrange
+                # print(f'{self.name} M4 maxmin: {mxmn}')
 
             else:
-                print(f'{self.name} MANUAL MAXMIN')
-                # return 0, 0
                 if self.is_ohlc:
                     ylow = np.min(slice_view['low'])
                     yhigh = np.max(slice_view['high'])
@@ -434,6 +432,7 @@ class Flow(msgspec.Struct):  # , frozen=True):
                     yhigh = np.max(view)
 
                 mxmn = ylow, yhigh
+                # print(f'{self.name} MANUAL maxmin: {mxmin}')
 
             if mxmn is not None:
                 # cache new mxmn result
@@ -668,7 +667,7 @@ class Flow(msgspec.Struct):  # , frozen=True):
             **rkwargs,
         )
         if showing_src_data:
-            print(f"{self.name} SHOWING SOURCE")
+            # print(f"{self.name} SHOWING SOURCE")
             # reset yrange to be computed from source data
             self.yrange = None
 
@@ -1075,6 +1074,7 @@ class Renderer(msgspec.Struct):
         # xy-path data transform: convert source data to a format
         # able to be passed to a `QPainterPath` rendering routine.
         if not len(hist):
+            # XXX: this might be why the profiler only has exits?
             return
 
         x_out, y_out, connect = self.format_xy(

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -639,18 +639,24 @@ async def open_vlm_displays(
             names: list[str],
 
         ) -> tuple[float, float]:
+            '''
+            Flows "group" maxmin loop; assumes all named flows
+            are in the same co-domain and thus can be sorted
+            as one set.
 
+            Iterates all the named flows and calls the chart
+            api to find their range values and return.
+
+            TODO: really we should probably have a more built-in API
+            for this?
+
+            '''
             mx = 0
             for name in names:
-
-                mxmn = chart.maxmin(name=name)
-                if mxmn:
-                    ymax = mxmn[1]
-                    if ymax > mx:
-                        mx = ymax
+                ymn, ymx = chart.maxmin(name=name)
+                mx = max(mx, ymx)
 
             return 0, mx
-        # chart.view.maxmin = partial(multi_maxmin, names=['volume'])
 
         # TODO: fix the x-axis label issue where if you put
         # the axis on the left it's totally not lined up...

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -782,15 +782,12 @@ async def open_vlm_displays(
             ) -> None:
                 for name in names:
 
-                    render = False
-
                     if 'dark' in name:
                         color = dark_vlm_color
                     elif 'rate' in name:
                         color = vlm_color
                     else:
                         color = 'bracket'
-                        render = True
 
                     curve, _ = chart.draw_curve(
                         name=name,
@@ -808,7 +805,6 @@ async def open_vlm_displays(
                     # since only a placeholder of `None` is entered in
                     # ``.draw_curve()``.
                     flow = chart._flows[name]
-                    # flow.render = render
                     assert flow.plot is pi
 
             chart_curves(

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -650,8 +650,7 @@ async def open_vlm_displays(
                         mx = ymax
 
             return 0, mx
-
-        chart.view.maxmin = partial(multi_maxmin, names=['volume'])
+        # chart.view.maxmin = partial(multi_maxmin, names=['volume'])
 
         # TODO: fix the x-axis label issue where if you put
         # the axis on the left it's totally not lined up...
@@ -776,12 +775,16 @@ async def open_vlm_displays(
 
             ) -> None:
                 for name in names:
+
+                    render = False
+
                     if 'dark' in name:
                         color = dark_vlm_color
                     elif 'rate' in name:
                         color = vlm_color
                     else:
                         color = 'bracket'
+                        render = True
 
                     curve, _ = chart.draw_curve(
                         name=name,
@@ -799,6 +802,7 @@ async def open_vlm_displays(
                     # since only a placeholder of `None` is entered in
                     # ``.draw_curve()``.
                     flow = chart._flows[name]
+                    # flow.render = render
                     assert flow.plot is pi
 
             chart_curves(

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -923,6 +923,7 @@ class ChartView(ViewBox):
                     # XXX: super important to be aware of this.
                     # or not flow.graphics.isVisible()
                 ):
+                    # print(f'skipping {flow.name}')
                     continue
 
                 # pass in no array which will read and render from the last

--- a/piker/ui/_pathops.py
+++ b/piker/ui/_pathops.py
@@ -49,12 +49,17 @@ def xy_downsample(
 
     x_spacer: float = 0.5,
 
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    float,
+    float,
+]:
 
     # downsample whenever more then 1 pixels per datum can be shown.
     # always refresh data bounds until we get diffing
     # working properly, see above..
-    bins, x, y = ds_m4(
+    bins, x, y, ymn, ymx = ds_m4(
         x,
         y,
         uppx,
@@ -67,7 +72,7 @@ def xy_downsample(
     )).flatten()
     y = y.flatten()
 
-    return x, y
+    return x, y, ymn, ymx
 
 
 @njit(


### PR DESCRIPTION
~Draft~ **Working POC** for an idea I had while pondering #325.

The idea is simple: pull total input yrange max and min from the m4 output since it's already computing the values per pixel window and we just need to do one more max min each step and then return the summary values with the output.

---
#### MAIN THINGS TO TEST:
- [x] pop a chart on this branch **and** one that is based on master's code ideally on the same symbol with more then 2 years worth of 1m OHLC
- [x] check if one feels faster then the other
- [x] do the same with an added `--profile 10` to the `chart` cmd and see if you notice any further difference and/or worse numbers from the actual profiler output

---
Notes:
- [x]  ~right now this seems to be most effective on long term crypto (1m) charts and slower (read not as fast) on 1s feeds (due to the large zeroed arrays allocated for trade rates / dark vlm?)~ now fixed via https://github.com/pikers/piker/pull/342/commits/c6205175435fd03c90de87801abf4021ef4c847a which means even zero-ed series are cached correctly and we get the same during-downsample-mxmn speedup effects 😎  
- obviously the mxmn summary valules are computed with a flow is **not** being downsampled so there's still room for improvement presuming using `numba` or a streaming algo (like demire see #325) would do better for zoomed in / source data graphics in view cases.
- the whole `.maxmin()` callback flow i still find super confusing, mostly because we have fsps on subcharts which each have flows but which also are somewhat needlessly calling `ChartPlotWidget.maxmin()` for each overlayed flow in a `PlotItem`
  - ideally we can somehow simplify this whole `ChartView._maxmin()`, `._set_yrange()`, `Flow.maxmin()` orchestration to be more "top level triggered" by whatever view is in use and then not have Qt signal callbacks firing all over the place? needs more thought and definitely a rework to make it more understandable (unfortunately this is growing pains of figuring out how to make Qt's signals wackiness fit with our async engine..)
  - [x] made a follow up issue to begin digging into solutions for this mess in  #343