### PR TITLE
Drop token attr from `NoBsWs`

### DIFF
--- a/piker/data/_web_bs.py
+++ b/piker/data/_web_bs.py
@@ -53,13 +53,11 @@ class NoBsWs:
     def __init__(
         self,
         url: str,
-        token: str,
         stack: AsyncExitStack,
         fixture: Callable,
         serializer: ModuleType = json,
     ):
         self.url = url
-        self.token = token
         self.fixture = fixture
         self._stack = stack
         self._ws: 'WebSocketConnection' = None  # noqa
@@ -83,14 +81,9 @@ class NoBsWs:
                     trio_websocket.open_websocket_url(self.url)
                 )
                 # rerun user code fixture
-                if self.token == '':
-                    ret = await self._stack.enter_async_context(
-                        self.fixture(self)
-                    )
-                else:
-                    ret = await self._stack.enter_async_context(
-                        self.fixture(self, self.token)
-                    )
+                ret = await self._stack.enter_async_context(
+                    self.fixture(self)
+                )
 
                 assert ret is None
 
@@ -135,14 +128,13 @@ async def open_autorecon_ws(
 
     # TODO: proper type annot smh
     fixture: Callable,
-    # used for authenticated websockets
-    token: str = '',
+
 ) -> AsyncGenerator[tuple[...],  NoBsWs]:
     """Apparently we can QoS for all sorts of reasons..so catch em.
 
     """
     async with AsyncExitStack() as stack:
-        ws = NoBsWs(url, token, stack, fixture=fixture)
+        ws = NoBsWs(url, stack, fixture=fixture)
         await ws._connect()
 
         try:


### PR DESCRIPTION
Drops `NoBsWs.token` and instead expects the user to `functools.partial()` in any extra state needed by `.fixture` as was done in #346, [here](https://github.com/pikers/piker/pull/346/files#diff-fdfbab77e4bbf9c1b5d79c4daa8dd93a498c497b35899bdc9bf5dc4dfadf587bR354). 