### PR TITLE
Paper race tolerance

### DIFF
--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -96,7 +96,7 @@ class Allocator(Struct):
     def next_order_info(
         self,
 
-        # we only need a startup size for exit calcs, we can the
+        # we only need a startup size for exit calcs, we can then
         # determine how large slots should be if the initial pp size was
         # larger then the current live one, and the live one is smaller
         # then the initial config settings.
@@ -137,12 +137,14 @@ class Allocator(Struct):
 
         # an entry (adding-to or starting a pp)
         if (
-            action == 'buy' and live_size > 0 or
-            action == 'sell' and live_size < 0 or
             live_size == 0
+            or (action == 'buy' and live_size > 0)
+            or action == 'sell' and live_size < 0
         ):
-
-            order_size = min(slot_size, l_sub_pp)
+            order_size = min(
+                slot_size,
+                max(l_sub_pp, 0),
+            )
 
         # an exit (removing-from or going to net-zero pp)
         else:

--- a/piker/clearing/_allocate.py
+++ b/piker/clearing/_allocate.py
@@ -244,14 +244,6 @@ class Allocator(Struct):
         return round(prop * self.slots)
 
 
-_derivs = (
-    'future',
-    'continuous_future',
-    'option',
-    'futures_option',
-)
-
-
 def mk_allocator(
 
     symbol: Symbol,
@@ -278,45 +270,9 @@ def mk_allocator(
         'currency_limit': 6e3,
         'slots': 6,
     }
-
     defaults.update(user_def)
 
-    alloc = Allocator(
+    return Allocator(
         symbol=symbol,
         **defaults,
     )
-
-    asset_type = symbol.type_key
-
-    # specific configs by asset class / type
-
-    if asset_type in _derivs:
-        # since it's harder to know how currency "applies" in this case
-        # given leverage properties
-        alloc.size_unit = '# units'
-
-        # set units limit to slots size thus making make the next
-        # entry step 1.0
-        alloc.units_limit = alloc.slots
-
-    else:
-        alloc.size_unit = 'currency'
-
-    # if the current position is already greater then the limit
-    # settings, increase the limit to the current position
-    if alloc.size_unit == 'currency':
-        startup_size = startup_pp.size * startup_pp.ppu
-
-        if startup_size > alloc.currency_limit:
-            alloc.currency_limit = round(startup_size, ndigits=2)
-
-    else:
-        startup_size = abs(startup_pp.size)
-
-        if startup_size > alloc.units_limit:
-            alloc.units_limit = startup_size
-
-            if asset_type in _derivs:
-                alloc.slots = alloc.units_limit
-
-    return alloc

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -106,7 +106,6 @@ class PaperBoi(Struct):
         if entry:
             # order is already existing, this is a modify
             (oid, symbol, action, old_price) = entry
-            assert old_price != price
             is_modify = True
         else:
             # register order internally
@@ -183,9 +182,9 @@ class PaperBoi(Struct):
         oid, symbol, action, price = self._reqids[reqid]
 
         if action == 'buy':
-            self._buys[symbol].pop((oid, price))
+            self._buys[symbol].pop(oid, None)
         elif action == 'sell':
-            self._sells[symbol].pop((oid, price))
+            self._sells[symbol].pop(oid, None)
 
         # TODO: net latency model
         await trio.sleep(0.05)

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -325,10 +325,10 @@ async def simulate_fills(
                 # dark order price filter(s)
                 types=('ask', 'bid', 'trade', 'last')
             ):
-                # print(tick)
                 match tick:
                     case {
                         'price': tick_price,
+                        # 'type': ('ask' | 'trade' | 'last'),
                         'type': 'ask',
                     }:
                         client.last_ask = (
@@ -345,6 +345,7 @@ async def simulate_fills(
 
                     case {
                         'price': tick_price,
+                        # 'type': ('bid' | 'trade' | 'last'),
                         'type': 'bid',
                     }:
                         client.last_bid = (
@@ -364,14 +365,17 @@ async def simulate_fills(
                         'price': tick_price,
                         'type': ('trade' | 'last'),
                     }:
-                        # TODO: simulate actual book queues and our orders
-                        # place in it, might require full L2 data?
+                        # TODO: simulate actual book queues and our
+                        # orders place in it, might require full L2
+                        # data?
                         continue
 
                 # iterate book prices descending
                 for oid, our_price in book_sequence:
-                    if pred(our_price):
-
+                    # print(tick)
+                    # print((sym, list(book_sequence), client._buys, client._sells))
+                    clearable = pred(our_price)
+                    if clearable:
                         # retreive order info
                         (size, reqid, action) = orders.pop((oid, our_price))
 
@@ -428,7 +432,7 @@ async def handle_order_requests(
                 # call our client api to submit the order
                 reqid = await client.submit_limit(
                     oid=order.oid,
-                    symbol=order.symbol,
+                    symbol=f'{order.symbol}.{client.broker}',
                     price=order.price,
                     action=order.action,
                     size=order.size,

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -639,11 +639,6 @@ async def open_order_mode(
             iter(accounts.keys())
         ) if accounts else 'paper'
 
-        # Pack position messages by account, should only be one-to-one.
-        # NOTE: requires the backend exactly specifies
-        # the expected symbol key in its positions msg.
-        # pps_by_account = {}
-
         # update pp trackers with data relayed from ``brokerd``.
         for account_name in accounts:
 
@@ -656,6 +651,7 @@ async def open_order_mode(
                 # XXX: BLEH, do we care about this on the client side?
                 bsuid=symbol,
             )
+
             # allocator config
             alloc = mk_allocator(
                 symbol=symbol,
@@ -750,7 +746,6 @@ async def open_order_mode(
         # to order sync pane handler
         for key in ('account', 'size_unit',):
             w = form.fields[key]
-
             w.currentTextChanged.connect(
                 partial(
                     order_pane.on_selection_change,
@@ -773,6 +768,9 @@ async def open_order_mode(
         # Begin order-response streaming
         done()
 
+        # Pack position messages by account, should only be one-to-one.
+        # NOTE: requires the backend exactly specifies
+        # the expected symbol key in its positions msg.
         for (broker, acctid), msgs in position_msgs.items():
             for msg in msgs:
                 log.info(f'Loading pp for {symkey}:\n{pformat(msg)}')
@@ -869,8 +867,7 @@ async def process_trade_msg(
             log.info(f'{fqsn} matched pp msg: {fmsg}')
             tracker = mode.trackers[msg['account']]
             tracker.live_pp.update_from_msg(msg)
-            # update order pane widgets
-            tracker.update_from_pp()
+            tracker.update_from_pp(set_as_startup=True)  # status/pane UI
             mode.pane.update_status_ui(tracker)
 
             if tracker.live_pp.size:


### PR DESCRIPTION
Logic tidbits for the ems and paper engine to handle racy cases discovered after more thorough testing using 1s sampled feeds on the `binance` backend - i.e. testing against actual HFT feeds.

### summary:
- tweaking the `PaperBoi` internal order tables to use `dict[str, defaultdict[str, bidict]]` with only `oid` keys on the second level instead of price (which can change in a racy way relative to existing / modified entries).
- adding special skip cases to the ems relay loop for when the paper engine relays status messages fast enough that they get scheduled for processing before preceding ack msgs - this might eventually drive adding `.oid` to `BrokerdStatus` responses and/or replacing that msg with `Status` on the `brokerd` leg
- a bug fix to actually pass the broker suffixed symbol key to `PaperBoi.submit_limit()` so that submissions actually clear 😂   

---
### todo:
- [x] sure would like the paper engine to clear "live" submissions on `'last', 'trade'` ticks to be more realistic instead of only on the l1 (bid/ask) ticks. **=> completed in cbc0eb43**
- [x] there currently seems to be a bug with the order mode allocator where you can make a position outside the limit and even close it out 😂 ?!? **=>** e5d8fa59, 80b5c4bd
  - **turns out there's more issue here but we're deferring to #392.. since the issues are actually already on master from the reworks to the `.ui.order_mode` codez.**
- [x] fix this stupid thing:
`Aug 24 15:13:54 (chart, 7162, piker.ui._interaction.handle_viewmode_kb_inputs)) [ERROR] piker.ui._position _position.py:260 Invalid value for `account`: paper` **=> 91ccdb71**