### PR TITLE
Pin back to `tractor` master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # we require a pinned dev branch to get some edge features that
 # are often untested in tractor's CI and/or being tested by us
 # first before committing as core features in tractor's base.
--e git+https://github.com/goodboy/tractor.git@reentrant_moc#egg=tractor
+-e git+https://github.com/goodboy/tractor.git@master#egg=tractor
 
 # `pyqtgraph` peeps keep breaking, fixing, improving so might as well
 # pin this to a dev branch that we have more control over especially


### PR DESCRIPTION
Change our pin to `master` since  we landed all the outstanding dev branches needed here.