### PR TITLE
Offline dark clearing

### DIFF
--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -842,6 +842,11 @@ async def translate_and_relay_brokerd_events(
                     status_msg.reqid = reqid
                     status_msg.brokerd_msg = msg
 
+                    # TODO: if no client is connected (aka we're
+                    # headless) we should record the fill in the
+                    # ``.msg_flow`` chain and re-transmit on client
+                    # connect so that fills can be displayed in a
+                    # chart?
                     await router.client_broadcast(
                         status_msg.req.symbol,
                         status_msg,

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -679,6 +679,8 @@ async def translate_and_relay_brokerd_events(
 
                 # fan-out-relay position msgs immediately by
                 # broadcasting updates on all client streams
+                # TODO: this should be subscription based for privacy
+                # eventually!
                 await router.client_broadcast('all', pos_msg)
                 continue
 

--- a/piker/data/types.py
+++ b/piker/data/types.py
@@ -49,9 +49,12 @@ class Struct(
             hasattr(sys, 'ps1')
             # TODO: check if we're in pdb
         ):
-            return f'Struct({pformat(self.to_dict())})'
+            return self.pformat()
 
         return super().__repr__()
+
+    def pformat(self) -> str:
+        return f'Struct({pformat(self.to_dict())})'
 
     def copy(
         self,

--- a/piker/ui/_notify.py
+++ b/piker/ui/_notify.py
@@ -1,0 +1,95 @@
+# piker: trading gear for hackers
+# Copyright (C) Tyler Goodlet (in stewardship for piker0)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Notifications utils.
+
+"""
+import os
+import platform
+import subprocess
+from typing import Optional
+
+import trio
+
+from ..log import get_logger
+from ..clearing._messages import (
+    Status,
+)
+
+log = get_logger(__name__)
+
+
+_dbus_uid: Optional[str] = ''
+
+
+async def notify_from_ems_status_msg(
+    uuid: str,
+    msg: Status,
+    is_subproc: bool = False,
+
+) -> None:
+    '''
+    Send a linux desktop notification.
+
+    Handle subprocesses by discovering the dbus user id
+    on first call.
+
+    '''
+    if platform.system() != "Linux":
+        return
+
+    # TODO: this in another task?
+    # not sure if this will ever be a bottleneck,
+    # we probably could do graphics stuff first tho?
+
+    if is_subproc:
+        global _dbus_uid
+        if not _dbus_uid:
+            su = os.environ['SUDO_USER']
+
+            # TODO: use `trio` but we need to use nursery.start()
+            # to use pipes?
+            # result = await trio.run_process(
+            result = subprocess.run(
+                [
+                    'id',
+                    '-u',
+                    su,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                # check=True
+            )
+            _dbus_uid = result.stdout.decode("utf-8").replace('\n', '')
+
+            os.environ['DBUS_SESSION_BUS_ADDRESS'] = (
+                f'unix:path=/run/user/{_dbus_uid}/bus'
+            )
+
+    result = await trio.run_process(
+        [
+            'notify-send',
+            '-u', 'normal',
+            '-t', '1616',
+            'piker',
+
+            # TODO: add in standard fill/exec info that maybe we
+            # pack in a broker independent way?
+            f"'{msg.resp}: {msg.req.price}'",
+        ],
+    )
+    log.runtime(result)

--- a/piker/ui/_notify.py
+++ b/piker/ui/_notify.py
@@ -37,8 +37,8 @@ _dbus_uid: Optional[str] = ''
 
 
 async def notify_from_ems_status_msg(
-    uuid: str,
     msg: Status,
+    duration: int = 3000,
     is_subproc: bool = False,
 
 ) -> None:
@@ -84,12 +84,12 @@ async def notify_from_ems_status_msg(
         [
             'notify-send',
             '-u', 'normal',
-            '-t', '1616',
+            '-t', f'{duration}',
             'piker',
 
             # TODO: add in standard fill/exec info that maybe we
             # pack in a broker independent way?
-            f"'{msg.resp}: {msg.req.price}'",
+            f"'{msg.pformat()}'",
         ],
     )
     log.runtime(result)

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -42,7 +42,8 @@ from ._anchors import (
     gpath_pin,
 )
 from ..calc import humanize, pnl, puterize
-from ..clearing._allocate import Allocator, Position
+from ..clearing._allocate import Allocator
+from ..pp import Position
 from ..data._normalize import iterticks
 from ..data.feed import Feed
 from ..data.types import Struct

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -1031,10 +1031,7 @@ async def process_trade_msg(
             )
             mode.lines.remove_line(uuid=oid)
             msg.req = req
-            await notify_from_ems_status_msg(
-                uuid,
-                msg,
-            )
+            await notify_from_ems_status_msg(msg)
 
         # response to completed 'dialog' for order request
         case Status(
@@ -1043,10 +1040,7 @@ async def process_trade_msg(
             req=req,
         ):
             msg.req = Order(**req)
-            await notify_from_ems_status_msg(
-                uuid,
-                msg,
-            )
+            await notify_from_ems_status_msg(msg)
             mode.lines.remove_line(uuid=oid)
 
         # each clearing tick is responded individually

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -433,7 +433,7 @@ class OrderMode:
         size = dialog.order.size
 
         # NOTE: sends modified order msg to EMS
-        self.book.update(
+        self.book.send_update(
             uuid=line.dialog.uuid,
             price=level,
             size=size,
@@ -1047,12 +1047,12 @@ async def process_trade_msg(
         case Status(resp='fill'):
 
             # handle out-of-piker fills reporting?
-            known_order = book._sent_orders.get(oid)
-            if not known_order:
+            order: Order = book._sent_orders.get(oid)
+            if not order:
                 log.warning(f'order {oid} is unknown')
-                return
+                order = msg.req
 
-            action = known_order.action
+            action = order.action
             details = msg.brokerd_msg
 
             # TODO: some kinda progress system
@@ -1077,7 +1077,9 @@ async def process_trade_msg(
                 ),
             )
 
-            # TODO: how should we look this up?
+            # TODO: append these fill events to the position's clear
+            # table?
+
             # tracker = mode.trackers[msg['account']]
             # tracker.live_pp.fills.append(msg)
 


### PR DESCRIPTION
(replacement for #406 after rebase history adjustments.)
Resolves the requirements listed in #405 and requires the patch in https://github.com/goodboy/tractor/pull/329.

Makes the `emsd` run the dark clearing and relay loop tasks in inside the long lived `Router.nursery` and avoid more then a single task per instrument real-time feed except where needed by the paper clearing engine.

---
#### deats:
- `_emsd_main()` now on-demand spawns trade relay tasks per symbol and leaves them running even when no clients are connected to the EMS and now only directly determines the lifetime of the `process_client_order_cmds()` task
- includes some naive support for notifications when the `emsd` is running "headless" which is currently packed into `Router.client_broadcast()`
- solve the slight causality dilemma when a backend first boots:
  - when a client connects the first time it needs the current position and/or book state but on the first connect to some backend the book will be empty and needs to be populated with existing live orders, but the `translate_and_relay_brokerd_events()` needs to be first started so that existing open orders can be loaded and relayed to the client
  - **solution => make `Router.open_trade_relays()` deliver a `client_ready: trio.Event` which the client-caller-task sets once it opened a stream thus signalling the relay task to start and existing orders to be relayed to the now registered client**

---
#### test list:
see #405