### PR TITLE
Kraken pair updates

### DIFF
--- a/piker/brokers/kraken/feed.py
+++ b/piker/brokers/kraken/feed.py
@@ -85,6 +85,7 @@ class Pair(Struct):
     margin_call: str  # margin call level
     margin_stop: str  # stop-out/liquidation margin level
     ordermin: float  # minimum order volume for pair
+    tick_size: float # min price step size
 
 
 class OHLC(Struct):

--- a/piker/brokers/kraken/feed.py
+++ b/piker/brokers/kraken/feed.py
@@ -271,8 +271,12 @@ async def open_history_client(
         ]:
 
             nonlocal queries
-            if queries > 0:
-                raise DataUnavailable
+            if (
+                queries > 0
+                or timeframe != 60
+            ):
+                raise DataUnavailable(
+                    'Only a single query for 1m bars supported')
 
             count = 0
             while count <= 3:


### PR DESCRIPTION
Very simple update adding `Pair.tick_size: float` and appropriate raising of `DataUnavailable` in the history loading endpoint to avoid loading 1m data in the 1s ohlc chart.