### PR TITLE
Drop `msgpack` from `marketstore` module

### DIFF
--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -37,7 +37,7 @@ import time
 from math import isnan
 
 from bidict import bidict
-import msgpack
+from msgspec.msgpack import encode, decode
 import pyqtgraph as pg
 import numpy as np
 import tractor
@@ -774,12 +774,13 @@ async def stream_quotes(
     async with open_websocket_url(f'ws://{host}:{port}/ws') as ws:
         # send subs topics to server
         resp = await ws.send_message(
-            msgpack.dumps({'streams': list(tbks.values())})
+
+            encode({'streams': list(tbks.values())})
         )
         log.info(resp)
 
         async def recv() -> dict[str, Any]:
-            return msgpack.loads((await ws.get_message()), encoding='utf-8')
+            return decode((await ws.get_message()), encoding='utf-8')
 
         streams = (await recv())['streams']
         log.info(f"Subscribed to {streams}")


### PR DESCRIPTION
Lingering import missed from https://github.com/goodboy/tractor/issues/313.

Thinks @iamzoltan already ran into this one.
Kinda surprised CI didn't catch it since it was an import issue?

Might be because we don't spin up `pikerd` in CI?