### PR TITLE
`Signal`-less pi overlays

### DIFF
--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -746,12 +746,12 @@ async def manage_history(
 
         # we expect the sub-actor to write
         readonly=False,
-        size=4*_secs_in_day,
+        size=3*_secs_in_day,
     )
 
     # (for now) set the rt (hft) shm array with space to prepend
     # only a few days worth of 1s history.
-    days = 3
+    days = 2
     start_index = days*_secs_in_day
     rt_shm._first.value = start_index
     rt_shm._last.value = start_index

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -814,7 +814,8 @@ class ChartPlotWidget(pg.PlotWidget):
     # a better one?
     def mk_vb(self, name: str) -> ChartView:
         cv = ChartView(name)
-        cv.linkedsplits = self.linked
+        # link new view to chart's view set
+        cv.linked = self.linked
         return cv
 
     def __init__(
@@ -1179,18 +1180,26 @@ class ChartPlotWidget(pg.PlotWidget):
         )
         pi.hideButtons()
 
-        # cv.enable_auto_yrange(self.view)
-        cv.enable_auto_yrange()
-
         # compose this new plot's graphics with the current chart's
         # existing one but with separate axes as neede and specified.
         self.pi_overlay.add_plotitem(
             pi,
             index=index,
 
-            # only link x-axes,
+            # only link x-axes and
+            # don't relay any ``ViewBox`` derived event
+            # handlers since we only care about keeping charts
+            # x-synced on interaction (at least for now).
             link_axes=(0,),
         )
+
+        # connect auto-yrange callbacks *from* this new
+        # view **to** this parent and likewise *from* the
+        # main/parent chart back *to* the created overlay.
+        cv.enable_auto_yrange(src_vb=self.view)
+        # makes it so that interaction on the new overlay will reflect
+        # back on the main chart (which overlay was added to).
+        self.view.enable_auto_yrange(src_vb=cv)
 
         # add axis title
         # TODO: do we want this API to still work?

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -624,6 +624,8 @@ async def open_vlm_displays(
         # built-in vlm which we plot ASAP since it's
         # usually data provided directly with OHLC history.
         shm = ohlcv
+        ohlc_chart = linked.chart
+
         chart = linked.add_plot(
             name='volume',
             shm=shm,
@@ -638,6 +640,9 @@ async def open_vlm_displays(
             # we do this internally ourselves since
             # the curve item internals are pretty convoluted.
             style='step',
+        )
+        ohlc_chart.view.enable_auto_yrange(
+            src_vb=chart.view,
         )
 
         # force 0 to always be in view


### PR DESCRIPTION
### Overlayed real-time charting rework to enable multi flow-graphics in a single view stack:
Meant to be a replacement for https://github.com/pyqtgraph/pyqtgraph/pull/2162 which itself was a replacement for https://github.com/pyqtgraph/pyqtgraph/pull/1359.

This is an initial `ViewBox` broadcasting subsystem rework to prep for overlayed real-time multi-broker-symbol charting.

---
#### TODOs:
- [x] rework `PlotItemOverlay` to avoid `Signal`/slot muckery and drop dependence on monkey-patching/re-connecting `Signal`s and the use of "relay" signal/slots
  - uses a single method override on the `Qt` event-source-object/widget and instead uses a python loop to broadcast to all subscriber/overlay (`ViewBox`s) objects.

---
#### Follow up with `pyqtgraph` upstream:
See #416