### PR TITLE
Agg feedz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,27 @@ on:
 
 jobs:
 
+  # test that we can generate a software distribution and install it
+  # thus avoid missing file issues after packaging.
+  sdist-linux:
+    name: 'sdist'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Build sdist
+        run: python setup.py sdist --formats=zip
+
+      - name: Install sdist from .zips
+        run: python -m pip install dist/*.zip
+
   testing:
     name: 'install + test-suite'
     runs-on: ubuntu-latest

--- a/dockering/ib/docker-compose.yml
+++ b/dockering/ib/docker-compose.yml
@@ -62,39 +62,39 @@ services:
       # - "127.0.0.1:4002:4002"
       # - "127.0.0.1:5900:5900"
 
-  ib_gw_live:
-    image: waytrade/ib-gateway:1012.2i
-    restart: always
-    network_mode: 'host'
+  # ib_gw_live:
+  #   image: waytrade/ib-gateway:1012.2i
+  #   restart: always
+  #   network_mode: 'host'
 
-    volumes:
-      - type: bind
-        source: ./jts_live.ini
-        target: /root/jts/jts.ini
-        # don't let ibc clobber this file for
-        # the main reason of not having a stupid
-        # timezone set..
-        read_only: true
+  #   volumes:
+  #     - type: bind
+  #       source: ./jts_live.ini
+  #       target: /root/jts/jts.ini
+  #       # don't let ibc clobber this file for
+  #       # the main reason of not having a stupid
+  #       # timezone set..
+  #       read_only: true
 
-      # force our own ibc config
-      - type: bind
-        source: ./ibc.ini
-        target: /root/ibc/config.ini
+  #     # force our own ibc config
+  #     - type: bind
+  #       source: ./ibc.ini
+  #       target: /root/ibc/config.ini
 
-      # force our noop script - socat isn't needed in host mode.
-      - type: bind
-        source: ./fork_ports_delayed.sh
-        target: /root/scripts/fork_ports_delayed.sh
+  #     # force our noop script - socat isn't needed in host mode.
+  #     - type: bind
+  #       source: ./fork_ports_delayed.sh
+  #       target: /root/scripts/fork_ports_delayed.sh
 
-      # force our noop script - socat isn't needed in host mode.
-      - type: bind
-        source: ./run_x11_vnc.sh
-        target: /root/scripts/run_x11_vnc.sh
-        read_only: true
+  #     # force our noop script - socat isn't needed in host mode.
+  #     - type: bind
+  #       source: ./run_x11_vnc.sh
+  #       target: /root/scripts/run_x11_vnc.sh
+  #       read_only: true
 
-    # NOTE: to fill these out, define an `.env` file in the same dir as
-    # this compose file which looks something like:
-    environment:
-      TRADING_MODE: 'live'
-      VNC_SERVER_PASSWORD: 'doggy'
-      VNC_SERVER_PORT: '3004'
+  #   # NOTE: to fill these out, define an `.env` file in the same dir as
+  #   # this compose file which looks something like:
+  #   environment:
+  #     TRADING_MODE: 'live'
+  #     VNC_SERVER_PASSWORD: 'doggy'
+  #     VNC_SERVER_PORT: '3004'

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -37,10 +37,15 @@ _root_dname = 'pikerd'
 
 _registry_host: str = '127.0.0.1'
 _registry_port: int = 6116
-_registry_addr = (
+_default_reg_addr: tuple[str, int] = (
     _registry_host,
     _registry_port,
 )
+
+# NOTE: this value is set as an actor-global once the first endpoint
+# who is capable, spawns a `pikerd` service tree.
+_registry_addr: tuple[str, int] | None = None
+
 _tractor_kwargs: dict[str, Any] = {
     # use a different registry addr then tractor's default
     'arbiter_addr': _registry_addr
@@ -152,13 +157,17 @@ async def open_pikerd(
 
     '''
     global _services
+    global _registry_addr
+
+    if _registry_addr is None:
+        _registry_addr = registry_addr or _default_reg_addr
 
     # XXX: this may open a root actor as well
     async with (
         tractor.open_root_actor(
 
             # passed through to ``open_root_actor``
-            arbiter_addr=registry_addr or _registry_addr,
+            arbiter_addr=_registry_addr,
             name=_root_dname,
             loglevel=loglevel,
             debug_mode=debug_mode,
@@ -197,7 +206,7 @@ async def open_piker_runtime(
     # XXX: you should pretty much never want debug mode
     # for data daemons when running in production.
     debug_mode: bool = False,
-    registry_addr: None | tuple[str, int] = _registry_addr,
+    registry_addr: None | tuple[str, int] = None,
 
 ) -> tractor.Actor:
     '''
@@ -206,13 +215,17 @@ async def open_piker_runtime(
 
     '''
     global _services
+    global _registry_addr
+
+    if _registry_addr is None:
+        _registry_addr = registry_addr or _default_reg_addr
 
     # XXX: this may open a root actor as well
     async with (
         tractor.open_root_actor(
 
             # passed through to ``open_root_actor``
-            arbiter_addr=registry_addr,
+            arbiter_addr=_registry_addr,
             name=name,
             loglevel=loglevel,
             debug_mode=debug_mode,

--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -35,11 +35,11 @@ log = get_logger(__name__)
 
 _root_dname = 'pikerd'
 
-_registry_host: str = '127.0.0.1'
-_registry_port: int = 6116
+_default_registry_host: str = '127.0.0.1'
+_default_registry_port: int = 6116
 _default_reg_addr: tuple[str, int] = (
-    _registry_host,
-    _registry_port,
+    _default_registry_host,
+    _default_registry_port,
 )
 
 # NOTE: this value is set as an actor-global once the first endpoint
@@ -159,7 +159,10 @@ async def open_pikerd(
     global _services
     global _registry_addr
 
-    if _registry_addr is None:
+    if (
+        _registry_addr is None
+        or registry_addr
+    ):
         _registry_addr = registry_addr or _default_reg_addr
 
     # XXX: this may open a root actor as well
@@ -217,7 +220,10 @@ async def open_piker_runtime(
     global _services
     global _registry_addr
 
-    if _registry_addr is None:
+    if (
+        _registry_addr is None
+        or registry_addr
+    ):
         _registry_addr = registry_addr or _default_reg_addr
 
     # XXX: this may open a root actor as well

--- a/piker/brokers/__init__.py
+++ b/piker/brokers/__init__.py
@@ -26,10 +26,21 @@ asks.init('trio')
 
 __brokers__ = [
     'binance',
-    'questrade',
-    'robinhood',
     'ib',
     'kraken',
+
+    # broken but used to work
+    # 'questrade',
+    # 'robinhood',
+
+    # TODO: we should get on these stat!
+    # alpaca
+    # wstrade
+    # iex
+
+    # deribit
+    # kucoin
+    # bitso
 ]
 
 

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -181,7 +181,7 @@ class Client:
         params = {}
 
         if sym is not None:
-            sym = sym.upper()
+            sym = sym.lower()
             params = {'symbol': sym}
 
         resp = await self._api(
@@ -465,7 +465,7 @@ async def stream_quotes(
             si = sym_infos[sym] = syminfo.to_dict()
             filters = {}
             for entry in syminfo.filters:
-                ftype = entry.pop('filterType')
+                ftype = entry['filterType']
                 filters[ftype] = entry
 
             # XXX: after manually inspecting the response format we

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -575,17 +575,18 @@ async def trades_dialogue(
                         # if new trades are detected from the API, prepare
                         # them for the ledger file and update the pptable.
                         if api_to_ledger_entries:
-                            trade_entries = api_to_ledger_entries[acctid]
+                            trade_entries = api_to_ledger_entries.get(acctid)
 
-                            # write ledger with all new trades **AFTER**
-                            # we've updated the `pps.toml` from the
-                            # original ledger state! (i.e. this is
-                            # currently done on exit)
-                            ledger.update(trade_entries)
+                            if trade_entries:
+                                # write ledger with all new trades **AFTER**
+                                # we've updated the `pps.toml` from the
+                                # original ledger state! (i.e. this is
+                                # currently done on exit)
+                                ledger.update(trade_entries)
 
-                            trans = trans_by_acct.get(acctid)
-                            if trans:
-                                table.update_from_trans(trans)
+                                trans = trans_by_acct.get(acctid)
+                                if trans:
+                                    table.update_from_trans(trans)
 
                         # XXX: not sure exactly why it wouldn't be in
                         # the updated output (maybe this is a bug?) but

--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -371,8 +371,8 @@ async def update_and_audit_msgs(
                     else:
                         entry = f'split_ratio = 1/{int(reverse_split_ratio)}'
 
-                    raise ValueError(
-                    # log.error(
+                    # raise ValueError(
+                    log.error(
                         f'POSITION MISMATCH ib <-> piker ledger:\n'
                         f'ib: {ibppmsg}\n'
                         f'piker: {msg}\n'
@@ -883,7 +883,7 @@ async def deliver_trade_events(
                     # execdict.pop('acctNumber')
 
                     fill_msg = BrokerdFill(
-                        # should match the value returned from
+                        # NOTE: should match the value returned from
                         # `.submit_limit()`
                         reqid=execu.orderId,
                         time_ns=time.time_ns(),  # cuz why not

--- a/piker/brokers/ib/feed.py
+++ b/piker/brokers/ib/feed.py
@@ -1047,7 +1047,13 @@ async def open_symbol_search(
                 stock_results = []
 
                 async def stash_results(target: Awaitable[list]):
-                    stock_results.extend(await target)
+                    try:
+                        results = await target
+                    except tractor.trionics.Lagged:
+                        print("IB SYM-SEARCH OVERRUN?!?")
+                        return
+
+                    stock_results.extend(results)
 
                 for i in range(10):
                     with trio.move_on_after(3) as cs:

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -1239,8 +1239,7 @@ async def process_client_order_cmds(
                 pred = mk_check(trigger_price, last, action)
 
                 spread_slap: float = 5
-                sym = fqsn.replace(f'.{brokers[0]}', '')
-                min_tick = feed.symbols[sym].tick_size
+                min_tick = feed.symbols[fqsn].tick_size
 
                 if action == 'buy':
                     tickfilter = ('ask', 'last', 'trade')

--- a/piker/clearing/_paper_engine.py
+++ b/piker/clearing/_paper_engine.py
@@ -578,7 +578,7 @@ async def trades_dialogue(
             )
 
             # paper engine simulator clearing task
-            await simulate_fills(feed.stream, client)
+            await simulate_fills(feed.streams[broker], client)
 
 
 @asynccontextmanager

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -29,8 +29,8 @@ from ..log import get_console_log, get_logger, colorize_json
 from ..brokers import get_brokermod
 from .._daemon import (
     _tractor_kwargs,
-    _registry_host,
-    _registry_port,
+    _default_registry_host,
+    _default_registry_port,
 )
 from .. import config
 
@@ -76,8 +76,8 @@ def pikerd(
     reg_addr: None | tuple[str, int] = None
     if host or port:
         reg_addr = (
-            host or _registry_host,
-            int(port) or _registry_port,
+            host or _default_registry_host,
+            int(port) or _default_registry_port,
         )
 
     async def main():
@@ -154,8 +154,8 @@ def cli(
     reg_addr: None | tuple[str, int] = None
     if host or port:
         reg_addr = (
-            host or _registry_host,
-            int(port) or _registry_port,
+            host or _default_registry_host,
+            int(port) or _default_registry_port,
         )
 
     ctx.obj.update({

--- a/piker/cli/__init__.py
+++ b/piker/cli/__init__.py
@@ -36,7 +36,6 @@ from .. import config
 
 
 log = get_logger('cli')
-DEFAULT_BROKER = 'questrade'
 
 
 @click.command()
@@ -118,7 +117,7 @@ def pikerd(
 @click.group(context_settings=config._context_defaults)
 @click.option(
     '--brokers', '-b',
-    default=[DEFAULT_BROKER],
+    default=None,
     multiple=True,
     help='Broker backend to use'
 )
@@ -144,10 +143,13 @@ def cli(
 
     ctx.ensure_object(dict)
 
-    if len(brokers) == 1:
-        brokermods = [get_brokermod(brokers[0])]
-    else:
-        brokermods = [get_brokermod(broker) for broker in brokers]
+    if not brokers:
+        # (try to) load all (supposedly) supported data/broker backends
+        from piker.brokers import __brokers__
+        brokers = __brokers__
+
+    brokermods = [get_brokermod(broker) for broker in brokers]
+    assert brokermods
 
     reg_addr: None | tuple[str, int] = None
     if host or port:

--- a/piker/config.py
+++ b/piker/config.py
@@ -197,6 +197,9 @@ def load(
     '''
     path = path or get_conf_path(conf_name)
 
+    if not os.path.isdir(_config_dir):
+        os.mkdir(_config_dir)
+
     if not os.path.isfile(path):
         fn = _conf_fn_w_ext(conf_name)
 
@@ -209,9 +212,9 @@ def load(
         # if one exists.
         if os.path.isfile(template):
             shutil.copyfile(template, path)
-        else:
-            with open(path, 'w'):
-                pass  # touch
+    else:
+        with open(path, 'r'):
+            pass  # touch it
 
     config = toml.load(path, **tomlkws)
     log.debug(f"Read config file {path}")

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -331,7 +331,6 @@ async def sample_and_broadcast(
             lags: int = 0
 
             for (stream, ctx, tick_throttle) in subs:
-
                 try:
                     with trio.move_on_after(0.2) as cs:
                         if tick_throttle:

--- a/piker/data/_sampling.py
+++ b/piker/data/_sampling.py
@@ -22,7 +22,10 @@ financial data flows.
 from __future__ import annotations
 from collections import Counter
 import time
-from typing import TYPE_CHECKING, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Union,
+)
 
 import tractor
 import trio
@@ -147,7 +150,7 @@ async def increment_ohlc_buffer(
 
 async def broadcast(
     delay_s: int,
-    shm: Optional[ShmArray] = None,
+    shm: ShmArray | None = None,
 
 ) -> None:
     '''
@@ -241,6 +244,8 @@ async def sample_and_broadcast(
 
     # iterate stream delivered by broker
     async for quotes in quote_stream:
+        # print(quotes)
+
         # TODO: ``numba`` this!
         for broker_symbol, quote in quotes.items():
             # TODO: in theory you can send the IPC msg *before* writing
@@ -314,7 +319,7 @@ async def sample_and_broadcast(
                 tuple[
                     Union[tractor.MsgStream, trio.MemorySendChannel],
                     tractor.Context,
-                    Optional[float],  # tick throttle in Hz
+                    float | None,  # tick throttle in Hz
                 ]
             ] = bus._subscribers[broker_symbol.lower()]
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -23,7 +23,8 @@ import decimal
 
 from bidict import bidict
 import numpy as np
-from msgspec import Struct
+
+from .types import Struct
 # from numba import from_dtype
 
 

--- a/piker/data/_source.py
+++ b/piker/data/_source.py
@@ -217,6 +217,10 @@ class Symbol(Struct):
         else:
             return (key, broker)
 
+    @property
+    def fqsn(self) -> str:
+        return '.'.join(self.tokens()).lower()
+
     def front_fqsn(self) -> str:
         '''
         fqsn = "fully qualified symbol name"

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -1450,6 +1450,7 @@ class Feed(Struct):
 
         if brokers is None:
             mods = self.mods
+            brokers = list(self.mods)
         else:
             mods = {name: self.mods[name] for name in brokers}
 

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -1255,7 +1255,7 @@ async def open_feed_bus(
         assert bfqsn in fqsn and brokername in fqsn
 
         if sym.suffix:
-            bfqsn = fqsn.rstrip(f'.{brokername}')
+            bfqsn = fqsn.removesuffix(f'.{brokername}')
             log.warning(f'{brokername} expanded symbol {symbol} -> {bfqsn}')
 
         # pack for ``.started()`` sync msg
@@ -1327,7 +1327,7 @@ async def open_feed_bus(
             # maybe use the current task-id to key the sub list that's
             # added / removed? Or maybe we can add a general
             # pause-resume by sub-key api?
-            bfqsn = fqsn.rstrip(f'.{brokername}')
+            bfqsn = fqsn.removesuffix(f'.{brokername}')
             bus_subs = bus._subscribers[bfqsn]
             bus_subs.append(sub)
             local_subs.append(sub)

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -1410,7 +1410,7 @@ async def open_feed(
 
             # symbol.broker_info[brokername] = si
             feed.symbols[fqsn] = symbol
-            feed.symbols[sym] = symbol
+            feed.symbols[f'{sym}.{brokername}'] = symbol
 
             # cast shm dtype to list... can't member why we need this
             for shm_key, shm in [

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -22,19 +22,21 @@ This module is enabled for ``brokerd`` daemons.
 """
 from __future__ import annotations
 from contextlib import asynccontextmanager as acm
-from dataclasses import (
-    dataclass,
-    field,
-)
+# from dataclasses import (
+#     dataclass,
+#     field,
+# )
 from datetime import datetime
 from functools import partial
 from types import ModuleType
 from typing import (
     Any,
     AsyncIterator,
+    AsyncContextManager,
     Callable,
     Optional,
     Awaitable,
+    Sequence,
     TYPE_CHECKING,
     Union,
 )
@@ -43,7 +45,10 @@ import trio
 from trio.abc import ReceiveChannel
 from trio_typing import TaskStatus
 import tractor
-from tractor.trionics import maybe_open_context
+from tractor.trionics import (
+    maybe_open_context,
+    gather_contexts,
+)
 import pendulum
 import numpy as np
 
@@ -58,6 +63,7 @@ from ._sharedmem import (
     maybe_open_shm_array,
     attach_shm_array,
     ShmArray,
+    _Token,
     _secs_in_day,
 )
 from .ingest import get_ingestormod
@@ -109,11 +115,6 @@ class _FeedsBus(Struct):
 
     task_lock: trio.StrictFIFOLock = trio.StrictFIFOLock()
 
-    # XXX: so weird but, apparently without this being `._` private
-    # pydantic will complain about private `tractor.Context` instance
-    # vars (namely `._portal` and `._cancel_scope`) at import time.
-    # Reported this bug:
-    # https://github.com/samuelcolvin/pydantic/issues/2816
     _subscribers: dict[
         str,
         list[
@@ -719,10 +720,14 @@ async def manage_history(
     buffer.
 
     '''
+
+    from tractor._state import _runtime_vars
+    port = _runtime_vars['_root_mailbox'][1]
+
     # (maybe) allocate shm array for this broker/symbol which will
     # be used for fast near-term history capture and processing.
     hist_shm, opened = maybe_open_shm_array(
-        key=f'{fqsn}_hist',
+        key=f'{fqsn}_hist', #_p{port}',
 
         # use any broker defined ohlc dtype:
         dtype=getattr(mod, '_ohlc_dtype', base_iohlc_dtype),
@@ -739,7 +744,7 @@ async def manage_history(
         )
 
     rt_shm, opened = maybe_open_shm_array(
-        key=f'{fqsn}_rt',
+        key=f'{fqsn}_rt', #_p{port}',
 
         # use any broker defined ohlc dtype:
         dtype=getattr(mod, '_ohlc_dtype', base_iohlc_dtype),
@@ -836,373 +841,61 @@ async def manage_history(
         await trio.sleep_forever()
 
 
-async def allocate_persistent_feed(
-    bus: _FeedsBus,
-
-    brokername: str,
-    symbol: str,
-
-    loglevel: str,
-    start_stream: bool = True,
-
-    task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
-
-) -> None:
+class Flume(Struct):
     '''
-    Create and maintain a "feed bus" which allocates tasks for real-time
-    streaming and optional historical data storage per broker/data provider
-    backend; this normally task runs *in* a `brokerd` actor.
+    Composite reference type which points to all the addressing handles
+    and other meta-data necessary for the read, measure and management
+    of a set of real-time updated data flows.
 
-    If none exists, this allocates a ``_FeedsBus`` which manages the
-    lifetimes of streaming tasks created for each requested symbol.
+    Can be thought of as a "flow descriptor" or "flow frame" which
+    describes the high level properties of a set of data flows that can
+    be used seamlessly across process-memory boundaries.
 
-
-    2 tasks are created:
-    - a real-time streaming task which connec
+    Each instance's sub-components normally includes:
+     - a msg oriented quote stream provided via an IPC transport
+     - history and real-time shm buffers which are both real-time
+       updated and backfilled.
+     - associated startup indexing information related to both buffer
+       real-time-append and historical prepend addresses.
+     - low level APIs to read and measure the updated data and manage
+       queuing properties.
 
     '''
-    # load backend module
-    try:
-        mod = get_brokermod(brokername)
-    except ImportError:
-        mod = get_ingestormod(brokername)
+    symbol: Symbol
+    first_quote: dict
+    _hist_shm_token: _Token
+    _rt_shm_token: _Token
 
-    # mem chan handed to broker backend so it can push real-time
-    # quotes to this task for sampling and history storage (see below).
-    send, quote_stream = trio.open_memory_channel(616)
+    # private shm refs loaded dynamically from tokens
+    _hist_shm: ShmArray | None = None
+    _rt_shm: ShmArray | None = None
 
-    # data sync signals for both history loading and market quotes
-    some_data_ready = trio.Event()
-    feed_is_live = trio.Event()
-
-    # establish broker backend quote stream by calling
-    # ``stream_quotes()``, which is a required broker backend endpoint.
-    init_msg, first_quote = await bus.nursery.start(
-        partial(
-            mod.stream_quotes,
-            send_chan=send,
-            feed_is_live=feed_is_live,
-            symbols=[symbol],
-            loglevel=loglevel,
-        )
-    )
-    # the broker-specific fully qualified symbol name,
-    # but ensure it is lower-cased for external use.
-    bfqsn = init_msg[symbol]['fqsn'].lower()
-    init_msg[symbol]['fqsn'] = bfqsn
-
-    # HISTORY, run 2 tasks:
-    # - a history loader / maintainer
-    # - a real-time streamer which consumers and sends new data to any
-    #   consumers as well as writes to storage backends (as configured).
-
-    # XXX: neither of these will raise but will cause an inf hang due to:
-    # https://github.com/python-trio/trio/issues/2258
-    # bus.nursery.start_soon(
-    # await bus.start_task(
-    (
-        izero_hist,
-        hist_shm,
-        izero_rt,
-        rt_shm,
-    ) = await bus.nursery.start(
-        manage_history,
-        mod,
-        bus,
-        '.'.join((bfqsn, brokername)),
-        some_data_ready,
-        feed_is_live,
-    )
-
-    # we hand an IPC-msg compatible shm token to the caller so it
-    # can read directly from the memory which will be written by
-    # this task.
-    msg = init_msg[symbol]
-    msg['hist_shm_token'] = hist_shm.token
-    msg['izero_hist'] = izero_hist
-    msg['izero_rt'] = izero_rt
-    msg['rt_shm_token'] = rt_shm.token
-
-    # true fqsn
-    fqsn = '.'.join((bfqsn, brokername))
-    # add a fqsn entry that includes the ``.<broker>`` suffix
-    # and an entry that includes the broker-specific fqsn (including
-    # any new suffixes or elements as injected by the backend).
-    init_msg[fqsn] = msg
-    init_msg[bfqsn] = msg
-
-    # TODO: pretty sure we don't need this? why not just leave 1s as
-    # the fastest "sample period" since we'll probably always want that
-    # for most purposes.
-    # pass OHLC sample rate in seconds (be sure to use python int type)
-    # init_msg[symbol]['sample_rate'] = 1 #int(delay_s)
-
-    # yield back control to starting nursery once we receive either
-    # some history or a real-time quote.
-    log.info(f'waiting on history to load: {fqsn}')
-    await some_data_ready.wait()
-
-    # append ``.<broker>`` suffix to each quote symbol
-    acceptable_not_fqsn_with_broker_suffix = symbol + f'.{brokername}'
-
-    generic_first_quotes = {
-        acceptable_not_fqsn_with_broker_suffix: first_quote,
-        fqsn: first_quote,
-    }
-
-    # for ambiguous names we simply apply the retreived
-    # feed to that name (for now).
-    bus.feeds[symbol] = bus.feeds[bfqsn] = (
-        init_msg,
-        generic_first_quotes,
-    )
-
-    # insert 1s ohlc into the increment buffer set
-    # to update and shift every second
-    sampler.ohlcv_shms.setdefault(
-        1,
-        []
-    ).append(rt_shm)
-
-    task_status.started()
-
-    if not start_stream:
-        await trio.sleep_forever()
-
-    # begin real-time updates of shm and tsb once the feed goes live and
-    # the backend will indicate when real-time quotes have begun.
-    await feed_is_live.wait()
-
-    # insert 1m ohlc into the increment buffer set
-    # to shift every 60s.
-    sampler.ohlcv_shms.setdefault(60, []).append(hist_shm)
-
-    # create buffer a single incrementer task broker backend
-    # (aka `brokerd`) using the lowest sampler period.
-    if sampler.incrementers.get(_default_delay_s) is None:
-        await bus.start_task(
-            increment_ohlc_buffer,
-            _default_delay_s,
-        )
-
-    sum_tick_vlm: bool = init_msg.get(
-        'shm_write_opts', {}
-    ).get('sum_tick_vlm', True)
-
-    # NOTE: if no high-freq sampled data has (yet) been loaded,
-    # seed the buffer with a history datum - this is most handy
-    # for many backends which don't sample @ 1s OHLC but do have
-    # slower data such as 1m OHLC.
-    if not len(rt_shm.array):
-        rt_shm.push(hist_shm.array[-3:-1])
-        ohlckeys = ['open', 'high', 'low', 'close']
-        rt_shm.array[ohlckeys][-2:] = hist_shm.array['close'][-1]
-        rt_shm.array['volume'][-2] = 0
-
-    # start sample loop and shm incrementer task for OHLC style sampling
-    # at the above registered step periods.
-    try:
-        await sample_and_broadcast(
-            bus,
-            rt_shm,
-            hist_shm,
-            quote_stream,
-            brokername,
-            sum_tick_vlm
-        )
-    finally:
-        log.warning(f'{fqsn} feed task terminated')
-
-
-@tractor.context
-async def open_feed_bus(
-
-    ctx: tractor.Context,
-    brokername: str,
-    symbol: str,  # normally expected to the broker-specific fqsn
-    loglevel: str,
-    tick_throttle: Optional[float] = None,
-    start_stream: bool = True,
-
-) -> None:
-    '''
-    Open a data feed "bus": an actor-persistent per-broker task-oriented
-    data feed registry which allows managing real-time quote streams per
-    symbol.
-
-    '''
-    if loglevel is None:
-        loglevel = tractor.current_actor().loglevel
-
-    # XXX: required to propagate ``tractor`` loglevel to piker logging
-    get_console_log(loglevel or tractor.current_actor().loglevel)
-
-    # local state sanity checks
-    # TODO: check for any stale shm entries for this symbol
-    # (after we also group them in a nice `/dev/shm/piker/` subdir).
-    # ensure we are who we think we are
-    servicename = tractor.current_actor().name
-    assert 'brokerd' in servicename
-    assert brokername in servicename
-
-    bus = get_feed_bus(brokername)
-
-    # if no cached feed for this symbol has been created for this
-    # brokerd yet, start persistent stream and shm writer task in
-    # service nursery
-    entry = bus.feeds.get(symbol)
-    if entry is None:
-        # allocate a new actor-local stream bus which
-        # will persist for this `brokerd`'s service lifetime.
-        async with bus.task_lock:
-            await bus.nursery.start(
-                partial(
-                    allocate_persistent_feed,
-
-                    bus=bus,
-                    brokername=brokername,
-                    # here we pass through the selected symbol in native
-                    # "format" (i.e. upper vs. lowercase depending on
-                    # provider).
-                    symbol=symbol,
-                    loglevel=loglevel,
-                    start_stream=start_stream,
-                )
-            )
-            # TODO: we can remove this?
-            assert isinstance(bus.feeds[symbol], tuple)
-
-    # XXX: ``first_quotes`` may be outdated here if this is secondary
-    # subscriber
-    init_msg, first_quotes = bus.feeds[symbol]
-
-    msg = init_msg[symbol]
-    bfqsn = msg['fqsn'].lower()
-
-    # true fqsn
-    fqsn = '.'.join([bfqsn, brokername])
-    assert fqsn in first_quotes
-    assert bus.feeds[bfqsn]
-
-    # broker-ambiguous symbol (provided on cli - eg. mnq.globex.ib)
-    bsym = symbol + f'.{brokername}'
-    assert bsym in first_quotes
-
-    # we use the broker-specific fqsn (bfqsn) for
-    # the sampler subscription since the backend isn't (yet)
-    # expected to append it's own name to the fqsn, so we filter
-    # on keys which *do not* include that name (e.g .ib) .
-    bus._subscribers.setdefault(bfqsn, [])
-
-    # send this even to subscribers to existing feed?
-    # deliver initial info message a first quote asap
-    await ctx.started((
-        init_msg,
-        first_quotes,
-    ))
-
-    if not start_stream:
-        log.warning(f'Not opening real-time stream for {fqsn}')
-        await trio.sleep_forever()
-
-    # real-time stream loop
-    async with (
-        ctx.open_stream() as stream,
-    ):
-        # re-send to trigger display loop cycle (necessary especially
-        # when the mkt is closed and no real-time messages are
-        # expected).
-        await stream.send({fqsn: first_quotes})
-
-        # open a bg task which receives quotes over a mem chan
-        # and only pushes them to the target actor-consumer at
-        # a max ``tick_throttle`` instantaneous rate.
-        if tick_throttle:
-            send, recv = trio.open_memory_channel(2**10)
-            cs = await bus.start_task(
-                uniform_rate_send,
-                tick_throttle,
-                recv,
-                stream,
-            )
-            sub = (send, ctx, tick_throttle)
-
-        else:
-            sub = (stream, ctx, tick_throttle)
-
-        subs = bus._subscribers[bfqsn]
-        subs.append(sub)
-
-        try:
-            uid = ctx.chan.uid
-
-            # ctrl protocol for start/stop of quote streams based on UI
-            # state (eg. don't need a stream when a symbol isn't being
-            # displayed).
-            async for msg in stream:
-
-                if msg == 'pause':
-                    if sub in subs:
-                        log.info(
-                            f'Pausing {fqsn} feed for {uid}')
-                        subs.remove(sub)
-
-                elif msg == 'resume':
-                    if sub not in subs:
-                        log.info(
-                            f'Resuming {fqsn} feed for {uid}')
-                        subs.append(sub)
-                else:
-                    raise ValueError(msg)
-        finally:
-            log.info(
-                f'Stopping {symbol}.{brokername} feed for {ctx.chan.uid}')
-
-            if tick_throttle:
-                # TODO: a one-cancels-one nursery
-                # n.cancel_scope.cancel()
-                cs.cancel()
-            try:
-                bus._subscribers[bfqsn].remove(sub)
-            except ValueError:
-                log.warning(f'{sub} for {symbol} was already removed?')
-
-
-@dataclass
-class Feed:
-    '''
-    A data feed for client-side interaction with far-process real-time
-    data sources.
-
-    This is an thin abstraction on top of ``tractor``'s portals for
-    interacting with IPC streams and storage APIs (shm and time-series
-    db).
-
-    '''
-    name: str
-    hist_shm: ShmArray
-    rt_shm: ShmArray
-    mod: ModuleType
-    first_quotes: dict  # symbol names to first quote dicts
-    _portal: tractor.Portal
-    stream: trio.abc.ReceiveChannel[dict[str, Any]]
-    status: dict[str, Any]
-
+    stream: tractor.MsgStream | None = None
     izero_hist: int = 0
     izero_rt: int = 0
-
-    throttle_rate: Optional[int] = None
-
-    _trade_stream: Optional[AsyncIterator[dict[str, Any]]] = None
-    _max_sample_rate: int = 1
-
-    # cache of symbol info messages received as first message when
-    # a stream startsc.
-    symbols: dict[str, Symbol] = field(default_factory=dict)
+    throttle_rate: int | None = None
 
     @property
-    def portal(self) -> tractor.Portal:
-        return self._portal
+    def rt_shm(self) -> ShmArray:
+
+        if self._rt_shm is None:
+            self._rt_shm = attach_shm_array(
+                token=self._rt_shm_token,
+                readonly=True,
+            )
+
+        return self._rt_shm
+
+    @property
+    def hist_shm(self) -> ShmArray:
+
+        if self._hist_shm is None:
+            self._hist_shm = attach_shm_array(
+                token=self._hist_shm_token,
+                readonly=True,
+            )
+
+        return self._hist_shm
 
     async def receive(self) -> dict:
         return await self.stream.receive()
@@ -1267,6 +960,489 @@ class Feed:
             ratio,
         )
 
+    # TODO: get native msgspec decoding for these workinn
+    def to_msg(self) -> dict:
+        msg = self.to_dict()
+        msg['symbol'] = msg['symbol'].to_dict()
+        # can't serialize the stream object, it's
+        # expected you'll have a ref to it since
+        # this msg should be rxed on a stream on
+        # whatever far end IPC..
+        msg.pop('stream')
+        return msg
+
+    @classmethod
+    def from_msg(cls, msg: dict) -> dict:
+        symbol = Symbol(**msg.pop('symbol'))
+        return cls(
+            symbol=symbol,
+            **msg,
+        )
+
+
+async def allocate_persistent_feed(
+    bus: _FeedsBus,
+
+    brokername: str,
+    symstr: str,
+
+    loglevel: str,
+    start_stream: bool = True,
+
+    task_status: TaskStatus[trio.CancelScope] = trio.TASK_STATUS_IGNORED,
+
+) -> None:
+    '''
+    Create and maintain a "feed bus" which allocates tasks for real-time
+    streaming and optional historical data storage per broker/data provider
+    backend; this normally task runs *in* a `brokerd` actor.
+
+    If none exists, this allocates a ``_FeedsBus`` which manages the
+    lifetimes of streaming tasks created for each requested symbol.
+
+
+    2 tasks are created:
+    - a real-time streaming task which connec
+
+    '''
+    # load backend module
+    try:
+        mod = get_brokermod(brokername)
+    except ImportError:
+        mod = get_ingestormod(brokername)
+
+    # mem chan handed to broker backend so it can push real-time
+    # quotes to this task for sampling and history storage (see below).
+    send, quote_stream = trio.open_memory_channel(616)
+
+    # data sync signals for both history loading and market quotes
+    some_data_ready = trio.Event()
+    feed_is_live = trio.Event()
+
+    # establish broker backend quote stream by calling
+    # ``stream_quotes()``, which is a required broker backend endpoint.
+    init_msg, first_quote = await bus.nursery.start(
+        partial(
+            mod.stream_quotes,
+            send_chan=send,
+            feed_is_live=feed_is_live,
+            symbols=[symstr],
+            loglevel=loglevel,
+        )
+    )
+    # TODO: this is indexed by symbol for now since we've planned (for
+    # some time) to expect backends to handle single
+    # ``.stream_quotes()`` calls with multiple symbols inputs to just
+    # work such that a backend can do its own multiplexing if desired.
+    #
+    # Likely this will require some design changes:
+    # - the .started() should return some config output determining
+    #   whether the backend does indeed multiplex multi-symbol quotes
+    #   internally or whether separate task spawns should be done per
+    #   symbol (as it is right now).
+    # - information about discovery of non-local host daemons which can
+    #   be contacted in the case where we want to support load disti
+    #   over multi-use clusters; eg. some new feed request is
+    #   re-directed to another daemon cluster because the current one is
+    #   at max capacity.
+    # - the same ideas ^ but when a local core is maxxed out (like how
+    #   binance does often with hft XD
+    # - if a brokerd is non-local then we can't just allocate a mem
+    #   channel here and have the brokerd write it, we instead need
+    #   a small streaming machine around the remote feed which can then
+    #   do the normal work of sampling and writing shm buffers
+    #   (depending on if we want sampling done on the far end or not?)
+    msg = init_msg[symstr]
+
+    # the broker-specific fully qualified symbol name,
+    # but ensure it is lower-cased for external use.
+    bfqsn = msg['fqsn'].lower()
+
+    # true fqsn including broker/provider suffix
+    fqsn = '.'.join((bfqsn, brokername))
+    # msg['fqsn'] = bfqsn
+
+    symbol = Symbol.from_fqsn(
+        fqsn=fqsn,
+        info=msg,
+    )
+
+    # HISTORY storage, run 2 tasks:
+    # - a history loader / maintainer
+    # - a real-time streamer which consumers and sends new data to any
+    #   consumers as well as writes to storage backends (as configured).
+
+    # XXX: neither of these will raise but will cause an inf hang due to:
+    # https://github.com/python-trio/trio/issues/2258
+    # bus.nursery.start_soon(
+    # await bus.start_task(
+    (
+        izero_hist,
+        hist_shm,
+        izero_rt,
+        rt_shm,
+    ) = await bus.nursery.start(
+        manage_history,
+        mod,
+        bus,
+        fqsn,
+        some_data_ready,
+        feed_is_live,
+    )
+
+    # we hand an IPC-msg compatible shm token to the caller so it
+    # can read directly from the memory which will be written by
+    # this task.
+
+    # msg['hist_shm_token'] = hist_shm.token
+    # msg['izero_hist'] = izero_hist
+    # msg['izero_rt'] = izero_rt
+    # msg['rt_shm_token'] = rt_shm.token
+
+    # add a fqsn entry that includes the ``.<broker>`` suffix
+    # and an entry that includes the broker-specific fqsn (including
+    # any new suffixes or elements as injected by the backend).
+    # init_msg[fqsn] = msg
+    # init_msg[bfqsn] = msg
+
+    # TODO: pretty sure we don't need this? why not just leave 1s as
+    # the fastest "sample period" since we'll probably always want that
+    # for most purposes.
+    # pass OHLC sample rate in seconds (be sure to use python int type)
+    # init_msg[symbol]['sample_rate'] = 1 #int(delay_s)
+
+    # yield back control to starting nursery once we receive either
+    # some history or a real-time quote.
+    log.info(f'waiting on history to load: {fqsn}')
+    await some_data_ready.wait()
+
+    # append ``.<broker>`` suffix to each quote symbol
+    # acceptable_not_fqsn_with_broker_suffix = symbol + f'.{brokername}'
+
+    # generic_first_quotes = {
+    #     acceptable_not_fqsn_with_broker_suffix: first_quote,
+    #     fqsn: first_quote,
+    # }
+
+    flume = Flume(
+        symbol=symbol,
+        _hist_shm_token=hist_shm.token,
+        _rt_shm_token=rt_shm.token,
+        first_quote=first_quote,
+        # stream=stream,
+        izero_hist=izero_hist,
+        izero_rt=izero_rt,
+        # throttle_rate=tick_throttle,
+    )
+
+    # for ambiguous names we simply apply the retreived
+    # feed to that name (for now).
+    bus.feeds[symstr] = bus.feeds[bfqsn] = flume
+        # init_msg,
+        # generic_first_quotes,
+    # )
+
+    # insert 1s ohlc into the increment buffer set
+    # to update and shift every second
+    sampler.ohlcv_shms.setdefault(
+        1,
+        []
+    ).append(rt_shm)
+
+    task_status.started()
+
+    if not start_stream:
+        await trio.sleep_forever()
+
+    # begin real-time updates of shm and tsb once the feed goes live and
+    # the backend will indicate when real-time quotes have begun.
+    await feed_is_live.wait()
+
+    # insert 1m ohlc into the increment buffer set
+    # to shift every 60s.
+    sampler.ohlcv_shms.setdefault(60, []).append(hist_shm)
+
+    # create buffer a single incrementer task broker backend
+    # (aka `brokerd`) using the lowest sampler period.
+    if sampler.incrementers.get(_default_delay_s) is None:
+        await bus.start_task(
+            increment_ohlc_buffer,
+            _default_delay_s,
+        )
+
+    sum_tick_vlm: bool = init_msg.get(
+        'shm_write_opts', {}
+    ).get('sum_tick_vlm', True)
+
+    # NOTE: if no high-freq sampled data has (yet) been loaded,
+    # seed the buffer with a history datum - this is most handy
+    # for many backends which don't sample @ 1s OHLC but do have
+    # slower data such as 1m OHLC.
+    if not len(rt_shm.array):
+        rt_shm.push(hist_shm.array[-3:-1])
+        ohlckeys = ['open', 'high', 'low', 'close']
+        rt_shm.array[ohlckeys][-2:] = hist_shm.array['close'][-1]
+        rt_shm.array['volume'][-2] = 0
+
+    # start sample loop and shm incrementer task for OHLC style sampling
+    # at the above registered step periods.
+    try:
+        await sample_and_broadcast(
+            bus,
+            rt_shm,
+            hist_shm,
+            quote_stream,
+            brokername,
+            sum_tick_vlm
+        )
+    finally:
+        log.warning(f'{fqsn} feed task terminated')
+
+
+@tractor.context
+async def open_feed_bus(
+
+    ctx: tractor.Context,
+    brokername: str,
+    symbols: list[str],  # normally expected to the broker-specific fqsn
+
+    loglevel: str = 'error',
+    tick_throttle: Optional[float] = None,
+    start_stream: bool = True,
+
+) -> dict[
+    str,  # fqsn
+    tuple[dict, dict]  # pair of dicts of the initmsg and first quotes
+]:
+    '''
+    Open a data feed "bus": an actor-persistent per-broker task-oriented
+    data feed registry which allows managing real-time quote streams per
+    symbol.
+
+    '''
+    if loglevel is None:
+        loglevel = tractor.current_actor().loglevel
+
+    # XXX: required to propagate ``tractor`` loglevel to piker logging
+    get_console_log(loglevel or tractor.current_actor().loglevel)
+
+    # local state sanity checks
+    # TODO: check for any stale shm entries for this symbol
+    # (after we also group them in a nice `/dev/shm/piker/` subdir).
+    # ensure we are who we think we are
+    servicename = tractor.current_actor().name
+    assert 'brokerd' in servicename
+    assert brokername in servicename
+
+    bus = get_feed_bus(brokername)
+
+    flumes: dict[str, Flume] = {}
+    for symbol in symbols:
+        # if no cached feed for this symbol has been created for this
+        # brokerd yet, start persistent stream and shm writer task in
+        # service nursery
+        entry = bus.feeds.get(symbol)
+        if entry is None:
+            # allocate a new actor-local stream bus which
+            # will persist for this `brokerd`'s service lifetime.
+            async with bus.task_lock:
+                await bus.nursery.start(
+                    partial(
+                        allocate_persistent_feed,
+
+                        bus=bus,
+                        brokername=brokername,
+                        # here we pass through the selected symbol in native
+                        # "format" (i.e. upper vs. lowercase depending on
+                        # provider).
+                        symstr=symbol,
+                        loglevel=loglevel,
+                        start_stream=start_stream,
+                    )
+                )
+                # TODO: we can remove this?
+                # assert isinstance(bus.feeds[symbol], tuple)
+
+        # XXX: ``first_quotes`` may be outdated here if this is secondary
+        # subscriber
+        # init_msg, first_quotes = bus.feeds[symbol]
+        flume = bus.feeds[symbol]
+        # assert bus.feeds[bfqsn] is flume
+
+        # msg = init_msg[symbol]
+        # bfqsn = msg['fqsn'].lower()
+        bfqsn = flume.symbol.key
+
+        # true fqsn
+        fqsn = '.'.join([bfqsn, brokername])
+        assert fqsn == flume.symbol.fqsn
+        # assert fqsn in first_quotes
+
+        # broker-ambiguous symbol (provided on cli - eg. mnq.globex.ib)
+        # bsym = symbol + f'.{brokername}'
+        # assert bsym in first_quotes
+
+        # pack for ``.started()`` sync msg
+        flumes[fqsn] = flume
+
+        # we use the broker-specific fqsn (bfqsn) for
+        # the sampler subscription since the backend isn't (yet)
+        # expected to append it's own name to the fqsn, so we filter
+        # on keys which *do not* include that name (e.g .ib) .
+        bus._subscribers.setdefault(bfqsn, [])
+
+    # send this even to subscribers to existing feed?
+    # deliver initial info message a first quote asap
+    await ctx.started(flumes)
+        # init_msg,
+        # first_quotes,
+    # ))
+
+    if not start_stream:
+        log.warning(f'Not opening real-time stream for {fqsn}')
+        await trio.sleep_forever()
+
+    # real-time stream loop
+    async with (
+        ctx.open_stream() as stream,
+    ):
+
+        local_subs: list = []
+        for fqsn, flume in flumes.items():
+            # re-send to trigger display loop cycle (necessary especially
+            # when the mkt is closed and no real-time messages are
+            # expected).
+            await stream.send({fqsn: flume.first_quote})
+
+            # set a common msg stream for all requested symbols
+            flume.stream = stream
+
+            # Add a real-time quote subscription to feed bus:
+            # This ``sub`` subscriber entry is added to the feed bus set so
+            # that the ``sample_and_broadcast()`` task (spawned inside
+            # ``allocate_persistent_feed()``) will push real-time quote
+            # (ticks) to this new consumer.
+
+            if tick_throttle:
+                flume.throttle_rate = tick_throttle
+
+                # open a bg task which receives quotes over a mem chan
+                # and only pushes them to the target actor-consumer at
+                # a max ``tick_throttle`` instantaneous rate.
+                send, recv = trio.open_memory_channel(2**10)
+
+                cs = await bus.start_task(
+                    uniform_rate_send,
+                    tick_throttle,
+                    recv,
+                    stream,
+                )
+                # NOTE: so the ``send`` channel here is actually a swapped
+                # in trio mem chan which gets pushed by the normal sampler
+                # task but instead of being sent directly over the IPC msg
+                # stream it's the throttle task does the work of
+                # incrementally forwarding to the IPC stream at the throttle
+                # rate.
+                sub = (send, ctx, tick_throttle)
+
+            else:
+                sub = (stream, ctx, tick_throttle)
+
+            # TODO: add an api for this on the bus?
+            # maybe use the current task-id to key the sub list that's
+            # added / removed? Or maybe we can add a general
+            # pause-resume by sub-key api?
+            bus_subs = bus._subscribers[bfqsn]
+            bus_subs.append(sub)
+            local_subs.append(sub)
+
+        try:
+            uid = ctx.chan.uid
+
+            # ctrl protocol for start/stop of quote streams based on UI
+            # state (eg. don't need a stream when a symbol isn't being
+            # displayed).
+            async for msg in stream:
+
+                if msg == 'pause':
+                    for sub in local_subs:
+                        if sub in bus_subs:
+                            log.info(
+                                f'Pausing {fqsn} feed for {uid}')
+                            bus_subs.remove(sub)
+
+                elif msg == 'resume':
+                    for sub in local_subs:
+                        if sub not in bus_subs:
+                            log.info(
+                                f'Resuming {fqsn} feed for {uid}')
+                            bus_subs.append(sub)
+                else:
+                    raise ValueError(msg)
+        finally:
+            log.info(
+                f'Stopping {symbol}.{brokername} feed for {ctx.chan.uid}')
+
+            if tick_throttle:
+                # TODO: a one-cancels-one nursery
+                # n.cancel_scope.cancel()
+                cs.cancel()
+
+            # drop all subs for this task from the bus
+            for sub in local_subs:
+                try:
+                    bus._subscribers[bfqsn].remove(sub)
+                except ValueError:
+                    log.warning(f'{sub} for {symbol} was already removed?')
+
+
+# @dataclass
+class Feed(Struct):
+    '''
+    A per-provider API for client-side consumption from real-time data
+    (streaming) sources, normally brokers and data services.
+
+    This is a somewhat thin abstraction on top of
+    a ``tractor.MsgStream`` plus associate share memory buffers which
+    can be read in a readers-writer-lock style IPC configuration.
+
+    Furhter, there is direct access to slower sampled historical data through
+    similarly allocated shm arrays.
+
+    '''
+    # name: str
+    # hist_shm: ShmArray
+    # rt_shm: ShmArray
+    mod: ModuleType
+    _portal: tractor.Portal
+    # symbol names to first quote dicts
+    # shms: dict[str, tuple[ShmArray, Shmarray]]
+    flumes: dict[str, Flume] = {}
+    # first_quotes: dict[str, dict] = {}
+    streams: dict[
+        str,
+        trio.abc.ReceiveChannel[dict[str, Any]],
+    ] = {}
+    status: dict[str, Any]
+
+    # izero_hist: int = 0
+    # izero_rt: int = 0
+    # throttle_rate: Optional[int] = None
+
+    _max_sample_rate: int = 1
+
+    # cache of symbol info messages received as first message when
+    # a stream startsc.
+    # symbols: dict[str, Symbol] = {}
+
+    @property
+    def portal(self) -> tractor.Portal:
+        return self._portal
+
+    @property
+    def name(self) -> str:
+        return self.mod.name
+
 
 @acm
 async def install_brokerd_search(
@@ -1320,118 +1496,172 @@ async def open_feed(
     Open a "data feed" which provides streamed real-time quotes.
 
     '''
-    fqsn = fqsns[0].lower()
+    # fqsn = fqsns[0].lower()
 
-    brokername, key, suffix = unpack_fqsn(fqsn)
-    bfqsn = fqsn.replace('.' + brokername, '')
+    providers: dict[ModuleType, list[str]] = {}
 
-    try:
-        mod = get_brokermod(brokername)
-    except ImportError:
-        mod = get_ingestormod(brokername)
-
-    # no feed for broker exists so maybe spawn a data brokerd
-    async with (
-
-        # if no `brokerd` for this backend exists yet we spawn
-        # and actor for one.
-        maybe_spawn_brokerd(
-            brokername,
-            loglevel=loglevel
-        ) as portal,
-
-        # (allocate and) connect to any feed bus for this broker
-        portal.open_context(
-            open_feed_bus,
-            brokername=brokername,
-            symbol=bfqsn,
-            loglevel=loglevel,
-            start_stream=start_stream,
-            tick_throttle=tick_throttle,
-
-        ) as (ctx, (init_msg, first_quotes)),
-
-        ctx.open_stream(
-            # XXX: be explicit about stream backpressure since we should
-            # **never** overrun on feeds being too fast, which will
-            # pretty much always happen with HFT XD
-            backpressure=backpressure,
-        ) as stream,
-
-    ):
-        init = init_msg[bfqsn]
-        # we can only read from shm
-        hist_shm = attach_shm_array(
-            token=init['hist_shm_token'],
-            readonly=True,
-        )
-        rt_shm = attach_shm_array(
-            token=init['rt_shm_token'],
-            readonly=True,
-        )
-
-        assert fqsn in first_quotes
-
-        feed = Feed(
-            name=brokername,
-            hist_shm=hist_shm,
-            rt_shm=rt_shm,
-            mod=mod,
-            first_quotes=first_quotes,
-            stream=stream,
-            _portal=portal,
-            status={},
-            izero_hist=init['izero_hist'],
-            izero_rt=init['izero_rt'],
-            throttle_rate=tick_throttle,
-        )
-
-        # fill out "status info" that the UI can show
-        host, port = feed.portal.channel.raddr
-        if host == '127.0.0.1':
-            host = 'localhost'
-
-        feed.status.update({
-            'actor_name': feed.portal.channel.uid[0],
-            'host': host,
-            'port': port,
-            'shm': f'{humanize(feed.hist_shm._shm.size)}',
-            'throttle_rate': feed.throttle_rate,
-        })
-        feed.status.update(init_msg.pop('status', {}))
-
-        for sym, data in init_msg.items():
-            si = data['symbol_info']
-            fqsn = data['fqsn'] + f'.{brokername}'
-            symbol = Symbol.from_fqsn(
-                fqsn,
-                info=si,
-            )
-
-            # symbol.broker_info[brokername] = si
-            feed.symbols[fqsn] = symbol
-            feed.symbols[f'{sym}.{brokername}'] = symbol
-
-            # cast shm dtype to list... can't member why we need this
-            for shm_key, shm in [
-                ('rt_shm_token', rt_shm),
-                ('hist_shm_token', hist_shm),
-            ]:
-                shm_token = data[shm_key]
-
-                # XXX: msgspec won't relay through the tuples XD
-                shm_token['dtype_descr'] = tuple(
-                    map(tuple, shm_token['dtype_descr']))
-
-                assert shm_token == shm.token  # sanity
-
-        feed._max_sample_rate = 1
+    for fqsn in fqsns:
+        brokername, key, suffix = unpack_fqsn(fqsn)
+        bfqsn = fqsn.replace('.' + brokername, '')
 
         try:
-            yield feed
-        finally:
-            # drop the infinite stream connection
-            await ctx.cancel()
+            mod = get_brokermod(brokername)
+        except ImportError:
+            mod = get_ingestormod(brokername)
+
+        # built a per-provider map to instrument names
+        providers.setdefault(mod, []).append(bfqsn)
+
+    # one actor per brokerd for now
+    brokerd_ctxs = []
+
+    for brokermod, bfqsns in providers.items():
+
+        # if no `brokerd` for this backend exists yet we spawn
+        # a daemon actor for it.
+        brokerd_ctxs.append(
+            maybe_spawn_brokerd(
+                brokermod.name,
+                loglevel=loglevel
+            )
+        )
+
+    portals: tuple[tractor.Portal]
+    async with gather_contexts(
+        brokerd_ctxs,
+    ) as portals:
+
+        bus_ctxs = []
+        for (
+            portal,
+            (brokermod, bfqsns),
+        ) in zip(portals, providers.items()):
+
+            feed = Feed(
+                mod=brokermod,
+                _portal=portal,
+                status={},
+            )
+            # fill out "status info" that the UI can show
+            host, port = feed.portal.channel.raddr
+            if host == '127.0.0.1':
+                host = 'localhost'
+
+            feed.status.update({
+                'actor_name': feed.portal.channel.uid[0],
+                'host': host,
+                'port': port,
+                # 'shm': f'{humanize(feed.hist_shm._shm.size)}',
+                # 'throttle_rate': feed.throttle_rate,
+            })
+            # feed.status.update(init_msg.pop('status', {}))
+
+            # (allocate and) connect to any feed bus for this broker
+            bus_ctxs.append(
+                portal.open_context(
+                    open_feed_bus,
+                    brokername=brokername,
+                    symbols=bfqsns,
+                    loglevel=loglevel,
+                    start_stream=start_stream,
+                    tick_throttle=tick_throttle,
+                )
+            )
+
+            async with (
+                gather_contexts(bus_ctxs) as ctxs,
+            ):
+                for (
+                    (ctx, flumes_msg_dict),
+                    (brokermod, bfqsns),
+                ) in zip(ctxs, providers.items()):
+
+                    stream_ctxs = []
+                    for fqsn, flume_msg in flumes_msg_dict.items():
+                        flume = Flume.from_msg(flume_msg)
+                        assert flume.symbol.fqsn == fqsn
+                        feed.flumes[fqsn] = flume
+
+                    # TODO: this is ugly but eventually we could
+                    # in theory do all this "tabling" of flumes on
+                    # the brokerd-side, in which case we'll likely
+                    # want to make each flume IPC-msg-native?
+                    # bfqsn = list(init_msgs)[0]
+                    # init = init_msg[bfqsn]
+
+                    # si = data['symbol_info']
+                    # fqsn = data['fqsn'] + f'.{brokername}'
+                    # symbol = Symbol.from_fqsn(
+                    #     fqsn,
+                    #     info=si,
+                    # )
+
+                        # attach and cache shm handles
+                        rt_shm = flume.rt_shm
+                        assert rt_shm
+                        hist_shm = flume.hist_shm
+                        assert hist_shm
+
+                    stream_ctxs.append(
+                        ctx.open_stream(
+                            # XXX: be explicit about stream backpressure since we should
+                            # **never** overrun on feeds being too fast, which will
+                            # pretty much always happen with HFT XD
+                            backpressure=backpressure,
+                        )
+                    )
+
+                async with (
+                    gather_contexts(stream_ctxs) as streams,
+                ):
+                    for (
+                        stream,
+                        (brokermod, bfqsns),
+                    ) in zip(streams, providers.items()):
+
+                        for bfqsn in bfqsns:
+                            fqsn = '.'.join((bfqsn, brokermod.name))
+
+                            # apply common rt steam to each flume
+                            # (normally one per broker)
+                            feed.flumes[fqsn].stream = stream
+                            feed.streams[brokermod.name] = stream
+
+                    try:
+                        yield feed
+                    finally:
+                        # drop the infinite stream connection
+                        await ctx.cancel()
+
+                    # we can only read from shm
+                    # hist_shm = attach_shm_array(
+                    #     token=init['hist_shm_token'],
+                    #     readonly=True,
+                    # )
+                    # rt_shm = attach_shm_array(
+                    #     token=init['rt_shm_token'],
+                    #     readonly=True,
+                    # )
+
+                # for sym, data in init_msg.items():
+
+                    # symbol.broker_info[brokername] = si
+                    # feed.symbols[fqsn] = symbol
+                    # feed.symbols[f'{sym}.{brokername}'] = symbol
+
+                    # cast shm dtype to list... can't member why we need this
+                    # for shm_key, shm in [
+                    #     ('rt_shm_token', rt_shm),
+                    #     ('hist_shm_token', hist_shm),
+                    # ]:
+                    #     shm_token = flume[shm_key]
+
+                    #     # XXX: msgspec won't relay through the tuples XD
+                    #     shm_token['dtype_descr'] = tuple(
+                    #         map(tuple, shm_token['dtype_descr']))
+
+                    #     assert shm_token == shm.token  # sanity
+                    # assert fqsn in first_quotes
 
 
 @acm

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -38,7 +38,7 @@ from math import isnan
 
 from bidict import bidict
 from msgspec.msgpack import encode, decode
-import pyqtgraph as pg
+# import pyqtgraph as pg
 import numpy as np
 import tractor
 from trio_websocket import open_websocket_url
@@ -429,10 +429,7 @@ class Storage:
         end: Optional[int] = None,
         limit: int = int(800e3),
 
-    ) -> dict[
-        int,
-        Union[dict, np.ndarray],
-    ]:
+    ) -> np.ndarray:
 
         client = self.client
         syms = await client.list_symbols()

--- a/piker/data/marketstore.py
+++ b/piker/data/marketstore.py
@@ -661,7 +661,7 @@ async def tsdb_history_update(
             [fqsn],
             start_stream=False,
 
-        ) as (feed, stream),
+        ) as feed,
     ):
         profiler(f'opened feed for {fqsn}')
 
@@ -669,12 +669,13 @@ async def tsdb_history_update(
         # to_prepend = None
 
         if fqsn:
-            symbol = feed.symbols.get(fqsn)
+            flume = feed.flumes[fqsn]
+            symbol = flume.symbol
             if symbol:
-                fqsn = symbol.front_fqsn()
+                fqsn = symbol.fqsn
 
             # diff db history with shm and only write the missing portions
-            # ohlcv = feed.hist_shm.array
+            # ohlcv = flume.hist_shm.array
 
             # TODO: use pg profiler
             # for secs in (1, 60):

--- a/piker/data/types.py
+++ b/piker/data/types.py
@@ -42,16 +42,17 @@ class Struct(
             for f in self.__struct_fields__
         }
 
-    def __repr__(self):
-        # only turn on pprint when we detect a python REPL
-        # at runtime B)
-        if (
-            hasattr(sys, 'ps1')
-            # TODO: check if we're in pdb
-        ):
-            return self.pformat()
+    # Lul, doesn't seem to work that well..
+    # def __repr__(self):
+    #     # only turn on pprint when we detect a python REPL
+    #     # at runtime B)
+    #     if (
+    #         hasattr(sys, 'ps1')
+    #         # TODO: check if we're in pdb
+    #     ):
+    #         return self.pformat()
 
-        return super().__repr__()
+    #     return super().__repr__()
 
     def pformat(self) -> str:
         return f'Struct({pformat(self.to_dict())})'

--- a/piker/ui/_app.py
+++ b/piker/ui/_app.py
@@ -19,15 +19,16 @@ Main app startup and run.
 
 '''
 from functools import partial
+from types import ModuleType
 
 from PyQt5.QtCore import QEvent
 import trio
 
 from .._daemon import maybe_spawn_brokerd
-from ..brokers import get_brokermod
 from . import _event
 from ._exec import run_qtractor
 from ..data.feed import install_brokerd_search
+from ..data._source import unpack_fqsn
 from . import _search
 from ._chart import GodWidget
 from ..log import get_logger
@@ -36,27 +37,26 @@ log = get_logger(__name__)
 
 
 async def load_provider_search(
-
-    broker: str,
+    brokermod: str,
     loglevel: str,
 
 ) -> None:
 
-    log.info(f'loading brokerd for {broker}..')
+    name = brokermod.name
+    log.info(f'loading brokerd for {name}..')
 
     async with (
 
         maybe_spawn_brokerd(
-            broker,
+            name,
             loglevel=loglevel
         ) as portal,
 
         install_brokerd_search(
             portal,
-            get_brokermod(broker),
+            brokermod,
         ),
     ):
-
         # keep search engine stream up until cancelled
         await trio.sleep_forever()
 
@@ -67,7 +67,7 @@ async def _async_main(
     main_widget: GodWidget,
 
     syms: list[str],
-    brokernames: str,
+    brokers: dict[str, ModuleType],
     loglevel: str,
 
 ) -> None:
@@ -98,6 +98,11 @@ async def _async_main(
 
     sbar = godwidget.window.status_bar
     starting_done = sbar.open_status('starting ze sexy chartz')
+
+    needed_brokermods: dict[str, ModuleType] = {}
+    for fqsn in syms:
+        brokername, *_ = unpack_fqsn(fqsn)
+        needed_brokermods[brokername] = brokers[brokername]
 
     async with (
         trio.open_nursery() as root_n,
@@ -140,8 +145,12 @@ async def _async_main(
         ):
             # load other providers into search **after**
             # the chart's select cache
-            for broker in brokernames:
-                root_n.start_soon(load_provider_search, broker, loglevel)
+            for brokername, mod in needed_brokermods.items():
+                root_n.start_soon(
+                    load_provider_search,
+                    mod,
+                    loglevel,
+                )
 
             await order_mode_ready.wait()
 
@@ -171,7 +180,7 @@ async def _async_main(
 
 def _main(
     syms: list[str],
-    brokernames: [str],
+    brokermods: list[ModuleType],
     piker_loglevel: str,
     tractor_kwargs,
 ) -> None:
@@ -182,7 +191,11 @@ def _main(
     '''
     run_qtractor(
         func=_async_main,
-        args=(syms, brokernames, piker_loglevel),
+        args=(
+            syms,
+            {mod.name: mod for mod in brokermods},
+            piker_loglevel,
+        ),
         main_widget_type=GodWidget,
         tractor_kwargs=tractor_kwargs,
     )

--- a/piker/ui/_app.py
+++ b/piker/ui/_app.py
@@ -66,7 +66,7 @@ async def _async_main(
     # implicit required argument provided by ``qtractor_run()``
     main_widget: GodWidget,
 
-    sym: str,
+    syms: list[str],
     brokernames: str,
     loglevel: str,
 
@@ -113,12 +113,16 @@ async def _async_main(
         # godwidget.hbox.addWidget(search)
         godwidget.search = search
 
-        symbol, _, provider = sym.rpartition('.')
+        symbols: list[str] = []
+
+        for sym in syms:
+            symbol, _, provider = sym.rpartition('.')
+            symbols.append(symbol)
 
         # this internally starts a ``display_symbol_data()`` task above
-        order_mode_ready = await godwidget.load_symbol(
+        order_mode_ready = await godwidget.load_symbols(
             provider,
-            symbol,
+            symbols,
             loglevel
         )
 
@@ -166,7 +170,7 @@ async def _async_main(
 
 
 def _main(
-    sym: str,
+    syms: list[str],
     brokernames: [str],
     piker_loglevel: str,
     tractor_kwargs,
@@ -178,7 +182,7 @@ def _main(
     '''
     run_qtractor(
         func=_async_main,
-        args=(sym, brokernames, piker_loglevel),
+        args=(syms, brokernames, piker_loglevel),
         main_widget_type=GodWidget,
         tractor_kwargs=tractor_kwargs,
     )

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -916,7 +916,7 @@ class ChartPlotWidget(pg.PlotWidget):
         try:
             for feed in self._feeds.values():
                 for flume in feed.flumes.values():
-                    self.linked.godwidget._root_n.start_soon(flume.resume)
+                    self.linked.godwidget._root_n.start_soon(feed.resume)
         except RuntimeError:
             # TODO: cancel the qtractor runtime here?
             raise
@@ -924,7 +924,7 @@ class ChartPlotWidget(pg.PlotWidget):
     def pause_all_feeds(self):
         for feed in self._feeds.values():
             for flume in feed.flumes.values():
-                self.linked.godwidget._root_n.start_soon(flume.pause)
+                self.linked.godwidget._root_n.start_soon(feed.pause)
 
     @property
     def view(self) -> ChartView:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -915,14 +915,16 @@ class ChartPlotWidget(pg.PlotWidget):
     def resume_all_feeds(self):
         try:
             for feed in self._feeds.values():
-                self.linked.godwidget._root_n.start_soon(feed.resume)
+                for flume in feed.flumes.values():
+                    self.linked.godwidget._root_n.start_soon(flume.resume)
         except RuntimeError:
             # TODO: cancel the qtractor runtime here?
             raise
 
     def pause_all_feeds(self):
         for feed in self._feeds.values():
-            self.linked.godwidget._root_n.start_soon(feed.pause)
+            for flume in feed.flumes.values():
+                self.linked.godwidget._root_n.start_soon(flume.pause)
 
     @property
     def view(self) -> ChartView:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -186,10 +186,10 @@ class GodWidget(QWidget):
     ) -> tuple[LinkedSplits, LinkedSplits]:  # type: ignore
         return self._chart_cache.get(symbol_key)
 
-    async def load_symbol(
+    async def load_symbols(
         self,
         providername: str,
-        symbol_key: str,
+        symbol_keys: list[str],
         loglevel: str,
         reset: bool = False,
 
@@ -200,12 +200,20 @@ class GodWidget(QWidget):
         Expects a ``numpy`` structured array containing all the ohlcv fields.
 
         '''
-        # our symbol key style is always lower case
-        symbol_key = symbol_key.lower()
+        fqsns: list[str] = []
 
-        # fully qualified symbol name (SNS i guess is what we're making?)
-        fqsn = '.'.join([symbol_key, providername])
-        all_linked = self.get_chart_symbol(fqsn)
+        # our symbol key style is always lower case
+        for key in list(map(str.lower, symbol_keys)):
+
+            # fully qualified symbol name (SNS i guess is what we're making?)
+            fqsn = '.'.join([key, providername])
+            fqsns.append(fqsn)
+
+        # NOTE: for now we use the first symbol in the set as the "key"
+        # for the overlay of feeds on the chart.
+        group_key = fqsns[0]
+
+        all_linked = self.get_chart_symbol(group_key)
         order_mode_started = trio.Event()
 
         if not self.vbox.isEmpty():
@@ -238,7 +246,7 @@ class GodWidget(QWidget):
                 display_symbol_data,
                 self,
                 providername,
-                symbol_key,
+                fqsns,
                 loglevel,
                 order_mode_started,
             )

--- a/piker/ui/_overlay.py
+++ b/piker/ui/_overlay.py
@@ -304,7 +304,7 @@ class PlotItemOverlay:
         # NOTE: required for scene layering/relaying; this guarantees
         # the "root" plot receives priority for interaction
         # events/signals.
-        root_plotitem.vb.setZValue(1000)
+        root_plotitem.vb.setZValue(10)
 
         self.overlays: list[PlotItem] = []
         self.layout = ComposedGridLayout(root_plotitem)
@@ -493,6 +493,8 @@ class PlotItemOverlay:
         assert not vb.focusWidget()
         root.vb.setFocus()
         assert root.vb.focusWidget()
+
+        vb.setZValue(100)
 
     def get_axis(
         self,

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -665,9 +665,9 @@ class SearchWidget(QtWidgets.QWidget):
 
         log.info(f'Requesting symbol: {symbol}.{provider}')
 
-        await godw.load_symbol(
+        await godw.load_symbols(
             provider,
-            symbol,
+            [symbol],
             'info',
         )
 

--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -174,7 +174,7 @@ def chart(
 
 
     _main(
-        sym=symbols[0],
+        syms=symbols,
         brokernames=brokernames,
         piker_loglevel=pikerloglevel,
         tractor_kwargs={

--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -166,16 +166,16 @@ def chart(
             ))
             return
 
-
     # global opts
     brokernames = config['brokers']
+    brokermods = config['brokermods']
+    assert brokermods
     tractorloglevel = config['tractorloglevel']
     pikerloglevel = config['loglevel']
 
-
     _main(
         syms=symbols,
-        brokernames=brokernames,
+        brokermods=brokermods,
         piker_loglevel=pikerloglevel,
         tractor_kwargs={
             'debug_mode': pdb,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # we require a pinned dev branch to get some edge features that
 # are often untested in tractor's CI and/or being tested by us
 # first before committing as core features in tractor's base.
--e git+https://github.com/goodboy/tractor.git@master#egg=tractor
+-e git+https://github.com/goodboy/tractor.git@piker_pin#egg=tractor
 
 # `pyqtgraph` peeps keep breaking, fixing, improving so might as well
 # pin this to a dev branch that we have more control over especially

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,15 @@ def travis(confdir):
         trio.run(ensure_config)
 
 
+_ci_env: bool = os.environ.get('CI', False)
+
+
+@pytest.fixture(scope='session')
+def ci_env() -> bool:
+    """Detect CI envoirment.
+    """
+    return _ci_env
+
 @pytest.fixture
 def us_symbols():
     return ['TSLA', 'AAPL', 'CGC', 'CRON']
@@ -96,3 +105,4 @@ def tmx_symbols():
 @pytest.fixture
 def cse_symbols():
     return ['TRUL.CN', 'CWEB.CN', 'SNN.CN']
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,6 @@ def pytest_addoption(parser):
                      help="Use a practice API account")
 
 
-@pytest.fixture(scope='session', autouse=True)
-def loglevel(request):
-    orig = tractor.log._default_loglevel
-    level = tractor.log._default_loglevel = request.config.option.loglevel
-    log.get_console_log(level)
-    yield level
-    tractor.log._default_loglevel = orig
-
-
 @pytest.fixture(scope='session')
 def test_config():
     dirname = os.path.dirname

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -25,10 +25,10 @@ from piker.data._source import (
         (100, {'btcusdt.binance', 'ethusdt.binance'}),
 
         # kraken
-        (20, {'xbteur.kraken', 'xbtusd.kraken'}),
+        (20, {'ethusdt.kraken', 'xbtusd.kraken'}),
 
         # binance + kraken
-        (200, {'btcusdt.binance', 'xbtusd.kraken'}),
+        (100, {'btcusdt.binance', 'xbtusd.kraken'}),
     ],
     ids=lambda param: f'quotes={param[0]}@fqsns={param[1]}',
 )
@@ -96,7 +96,7 @@ def test_multi_fqsn_feed(
                             assert quote['last'] == flume.first_quote['last']
 
                 cntr = Counter()
-                with trio.fail_after(5):
+                with trio.fail_after(6):
                     async for quotes in stream:
                         for fqsn, quote in quotes.items():
                             cntr[fqsn] += 1

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -1,0 +1,65 @@
+'''
+Data feed layer APIs, performance, msg throttling.
+
+'''
+from pprint import pprint
+
+import pytest
+import trio
+from piker import (
+    open_piker_runtime,
+    open_feed,
+)
+from piker.data import ShmArray
+
+
+@pytest.mark.parametrize(
+    'fqsns',
+    [
+        ['btcusdt.binance']
+    ],
+    ids=lambda param: f'fqsns={param}',
+)
+def test_basic_rt_feed(
+    fqsns: list[str],
+):
+    '''
+    Start a real-time data feed for provided fqsn and pull
+    a few quotes then simply shut down.
+
+    '''
+    async def main():
+        async with (
+            open_piker_runtime('test_basic_rt_feed'),
+            open_feed(
+                fqsns,
+                loglevel='info',
+
+                # TODO: ensure throttle rate is applied
+                # limit to at least display's FPS
+                # avoiding needless Qt-in-guest-mode context switches
+                # tick_throttle=_quote_throttle_rate,
+
+            ) as feed
+        ):
+            for fqin in fqsns:
+                assert feed.symbols[fqin]
+
+            ohlcv: ShmArray = feed.rt_shm
+            hist_ohlcv: ShmArray = feed.hist_shm
+
+            count: int = 0
+            async for quotes in feed.stream:
+
+                # print quote msg, rt and history
+                # buffer values on console.
+                pprint(quotes)
+                pprint(ohlcv.array[-1])
+                pprint(hist_ohlcv.array[-1])
+
+                if count >= 100:
+                    break
+
+                count += 1
+
+    trio.run(main)

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -96,7 +96,7 @@ def test_multi_fqsn_feed(
                             assert quote['last'] == flume.first_quote['last']
 
                 cntr = Counter()
-                with trio.fail_after(3):
+                with trio.fail_after(5):
                     async for quotes in stream:
                         for fqsn, quote in quotes.items():
                             cntr[fqsn] += 1


### PR DESCRIPTION
Enhances our `piker.open_feed()` real-time quotes and history managment layer `piker.data.feed` to accept multi-fqsn inputs to deliver multi-symbol quote streams and a new internal data streaming abstraction/API: `.data.Flume` which provides the basis for real-time stream mangement, access and measure for the needs of real-time data-flow management and orchestration.

---
#### Synopsis
The final core-UX feature you always wanted as a chart trader is probably something like: 

*mult-instrument overlayed real-time and historical data feeds with simultaneous interaction and "current symbol" selectable order mode control*..

well, this **is finally within reach** 😎  and this patch add the "backend" work making it possible 🏄🏼 

---
#### Notes for manual testing
Ideally reviewers run the new feeds test set with `pytest tests/test_feeds.py`.
Note that you'll need to install the `piker_pin` branch of `tractor` in order for the test set to run green:
- the requirements file was updates in this patch: https://github.com/pikers/piker/pull/414/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552
- you can also simply switch to the remote `piker_pin` branch for `tractor` if installed in dev mode locally.

---
#### to land
- [x] fill out commit msg for 7abcb3e0 which was initial (half-working) patch to get basic funtionality 
- [x] port all consumer code in clearing, order mode, charting/graphics layer to expect this adjusted `Feed` api.
- [x] add basic per-`brokerd` multi-symbol real-time feeds working
  - enables `piker.open_feed(fqsns=['btcusdt.binance', 'ethusdt.binance']) as feed)` where the delivered `Feed` now has a `.flumes: dict[str, Flume]` which enables per-`fqsn` data flow access, mgmt, measure (see the historical [flume](https://en.wikipedia.org/wiki/Flume#Flow_measurement_flume) for idea behind this abstraction terminology)
  - [x] add a test in `test_feeds.py`
    - [x] `binance` multi-symbol case
    - [x] `kraken` multi-symbol case
    - [x] `kraken` currently seems to depend on a `brokers.toml` existing? we should fix this..

- [x] add cross-`brokerd` multi-feeds such that  `piker.open_feed(fqsns=['btcusdt.binance', 'xbtusdt.kraken']) will work with an aggregate receive channel delivering quotes from both backends?
    - [x] multi-brokerd` multi-sym case (`kraken` + `binance`)
    
---
### Test suite TODO: see [two comments below](https://github.com/pikers/piker/pull/414#issuecomment-1349536994)
