### PR TITLE
Doin the splits

### DIFF
--- a/piker/brokers/ib/api.py
+++ b/piker/brokers/ib/api.py
@@ -1245,7 +1245,6 @@ async def open_client_proxies() -> tuple[
 ]:
     async with (
         tractor.trionics.maybe_open_context(
-            # acm_func=open_client_proxies,
             acm_func=tractor.to_asyncio.open_channel_from,
             kwargs={'target': load_clients_for_trio},
 

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -462,8 +462,8 @@ async def trades_dialogue(
         with (
             ExitStack() as lstack,
         ):
+            # load ledgers and pps for all detected client-proxies
             for account, proxy in proxies.items():
-
                 assert account in accounts_def
                 accounts.add(account)
                 acctid = account.strip('ib.')
@@ -478,6 +478,7 @@ async def trades_dialogue(
                     open_pps('ib', acctid)
                 )
 
+            for account, proxy in proxies.items():
                 client = aioclients[account]
 
                 # process pp value reported from ib's system. we only use these
@@ -971,7 +972,9 @@ def norm_trade_records(
     for tid, record in ledger.items():
 
         conid = record.get('conId') or record['conid']
-        comms = record.get('commission') or -1*record['ibCommission']
+        comms = record.get('commission')
+        if comms is None:
+            comms = -1*record['ibCommission']
         price = record.get('price') or record['tradePrice']
 
         # the api doesn't do the -/+ on the quantity for you but flex

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -616,7 +616,7 @@ async def trades_dialogue(
                 trio.open_nursery() as n,
             ):
 
-                for client in aioclients.values():
+                for client in set(aioclients.values()):
                     trade_event_stream = await n.start(
                         open_trade_event_stream,
                         client,

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -405,11 +405,12 @@ async def update_and_audit_msgs(
                 avg_price=p.ppu,
             )
             if validate and p.size:
-                raise ValueError(
-                    f'UNEXPECTED POSITION ib <-> piker ledger:\n'
+                # raise ValueError(
+                log.error(
+                    f'UNEXPECTED POSITION says ib:\n'
                     f'piker: {msg}\n'
                     'YOU SHOULD FIGURE OUT WHY TF YOUR LEDGER IS OFF!?\n'
-                    'MAYBE THEY LIQUIDATED YOU BRO!??!'
+                    'THEY LIQUIDATED YOU OR YOUR MISSING LEDGER RECORDS!?'
                 )
             msgs.append(msg)
 
@@ -506,6 +507,7 @@ async def trades_dialogue(
                     ):
                         trans = norm_trade_records(ledger)
                         table.update_from_trans(trans)
+
                         # update trades ledgers for all accounts from connected
                         # api clients which report trades for **this session**.
                         trades = await proxy.trades()

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -547,6 +547,12 @@ async def trades_dialogue(
                             )
                             continue
 
+                        # XXX: not sure exactly why it wouldn't be in
+                        # the updated output (maybe this is a bug?) but
+                        # if you create a pos from TWS and then load it
+                        # from the api trades it seems we get a key
+                        # error from ``update[bsuid]`` ?
+                        pp = table.pps[bsuid]
                         if msg.size != pp.size:
                             log.error(
                                 'Position mismatch {pp.symbol.front_fqsn()}:\n'

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -494,8 +494,6 @@ async def trades_dialogue(
                     ):
                         trans = norm_trade_records(ledger)
                         updated = table.update_from_trans(trans)
-                        pp = updated[bsuid]
-
                         # update trades ledgers for all accounts from connected
                         # api clients which report trades for **this session**.
                         trades = await proxy.trades()
@@ -523,7 +521,18 @@ async def trades_dialogue(
                                 table.update_from_trans(trans)
                                 updated = table.update_from_trans(trans)
 
-                        assert msg.size == pp.size, 'WTF'
+                        # XXX: not sure exactly why it wouldn't be in
+                        # the updated output (maybe this is a bug?) but
+                        # if you create a pos from TWS and then load it
+                        # from the api trades it seems we get a key
+                        # error from ``update[bsuid]`` ?
+                        pp = table.pps[bsuid]
+                        if msg.size != pp.size:
+                            log.error(
+                                'Position mismatch {pp.symbol.front_fqsn()}:\n'
+                                f'ib: {msg.size}\n'
+                                f'piker: {pp.size}\n'
+                            )
 
                 active_pps, closed_pps = table.dump_active()
 


### PR DESCRIPTION
Uber basic stock (not sure any other instrument does this?) split support in `pps.toml` files by allowing an `split_ratio: float` field in each position section that can avoid size discrepancies from a backend (like `ib`) when a split happens behind the scenes.

Probably more ideally we support different types of "events" in the `clears` table (but maybe relabel it as `events: list[dict]` and then we can have the user insert a split/reversesplit entry which will then generate a new `ppu` and `accum_size` when detected?

----
This patch also includes some general fixes to the `.ib.broker` module that seems to have been missed/broken as part of #372?  

Mainly:
- ensuring that pp tables and ledgers are loaded for each account and used per-account in stead of what was a factoring bug where only the last account-set loaded was being used resulting in incorrect pos sizing.. 
- repairing the client scan loop to only register clients that actually connect to API endpoints.. [f202699](https://github.com/pikers/piker/pull/383/commits/f202699c25345b81cc7c784b46c2381d68351eef)
- starting **one and only one** order handler task pair per loaded client instead of per account since accounts are a surjection onto clients:
  - [0fb0767](https://github.com/pikers/piker/pull/383/commits/0fb07670d2277b9d3f8a695447bba472d9326c03)
  - [52febac](https://github.com/pikers/piker/pull/383/commits/52febac6ae5add7de83d2aec290826e88064ff43)