### PR TITLE
Ahab hardkill

### DIFF
--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -51,10 +51,6 @@ class DockerNotStarted(Exception):
     'Prolly you dint start da daemon bruh'
 
 
-class ContainerError(RuntimeError):
-    'Error reported via app-container logging level'
-
-
 @acm
 async def open_docker(
     url: Optional[str] = None,
@@ -189,7 +185,7 @@ class Container:
     def hard_kill(self, start: float) -> None:
         delay = time.time() - start
         log.error(
-            f'Failed to kill container {cid} after {delay}s\n'
+            f'Failed to kill container {self.cntr.id} after {delay}s\n'
             'sending SIGKILL..'
         )
         # get out the big guns, bc apparently marketstore

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -37,7 +37,7 @@ from docker.models.containers import Container as DockerContainer
 from docker.errors import (
     DockerException,
     APIError,
-    ContainerError,
+    # ContainerError,
 )
 from requests.exceptions import ConnectionError, ReadTimeout
 
@@ -49,6 +49,10 @@ log = get_logger(__name__)
 
 class DockerNotStarted(Exception):
     'Prolly you dint start da daemon bruh'
+
+
+class ApplicationLogError(Exception):
+    'App in container reported an error in logs'
 
 
 @acm
@@ -153,7 +157,7 @@ class Container:
 
                     # print(f'level: {level}')
                     if level in ('error', 'fatal'):
-                        raise ContainerError(msg)
+                        raise ApplicationLogError(msg)
 
                 if patt in msg:
                     return True

--- a/piker/data/_ahab.py
+++ b/piker/data/_ahab.py
@@ -37,6 +37,7 @@ from docker.models.containers import Container as DockerContainer
 from docker.errors import (
     DockerException,
     APIError,
+    ContainerError,
 )
 from requests.exceptions import ConnectionError, ReadTimeout
 
@@ -96,9 +97,9 @@ async def open_docker(
         # not perms?
         raise
 
-    finally:
-        if client:
-            client.close()
+    # finally:
+    #     if client:
+    #         client.close()
 
 
 class Container:
@@ -185,6 +186,21 @@ class Container:
             if 'is not running' in err.explanation:
                 return False
 
+    def hard_kill(self, start: float) -> None:
+        delay = time.time() - start
+        log.error(
+            f'Failed to kill container {cid} after {delay}s\n'
+            'sending SIGKILL..'
+        )
+        # get out the big guns, bc apparently marketstore
+        # doesn't actually know how to terminate gracefully
+        # :eyeroll:...
+        self.try_signal('SIGKILL')
+        self.cntr.wait(
+            timeout=3,
+            condition='not-running',
+        )
+
     async def cancel(
         self,
         stop_msg: str,
@@ -231,21 +247,9 @@ class Container:
                 ConnectionError,
             ):
                 log.exception('Docker connection failure')
-                break
+                self.hard_kill(start)
         else:
-            delay = time.time() - start
-            log.error(
-                f'Failed to kill container {cid} after {delay}s\n'
-                'sending SIGKILL..'
-            )
-            # get out the big guns, bc apparently marketstore
-            # doesn't actually know how to terminate gracefully
-            # :eyeroll:...
-            self.try_signal('SIGKILL')
-            self.cntr.wait(
-                timeout=3,
-                condition='not-running',
-            )
+            self.hard_kill(start)
 
         log.cancel(f'Container stopped: {cid}')
 


### PR DESCRIPTION
Hopefully the final fix for this 😂.

Basically if we don't hard kill the container on both timeout **and** a wait error we can get in  state where it's pretty difficult to kill the supervisor actor from the parent since the root perms get dropped in the parent after the child is spawned...

This also just changes the error raised when a nasty log is detected to instead be the more explicit `ApplicationLogError` which better describes what/why we're raising. 