### PR TITLE
Ppu history

### DIFF
--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -383,7 +383,7 @@ async def update_and_audit_msgs(
                 symbol=ibppmsg.symbol,
                 currency=ibppmsg.currency,
                 size=p.size,
-                avg_price=p.be_price,
+                avg_price=p.ppu,
             )
             msgs.append(msg)
 
@@ -430,7 +430,7 @@ async def update_and_audit_msgs(
                 symbol=p.symbol.front_fqsn(),
                 # currency=ibppmsg.currency,
                 size=p.size,
-                avg_price=p.be_price,
+                avg_price=p.ppu,
             )
             if validate and p.size:
                 raise ValueError(

--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -126,7 +126,7 @@ class Allocator(Struct):
             l_sub_pp = self.units_limit - abs_live_size
 
         elif size_unit == 'currency':
-            live_cost_basis = abs_live_size * live_pp.be_price
+            live_cost_basis = abs_live_size * live_pp.ppu
             slot_size = currency_per_slot / price
             l_sub_pp = (self.currency_limit - live_cost_basis) / price
 
@@ -158,7 +158,7 @@ class Allocator(Struct):
             if size_unit == 'currency':
                 # compute the "projected" limit's worth of units at the
                 # current pp (weighted) price:
-                slot_size = currency_per_slot / live_pp.be_price
+                slot_size = currency_per_slot / live_pp.ppu
 
             else:
                 slot_size = u_per_slot
@@ -200,7 +200,7 @@ class Allocator(Struct):
                 Position(
                     symbol=sym,
                     size=order_size,
-                    be_price=price,
+                    ppu=price,
                     bsuid=sym,
                 )
             )
@@ -229,8 +229,8 @@ class Allocator(Struct):
         abs_pp_size = abs(pp.size)
 
         if self.size_unit == 'currency':
-            # live_currency_size = size or (abs_pp_size * pp.be_price)
-            live_currency_size = abs_pp_size * pp.be_price
+            # live_currency_size = size or (abs_pp_size * pp.ppu)
+            live_currency_size = abs_pp_size * pp.ppu
             prop = live_currency_size / self.currency_limit
 
         else:
@@ -303,7 +303,7 @@ def mk_allocator(
     # if the current position is already greater then the limit
     # settings, increase the limit to the current position
     if alloc.size_unit == 'currency':
-        startup_size = startup_pp.size * startup_pp.be_price
+        startup_size = startup_pp.size * startup_pp.ppu
 
         if startup_size > alloc.currency_limit:
             alloc.currency_limit = round(startup_size, ndigits=2)

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -259,7 +259,7 @@ class PaperBoi:
             Position(
                 Symbol(key=symbol),
                 size=size,
-                be_price=price,
+                ppu=price,
                 bsuid=symbol,
             )
         )
@@ -283,7 +283,7 @@ class PaperBoi:
             # inferred from the pair?
             currency='',
             size=pp.size,
-            avg_price=pp.be_price,
+            avg_price=pp.ppu,
         )
 
         await self.ems_trades_stream.send(pp_msg)

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -106,8 +106,8 @@ async def update_pnl_from_feed(
                             # compute and display pnl status
                             order_mode.pane.pnl_label.format(
                                 pnl=copysign(1, size) * pnl(
-                                    # live.be_price,
-                                    order_mode.current_pp.live_pp.be_price,
+                                    # live.ppu,
+                                    order_mode.current_pp.live_pp.ppu,
                                     tick['price'],
                                 ),
                             )
@@ -357,7 +357,7 @@ class SettingsPane:
             # last historical close price
             last = feed.shm.array[-1][['close']][0]
             pnl_value = copysign(1, size) * pnl(
-                tracker.live_pp.be_price,
+                tracker.live_pp.ppu,
                 last,
             )
 
@@ -557,7 +557,7 @@ class PositionTracker:
         pp = position or self.live_pp
 
         self.update_line(
-            pp.be_price,
+            pp.ppu,
             pp.size,
             self.chart.linked.symbol.lot_size_digits,
         )
@@ -571,7 +571,7 @@ class PositionTracker:
             self.hide()
 
         else:
-            self._level_marker.level = pp.be_price
+            self._level_marker.level = pp.ppu
 
             # these updates are critical to avoid lag on view/scene changes
             self._level_marker.update()  # trigger paint

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -610,7 +610,7 @@ async def open_order_mode(
             startup_pp = Position(
                 symbol=symbol,
                 size=0,
-                be_price=0,
+                ppu=0,
 
                 # XXX: BLEH, do we care about this on the client side?
                 bsuid=symbol,


### PR DESCRIPTION
Proper fixes and terminology to get us ready for historical position lifetimes as described in #345.

---
More to come in terms of explanation... or not 😂 

---
#### `pps.toml` format changes:
- [x] could we maybe just drop the top level `.size` and `be_price` values ?
  - so we can't (yet), because the ems uses the `Position` type internally as well and doesn't track all the
    clears (since that would be more msging overhead) so I think maybe having these is fine but we should probably
   change `.be_price` -> `.ppu`?
  - and instead just arrange the clears table to make these rolling values more obvious?, for eg:
```toml
[kraken.spot."xbteur.kraken"]
bsuid = "xbteur"
clears = [
 {  accum_size = 0.00639943, ppu = 19620.4996648139, cost = 0.32477, price = 19519.0, size = 0.00639943, dt = "2022-06-17T00:17:53.030664+00:00", tid = "TZVEXD-USARI-COY2ZR"},
```
which would be easiest to read if we sort clears reverse chronological so that the most recent trades (and thus their `ppu` and `accum_size` entries would be closest to the top?
- [x] it follows that maybe we should adjust the column order for each clears entry maybe to: `dt, ppu, accum_size, price, size, cost, tid`?
- ~[ ] i was hoping to have an indent per account (mentioned it in #345 as part of a custom encoder) such that it's distinguishable which pps are grouped together by backend, my only concern is then the clears table entries will be a bit cramped horizontally?~  **delaying this one again**