### PR TITLE
HOTFIX: Fix `_main()` arg back to `sym: str`

### DIFF
--- a/piker/ui/cli.py
+++ b/piker/ui/cli.py
@@ -174,7 +174,7 @@ def chart(
 
 
     _main(
-        syms=symbols,
+        sym=symbols[0],
         brokernames=brokernames,
         piker_loglevel=pikerloglevel,
         tractor_kwargs={


### PR DESCRIPTION
This slipped in early from #414 before merge and was likely due to cherry-picking from #417.