### PR TITLE
Brokercheck an all backends

### DIFF
--- a/piker/brokers/__init__.py
+++ b/piker/brokers/__init__.py
@@ -30,6 +30,7 @@ __brokers__ = [
     'robinhood',
     'ib',
     'kraken',
+    'deribit'
 ]
 
 

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -282,7 +282,7 @@ class Client:
 
 
 @acm
-async def get_client() -> Client:
+async def get_client(is_brokercheck: bool = False) -> Client:
     client = Client()
     await client.cache_symbols()
     yield client

--- a/piker/brokers/kraken/api.py
+++ b/piker/brokers/kraken/api.py
@@ -518,7 +518,7 @@ class Client:
 
 
 @acm
-async def get_client() -> Client:
+async def get_client(is_brokercheck: bool = False) -> Client:
 
     conf = get_config()
     if conf:

--- a/piker/brokers/questrade.py
+++ b/piker/brokers/questrade.py
@@ -732,7 +732,8 @@ def get_config(
 @asynccontextmanager
 async def get_client(
     config_path: str = None,
-    ask_user: bool = True
+    ask_user: bool = True,
+    is_brokercheck: bool = False
 ) -> Client:
     """Spawn a broker client for making requests to the API service.
     """

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -1,0 +1,72 @@
+from tractor.testing import tractor_test
+
+from piker.brokers import __brokers__, get_brokermod
+
+
+async def run_method(client, meth_name: str, **kwargs):
+    result = await getattr(client, meth_name)(**kwargs)
+    return result
+
+
+async def run_test(broker_name: str):
+    brokermod = get_brokermod(broker_name)
+
+    assert hasattr(brokermod, 'get_client')
+
+    async with brokermod.get_client(is_brokercheck=True) as client:
+
+        # check for methods present on brokermod
+        method_list = [
+            'get_client',
+            'trades_dialogue',
+            'open_history_client',
+            'open_symbol_search',
+            'stream_quotes',
+        ]
+
+        for method in method_list:
+            assert hasattr(brokermod, method)
+
+        # check for methods present con brokermod.Client and their
+        # results
+
+        # for private methods only check is present
+        method_list = [
+            'get_balances',
+            'get_assets',
+            'get_trades',
+            'get_xfers',
+            'submit_limit',
+            'submit_cancel',
+            'search_symbols',
+        ]
+
+        for method_name in method_list:
+            assert hasattr(client, method_name)
+
+
+        # check for methods present con brokermod.Client and their
+        # results
+
+        syms = await run_method(client, 'symbol_info')
+
+        if len(syms) == 0:
+            raise BaseException('Empty Symbol list?')
+
+        first_sym = tuple(syms.keys())[0]
+
+        method_list = [
+            ('cache_symbols', {}),
+            ('search_symbols', {'pattern': first_sym[:-1]}),
+            ('bars', {'symbol': first_sym})
+        ]
+
+        for method_name, method_kwargs in method_list:
+             await run_method(client, method_name, **method_kwargs)
+
+
+@tractor_test
+async def test_brokercheck_all():
+    for broker in __brokers__:
+        await run_test(broker)
+


### PR DESCRIPTION
Begin work on #387

Do a `brokercheck` without logging on all backends, we pull backends from `piker.brokers.__brokers__`, I added `deribit` while I was at it cause I forgot to when doing the backend PR.

Currently not passing cause binance doesn't have a `trades_dialogue`, or `get_balance`.

Also should we log to console more like when running `brokercheck` on cli? This would require `log_cli` flag to be set on `pytest` config.