### PR TITLE
Multi client order mgt

### DIFF
--- a/piker/brokers/kraken/broker.py
+++ b/piker/brokers/kraken/broker.py
@@ -1015,11 +1015,10 @@ async def handle_order_updates(
                             fill_msg = BrokerdFill(
                                 time_ns=time.time_ns(),
                                 reqid=reqid,
-
-                                # action=action,  # just use size value
-                                # for now?
-                                size=vlm,
-                                price=price,
+                                # just use size value for now?
+                                # action=action,
+                                size=float(vlm),
+                                price=float(price),
 
                                 # TODO: maybe capture more msg data
                                 # i.e fees?

--- a/piker/brokers/kraken/feed.py
+++ b/piker/brokers/kraken/feed.py
@@ -61,6 +61,7 @@ class Pair(Struct):
     quote: str  # asset id of quote component
     lot: str  # volume lot size
 
+    cost_decimals: int
     pair_decimals: int  # scaling decimal places for pair
     lot_decimals: int  # scaling decimal places for volume
 
@@ -342,8 +343,8 @@ async def stream_quotes(
 
             # transform to upper since piker style is always lower
             sym = sym.upper()
-
-            si = Pair(**await client.symbol_info(sym))  # validation
+            sym_info = await client.symbol_info(sym)
+            si = Pair(**sym_info)  # validation
             syminfo = si.to_dict()
             syminfo['price_tick_size'] = 1 / 10**si.pair_decimals
             syminfo['lot_tick_size'] = 1 / 10**si.lot_decimals

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -884,11 +884,15 @@ async def translate_and_relay_brokerd_events(
                 oid = book._ems2brokerd_ids.inverse.get(reqid)
                 msg = f'Unhandled broker status for dialog {reqid}:\n'
                 if oid:
-                    status_msg = book._active[oid]
-                    msg += (
-                        f'last status msg: {pformat(status_msg)}\n\n'
-                        f'this msg:{fmsg}\n'
-                    )
+                    status_msg = book._active.get(oid)
+                    # status msg may not have been set yet or popped?
+                    # NOTE: have seen a key error here on kraken
+                    # clearable limits..
+                    if status_msg:
+                        msg += (
+                            f'last status msg: {pformat(status_msg)}\n\n'
+                            f'this msg:{fmsg}\n'
+                        )
 
                 log.warning(msg)
 

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -417,7 +417,7 @@ class Router(Struct):
         for client_stream in self.clients.copy():
             try:
                 await client_stream.send(msg)
-            except(
+            except (
                 trio.ClosedResourceError,
                 trio.BrokenResourceError,
             ):
@@ -740,8 +740,8 @@ async def translate_and_relay_brokerd_events(
                     or not status_msg
                 ):
                     log.warning(
-                        'Received status for unknown dialog {oid}:\n'
-                        '{fmsg}'
+                        f'Received status for unknown dialog {oid}:\n'
+                        f'{fmsg}'
                     )
                     continue
 

--- a/piker/clearing/_messages.py
+++ b/piker/clearing/_messages.py
@@ -261,10 +261,10 @@ class BrokerdFill(Struct):
     time_ns: int
 
     # order exeuction related
-    action: str
     size: float
     price: float
 
+    action: Optional[str] = None
     broker_details: dict = {}  # meta-data (eg. commisions etc.)
 
     # brokerd timestamp required for order mode arrow placement on x-axis

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -207,9 +207,10 @@ class PaperBoi(Struct):
         remaining: float = 0,
 
     ) -> None:
-        """Pretend to fill a broker order @ price and size.
+        '''
+        Pretend to fill a broker order @ price and size.
 
-        """
+        '''
         # TODO: net latency model
         await trio.sleep(0.05)
         fill_time_ns = time.time_ns()
@@ -230,6 +231,7 @@ class PaperBoi(Struct):
                 'name': self.broker + '_paper',
             },
         )
+        log.info(f'Fake filling order:\n{fill_msg}')
         await self.ems_trades_stream.send(fill_msg)
 
         self._trade_ledger.update(fill_msg.to_dict())
@@ -407,6 +409,7 @@ async def simulate_fills(
                 for order_info, pred in iter_entries:
                     (our_price, size, reqid, action) = order_info
 
+                    # print(order_info)
                     clearable = pred(our_price)
                     if clearable:
                         # pop and retreive order info
@@ -481,8 +484,8 @@ async def handle_order_requests(
                     # counter - collision prone..)
                     reqid=reqid,
                 )
+                log.info(f'Submitted paper LIMIT {reqid}:\n{order}')
 
-            # elif action == 'cancel':
             case {'action': 'cancel'}:
                 msg = BrokerdCancel(**request_msg)
                 await client.submit_cancel(


### PR DESCRIPTION
This originally was a set of bug fixes but turned into somewhat of an enhancement where we can now support multi-client management of an `emsd`'s orders.

---
### Summary:
- every client that connects to the ems for a given `fqsn` becomes a subscriber and thus un-hindered manager of orders. this fixes bugs to do with reconnecting clients who weren't previously receiving order updates as well as lays ground work for true multi-user trading on a given ems cluster.
- variety of face-palm-y `kraken` broker backend fixes
- teensie bit of logging adding to the paper engine

----
### TO TEST
start binance order mode with the paper engine and,
- [x] enter both live and dark orders and let some or none execute, disconnect the client, reconnect a new client, ensure that the old orders (both dark and live) show up and can be editted to get filled (without editing them to be clear-able immediately)
- [x] do the same but let some live orders clear without having any client connected (darks don't support this yet see below) and ensure on a chart-client reconnect the new pos is correct
- [x] for now you can probably verify that dark orders will not trigger when no client is connected
- [x] spawn more then one chart-client and be sure that changes from one are reflected in the other


---
### TODO:
- [ ] make the dark clearing loop also run as part of the lifetime of the `emsd` actor, offer this as a config option (**deferred to #405**)