### PR TITLE
Even moar `kraken` order fixes

### DIFF
--- a/piker/brokers/kraken/broker.py
+++ b/piker/brokers/kraken/broker.py
@@ -795,7 +795,7 @@ async def handle_order_updates(
                     # 'vol_exec': exec_vlm}  # 0.0000
                     match update_msg:
 
-                        # EMS-unknown live order that needs to be
+                        # EMS-unknown LIVE order that needs to be
                         # delivered and loaded on the client-side.
                         case {
                             'userref': reqid,
@@ -849,7 +849,7 @@ async def handle_order_updates(
                                 ),
                                 src='kraken',
                             )
-                            apiflows[reqid].maps.append(status_msg)
+                            apiflows[reqid].maps.append(status_msg.to_dict())
                             await ems_stream.send(status_msg)
                             continue
 
@@ -1104,7 +1104,6 @@ async def handle_order_updates(
                             'txid': [txid],
                         })
             case _:
-
                 log.warning(f'Unhandled trades update msg: {msg}')
 
 

--- a/piker/brokers/kraken/feed.py
+++ b/piker/brokers/kraken/feed.py
@@ -62,6 +62,7 @@ class Pair(Struct):
     lot: str  # volume lot size
 
     cost_decimals: int
+    costmin: float
     pair_decimals: int  # scaling decimal places for pair
     lot_decimals: int  # scaling decimal places for volume
 

--- a/piker/clearing/_messages.py
+++ b/piker/clearing/_messages.py
@@ -110,7 +110,6 @@ class Cancel(Struct):
     action: str = 'cancel'
     oid: str  # uuid4
     symbol: str
-    account: str = ''
 
 
 # --------------
@@ -144,7 +143,7 @@ class Status(Struct):
     # (eg. the Order/Cancel which causes this msg) and
     # acts as a back-reference to the corresponding
     # request message which was the source of this msg.
-    req: Optional[Order | Cancel] = None
+    req: Order | None = None
 
     # XXX: better design/name here?
     # flag that can be set to indicate a message for an order
@@ -152,6 +151,10 @@ class Status(Struct):
     # trading system which does it's own order control but that you
     # might want to "track" using piker UIs/systems).
     src: Optional[str] = None
+
+    # set when a cancel request msg was set for this order flow dialog
+    # but the brokerd dialog isn't yet in a cancelled state.
+    cancel_called: bool = False
 
     # for relaying a boxed brokerd-dialog-side msg data "through" the
     # ems layer to clients.

--- a/piker/clearing/_messages.py
+++ b/piker/clearing/_messages.py
@@ -110,6 +110,7 @@ class Cancel(Struct):
     action: str = 'cancel'
     oid: str  # uuid4
     symbol: str
+    account: str = ''
 
 
 # --------------

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -293,7 +293,7 @@ class SettingsPane:
 
             # don't log account "change" case since it'll be submitted
             # on every mouse interaction.
-            log.info(f'settings change: {key}: {value}')
+            log.runtime(f'settings change: {key}: {value}')
 
         # TODO: maybe return a diff of settings so if we can an error we
         # can have general input handling code to report it through the

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -56,7 +56,7 @@ from ._position import (
 from ._forms import FieldsForm
 from ._window import MultiStatus
 from ..clearing._messages import (
-    Cancel,
+    # Cancel,
     Order,
     Status,
     # BrokerdOrder,
@@ -1011,12 +1011,11 @@ async def process_trade_msg(
         case Status(resp='canceled'):
             # delete level line from view
             mode.on_cancel(oid)
-            req = Cancel(**msg.req)
-            log.cancel(f'Canceled {req.action}:{oid}')
+            log.cancel(f'Canceled {msg.req["action"]}:{oid}')
 
         case Status(
             resp='triggered',
-            # req=Order(exec_mode='dark')  # TODO:
+            # req=Order(exec_mode='dark')  # TODO: msgspec
             req={'exec_mode': 'dark'},
         ):
             # TODO: UX for a "pending" clear/live order

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -1011,7 +1011,8 @@ async def process_trade_msg(
         case Status(resp='canceled'):
             # delete level line from view
             mode.on_cancel(oid)
-            log.cancel(f'Canceled {msg.req["action"]}:{oid}')
+            action = msg.req["action"]
+            log.cancel(f'Canceled {action}:{oid}')
 
         case Status(
             resp='triggered',

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -56,6 +56,7 @@ from ._position import (
 from ._forms import FieldsForm
 from ._window import MultiStatus
 from ..clearing._messages import (
+    Cancel,
     Order,
     Status,
     # BrokerdOrder,
@@ -961,15 +962,20 @@ async def process_trade_msg(
     dialog: Dialog = mode.dialogs.get(oid)
 
     match msg:
-        case Status(resp='dark_open' | 'open'):
+        case Status(
+            resp='dark_open' | 'open',
+        ) if msg.req['action'] != 'cancel':
 
             order = Order(**msg.req)
 
-            if dialog is not None:
+            if (
+                dialog is not None
+                and order.action != 'cancel'
+            ):
                 # show line label once order is live
                 mode.on_submit(oid, order=order)
 
-            else:
+            elif order.action != 'cancel':
                 log.warning(
                     f'received msg for untracked dialog:\n{fmsg}'
                 )
@@ -1005,7 +1011,7 @@ async def process_trade_msg(
         case Status(resp='canceled'):
             # delete level line from view
             mode.on_cancel(oid)
-            req = Order(**msg.req)
+            req = Cancel(**msg.req)
             log.cancel(f'Canceled {req.action}:{oid}')
 
         case Status(


### PR DESCRIPTION
Are you really surprised?
Mostly internal fixes and would only be noticed by `kraken` backend users..

- add new `Pair.costmin` to msg schema
- fix a `ChainMap` append bug where we were adding the `Status` instead of it's `dict` form
- adjustments to the EMS core to handle further issues:
 - error msg handling wasn't using the `fqsn` when calling `.client_broadcast()` which meant errors weren't always being relayed to the client side..
 - ^ required some tweaks where now we just stash the client-side `Cancel` msg in the *canceled faster then acked* case thus being more consistent with client vs. brokerd side msg types.