### PR TITLE
Kill `pydantic` from `kraken`

### DIFF
--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -33,7 +33,6 @@ import asks
 from fuzzywuzzy import process as fuzzy
 import numpy as np
 import tractor
-from pydantic.dataclasses import dataclass
 import wsproto
 
 from .._cacheables import open_cached_client
@@ -106,14 +105,14 @@ class Pair(Struct, frozen=True):
     permissions: list[str]
 
 
-@dataclass
-class OHLC:
-    """Description of the flattened OHLC quote format.
+class OHLC(Struct):
+    '''
+    Description of the flattened OHLC quote format.
 
     For schema details see:
     https://binance-docs.github.io/apidocs/spot/en/#kline-candlestick-streams
 
-    """
+    '''
     time: int
 
     open: float
@@ -262,6 +261,7 @@ class Client:
         for i, bar in enumerate(bars):
 
             bar = OHLC(*bar)
+            bar.typecast()
 
             row = []
             for j, (name, ftype) in enumerate(_ohlc_dtype[1:]):

--- a/piker/brokers/kraken/api.py
+++ b/piker/brokers/kraken/api.py
@@ -34,7 +34,6 @@ import pendulum
 import asks
 from fuzzywuzzy import process as fuzzy
 import numpy as np
-from pydantic.dataclasses import dataclass
 import urllib.parse
 import hashlib
 import hmac
@@ -76,31 +75,6 @@ _show_wap_in_history = True
 _symbol_info_translation: dict[str, str] = {
     'tick_decimals': 'pair_decimals',
 }
-
-
-@dataclass
-class OHLC:
-    '''
-    Description of the flattened OHLC quote format.
-
-    For schema details see:
-        https://docs.kraken.com/websockets/#message-ohlc
-
-    '''
-    chan_id: int  # internal kraken id
-    chan_name: str  # eg. ohlc-1  (name-interval)
-    pair: str  # fx pair
-    time: float  # Begin time of interval, in seconds since epoch
-    etime: float  # End time of interval, in seconds since epoch
-    open: float  # Open price of interval
-    high: float  # High price within interval
-    low: float  # Low price within interval
-    close: float  # Close price of interval
-    vwap: float  # Volume weighted average price within interval
-    volume: float  # Accumulated volume **within interval**
-    count: int  # Number of trades within interval
-    # (sampled) generated tick data
-    ticks: list[Any] = field(default_factory=list)
 
 
 def get_config() -> dict[str, Any]:

--- a/piker/brokers/kraken/api.py
+++ b/piker/brokers/kraken/api.py
@@ -19,7 +19,6 @@ Kraken web API wrapping.
 
 '''
 from contextlib import asynccontextmanager as acm
-from dataclasses import field
 from datetime import datetime
 import itertools
 from typing import (

--- a/piker/data/types.py
+++ b/piker/data/types.py
@@ -66,3 +66,10 @@ class Struct(
         ).decode(
             msgspec.msgpack.Encoder().encode(self)
         )
+
+    def typecast(
+        self,
+        # fields: Optional[list[str]] = None,
+    ) -> None:
+        for fname, ftype in self.__annotations__.items():
+            setattr(self, fname, ftype(getattr(self, fname)))


### PR DESCRIPTION
Somehow these bits got missed during #353, no idea how but probably something to to with the #349 patchset still being in progress.

Note this PR should land on master **after** https://github.com/pikers/piker/pull/369.

This coverts the remaining bits to use `msgspec` equivalents inside the `kraken` backend:
- add a `Struct.typecast()` method to get `pydantic`-runtime-casting style conversion of field values
-  converts remaining `OHLC` stuff in `kraken` data feed msg parsers to use our internal struct variant

 