### PR TITLE
Kraken fill bugs

### DIFF
--- a/piker/brokers/kraken/broker.py
+++ b/piker/brokers/kraken/broker.py
@@ -1024,7 +1024,7 @@ async def handle_order_updates(
                                 # TODO: maybe capture more msg data
                                 # i.e fees?
                                 broker_details={'name': 'kraken'} | order_msg,
-                                broker_time=broker_time
+                                broker_time=time.time(),
                             )
                             await ems_stream.send(fill_msg)
 

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -287,7 +287,7 @@ class PaperBoi(Struct):
 
 
 async def simulate_fills(
-    quote_stream: 'tractor.ReceiveStream',  # noqa
+    quote_stream: tractor.MsgStream,  # noqa
     client: PaperBoi,
 
 ) -> None:

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -98,8 +98,6 @@ class PaperBoi(Struct):
         Place an order and return integer request id provided by client.
 
         '''
-        is_modify: bool = False
-
         if action == 'alert':
             # bypass all fill simulation
             return reqid
@@ -108,7 +106,6 @@ class PaperBoi(Struct):
         if entry:
             # order is already existing, this is a modify
             (oid, symbol, action, old_price) = entry
-            is_modify = True
         else:
             # register order internally
             self._reqids[reqid] = (oid, symbol, action, price)
@@ -152,25 +149,18 @@ class PaperBoi(Struct):
                 oid,
             )
 
+        # register this submissions as a paper live order
         else:
-            # register this submissions as a paper live order
-
-            # submit order to book simulation fill loop
+            # set the simulated order in the respective table for lookup
+            # and trigger by the simulated clearing task normally
+            # running ``simulate_fills()``.
             if action == 'buy':
                 orders = self._buys
 
             elif action == 'sell':
                 orders = self._sells
 
-            # set the simulated order in the respective table for lookup
-            # and trigger by the simulated clearing task normally
-            # running ``simulate_fills()``.
-
-            if is_modify:
-                # remove any existing order for the old price
-                orders[symbol].pop(oid)
-
-            # buys/sells: {symbol  -> bidict[oid, (<price data>)]}
+            # {symbol -> bidict[oid, (<price data>)]}
             orders[symbol][oid] = (price, size, reqid, action)
 
         return reqid

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -985,7 +985,19 @@ async def process_trade_msg(
                 pointing='up' if action == 'buy' else 'down',
 
                 # TODO: put the actual exchange timestamp
-                arrow_index=get_index(details['broker_time']),
+                arrow_index=get_index(
+                    # TODO: note currently the ``kraken`` openOrders sub
+                    # doesn't deliver their engine timestamp as part of
+                    # it's schema, so this value is **not** from them
+                    # (see our backend code). We should probably either
+                    # include all provider-engine timestamps in the
+                    # summary 'closed' status msg and/or figure out
+                    # a way to indicate what is a `brokerd` stamp versus
+                    # a true backend one? This will require finagling
+                    # with how each backend tracks/summarizes time
+                    # stamps for the downstream API.
+                    details['broker_time']
+                ),
             )
 
             # TODO: how should we look this up?


### PR DESCRIPTION
Even more..

Turns out that refactoring from relaying `BrokerdFill` from the `openOrder` sub wasn't tested all too well 😂.

Fixes a 2nd name error for the `.broker_time` field (which isn't provided in the incremental update msg so this just sets it as the `brokerd` time (from `time.time()`) for now; comments added about how we might approach getting the `ownTrades` (the original value we were passing) in the response message eventually.

Also included is a further fix to the paper engine to just avoid trying to pop simulated order book entries on modifies since it's not really necessary and further it was the source of a linger race-crash with the actual paper clear case (popped after already popped by clear task).