### PR TITLE
Fix forex

### DIFF
--- a/piker/brokers/ib/api.py
+++ b/piker/brokers/ib/api.py
@@ -47,6 +47,7 @@ import ib_insync as ibis
 from ib_insync.contract import (
     Contract,
     ContractDetails,
+    Option,
 )
 from ib_insync.order import Order
 from ib_insync.ticker import Ticker
@@ -473,7 +474,6 @@ class Client:
             pattern,
             upto=upto,
         )
-
         for key, deats in results.copy().items():
 
             tract = deats.contract
@@ -968,6 +968,10 @@ def con2fqsn(
     expiry = con.lastTradeDateOrContractMonth or ''
 
     match con:
+        case Option():
+            # TODO: option symbol parsing and sane display:
+            symbol = con.localSymbol.replace(' ', '')
+
         case ibis.Commodity():
             # commodities and forex don't have an exchange name and
             # no real volume so we have to calculate the price
@@ -983,6 +987,17 @@ def con2fqsn(
 
             # no real volume on forex feeds..
             calc_price = True
+
+    if not suffix:
+        entry = _adhoc_symbol_map.get(
+            con.symbol or con.localSymbol
+        )
+        if entry:
+            meta, kwargs = entry
+            cid = meta.get('conId')
+            if cid:
+                assert con.conId == meta['conId']
+            suffix = meta['exchange']
 
     # append a `.<suffix>` to the returned symbol
     # key for derivatives that normally is the expiry

--- a/piker/brokers/ib/api.py
+++ b/piker/brokers/ib/api.py
@@ -644,8 +644,10 @@ class Client:
                 exch = 'SMART'
 
             else:
-                exch = 'SMART'
+                # XXX: order is super important here since
+                # a primary == 'SMART' won't ever work.
                 primaryExchange = exch
+                exch = 'SMART'
 
             con = ibis.Stock(
                 symbol=sym,

--- a/piker/brokers/ib/feed.py
+++ b/piker/brokers/ib/feed.py
@@ -207,8 +207,6 @@ async def get_bars(
 
         except RequestError as err:
             msg = err.message
-            # why do we always need to rebind this?
-            # _err = err
 
             if 'No market data permissions for' in msg:
                 # TODO: signalling for no permissions searches
@@ -778,7 +776,9 @@ async def stream_quotes(
                     # generally speaking these feeds don't
                     # include vlm data.
                     atype = syminfo['asset_type']
-                    log.info(f'Non-volume asset {sym}@{atype}, skipping quote poll.')
+                    log.info(
+                        f'Non-vlm asset {sym}@{atype}, skipping quote poll...'
+                    )
 
                 else:
                     # wait for real volume on feed (trading might be closed)

--- a/piker/brokers/ib/feed.py
+++ b/piker/brokers/ib/feed.py
@@ -573,12 +573,19 @@ def normalize(
     con = ticker.contract
     if type(con) in (
         ibis.Commodity,
-        ibis.Forex,
     ):
         # commodities and forex don't have an exchange name and
         # no real volume so we have to calculate the price
         suffix = con.secType
         # no real volume on this tract
+        calc_price = True
+
+    elif type(con) in (
+        ibis.Forex,
+    ):
+        suffix = 'forex'
+        con.symbol = con.pair()
+        # no real volume on forex feeds..
         calc_price = True
 
     else:
@@ -812,6 +819,9 @@ async def data_reset_hack(
           successful.
         - other OS support?
         - integration with ``ib-gw`` run in docker + Xorg?
+        - is it possible to offer a local server that can be accessed by
+          a client? Would be sure be handy for running native java blobs
+          that need to be wrangle.
 
     '''
 

--- a/piker/data/_normalize.py
+++ b/piker/data/_normalize.py
@@ -56,7 +56,7 @@ def iterticks(
                     sig = (
                         time,
                         tick['price'],
-                        tick['size']
+                        tick.get('size')
                     )
 
                     if ttype == 'dark_trade':

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -453,13 +453,6 @@ class LinkedSplits(QWidget):
         # add crosshair graphic
         self.chart.addItem(self.cursor)
 
-        # axis placement
-        if (
-            _xaxis_at == 'bottom' and
-            'bottom' in self.chart.plotItem.axes
-        ):
-            self.chart.hideAxis('bottom')
-
         # style?
         self.chart.setFrameStyle(
             QFrame.StyledPanel |
@@ -524,20 +517,25 @@ class LinkedSplits(QWidget):
         cpw.hideAxis('left')
         cpw.hideAxis('bottom')
 
-        if self.xaxis_chart:
-            self.xaxis_chart.hideAxis('bottom')
+        if (
+            _xaxis_at == 'bottom' and (
+                self.xaxis_chart
+                or (
+                    not self.subplots
+                    and self.xaxis_chart is None
+                )
+            )
+        ):
+            if self.xaxis_chart:
+                self.xaxis_chart.hideAxis('bottom')
 
             # presuming we only want it at the true bottom of all charts.
             # XXX: uses new api from our ``pyqtgraph`` fork.
             # https://github.com/pikers/pyqtgraph/tree/plotitemoverlay_onto_pg_master
             # _ = self.xaxis_chart.removeAxis('bottom', unlink=False)
             # assert 'bottom' not in self.xaxis_chart.plotItem.axes
-
             self.xaxis_chart = cpw
             cpw.showAxis('bottom')
-
-        if self.xaxis_chart is None:
-            self.xaxis_chart = cpw
 
         qframe.chart = cpw
         qframe.hbox.addWidget(cpw)

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -824,6 +824,9 @@ async def display_symbol_data(
                     order_mode_started
                 )
             ):
+                if not vlm_chart:
+                    chart.default_view()
+
                 # let Qt run to render all widgets and make sure the
                 # sidepanes line up vertically.
                 await trio.sleep(0)


### PR DESCRIPTION
Fixes to get fiat forex pairs working again on `ib`, since the volume / flows fsp work this stuff was broken since there is no vlm data provided on the feed but the code hadn't been adjusted to compensate. This patch set fixes that.

---
Still todo:
- [x] fix x-axis labels back such that you can have **only the price chart** and you still see the label
- [x] on boot it seems the forex chart won't show currently until you hit `r`..
- ~[ ] maybe a default fsp for non-vlm feeds like these?~ leaving this for now, i'm sure someone will think of something.
- [x] still an issue with forex order mode stuff?, **no** all fixed now.
```python
(Pdb++) pp self._contracts
{
 'eur.idealpro': Forex('EURCAD', conId=15016068, exchange='IDEALPRO', localSymbol='EUR.CAD', tradingClass='EUR.CAD'),
 'eurcad.idealpro': Forex('EURCAD', conId=15016068, exchange='IDEALPRO', localSymbol='EUR.CAD', tradingClass='EUR.CAD'),
}
```

whereas the passed in `symbol` in this case is `'eur.forex'`, though the above is probably more correct?