### PR TITLE
`PpTable`s

### DIFF
--- a/piker/pp.py
+++ b/piker/pp.py
@@ -391,7 +391,8 @@ class PpTable(Struct):
             pp = pp_objs[bsuid]
 
             # XXX: debug hook for size mismatches
-            # if bsuid == 447767096:
+            # qqqbsuid = 320227571
+            # if bsuid == qqqbsuid:
             #     breakpoint()
 
             pp.minimize_clears()
@@ -649,7 +650,11 @@ def load_pps_from_toml(
     none yet exists.
 
     '''
-    with open_pps(brokername, acctid) as table:
+    with open_pps(
+        brokername,
+        acctid,
+        write_on_exit=False,
+    ) as table:
         pp_objs = table.pps
 
         # no pps entry yet for this broker/account so parse any available
@@ -687,8 +692,9 @@ def load_pps_from_toml(
 def open_pps(
     brokername: str,
     acctid: str,
+    write_on_exit: bool = True,
 
-) -> dict[str, dict[str, Position]]:
+) -> PpTable:
     '''
     Read out broker-specific position entries from
     incremental update file: ``pps.toml``.
@@ -764,6 +770,9 @@ def open_pps(
     finally:
         # breakpoint()
         # if orig != table.pps:
+
+        if not write_on_exit:
+            return
 
         # TODO: show diff output?
         # https://stackoverflow.com/questions/12956957/print-diff-of-python-dictionaries

--- a/piker/pp.py
+++ b/piker/pp.py
@@ -96,7 +96,7 @@ def open_trade_ledger(
                 return toml.dump(ledger, cf)
 
 
-class Transaction(Struct):
+class Transaction(Struct, frozen=True):
     # TODO: should this be ``.to`` (see below)?
     fqsn: str
 
@@ -688,6 +688,18 @@ def update_pps_conf(
     dict[str, Position],
     dict[str, Position],
 ]:
+    # TODO: ideally we can pass in an existing
+    # pps state to this right? such that we
+    # don't have to do a ledger reload all the
+    # time.. a couple ideas I can think of,
+    # - load pps once after backend ledger state
+    #   is loaded and keep maintainend in memory
+    #   inside a with block,
+    # - mirror this in some client side actor which
+    #   does the actual ledger updates (say the paper
+    #   engine proc if we decide to always spawn it?),
+    # - do diffs against updates from the ledger writer
+    #   actor and the in-mem state here?
 
     # this maps `.bsuid` values to positions
     pp_objs: dict[Union[str, int], Position]


### PR DESCRIPTION
Reworks the `piker.pp` apis to include a new `open_pps()` context manager which delivers a `PpTable`, a type that allows real-time incremental management of position updates from backend transaction records.

This more or less deprecates the previous `update_pps_conf()` routine.

---
In follow up,

**both moved to #345**.
~- [ ] we should add support for immediate config file (ledger or `pps.toml`) writing likely via the [`trio` async file IO apis](https://trio.readthedocs.io/en/stable/reference-io.html#asynchronous-filesystem-i-o) which use a bg thread to avoid main thread latency.~
~- [ ] probably adjust the `PpTable.dump_active()` output to be the open and closed `Position` object dicts and have a seperate method which generates the toml-ready "entries" dict for the `pps.toml`?~