### PR TITLE
Tractor core port

### DIFF
--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -529,8 +529,8 @@ def open_shm_array(
     # pushing teardown calls onto actor context stack
 
     # TODO: make this a public API in ``tractor``..
-    tractor._actor._lifetime_stack.callback(shmarr.close)
-    tractor._actor._lifetime_stack.callback(shmarr.destroy)
+    tractor._runtime._lifetime_stack.callback(shmarr.close)
+    tractor._runtime._lifetime_stack.callback(shmarr.destroy)
 
     return shmarr
 
@@ -615,7 +615,7 @@ def attach_shm_array(
         _known_tokens[key] = token
 
     # "close" attached shm on process teardown
-    tractor._actor._lifetime_stack.callback(sha.close)
+    tractor._runtime._lifetime_stack.callback(sha.close)
 
     return sha
 

--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -528,9 +528,9 @@ def open_shm_array(
     # "unlink" created shm on process teardown by
     # pushing teardown calls onto actor context stack
 
-    # TODO: make this a public API in ``tractor``..
-    tractor._runtime._lifetime_stack.callback(shmarr.close)
-    tractor._runtime._lifetime_stack.callback(shmarr.destroy)
+    stack = tractor.current_actor().lifetime_stack
+    stack.callback(shmarr.close)
+    stack.callback(shmarr.destroy)
 
     return shmarr
 
@@ -614,8 +614,8 @@ def attach_shm_array(
     if key not in _known_tokens:
         _known_tokens[key] = token
 
-    # "close" attached shm on process teardown
-    tractor._runtime._lifetime_stack.callback(sha.close)
+    # "close" attached shm on actor teardown
+    tractor.current_actor().lifetime_stack.callback(sha.close)
 
     return sha
 


### PR DESCRIPTION
Matches with `tractor` core changes in both of:
- https://github.com/goodboy/tractor/pull/322
- https://github.com/goodboy/tractor/pull/326 

More or less just the `.data._sharedmem.py` history changes needed to match the actor lifettime stack public api differences.