### PR TITLE
Cz post ftx

### DIFF
--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -460,11 +460,19 @@ async def stream_quotes(
             syminfo = Pair(**d)  # validation
 
             si = sym_infos[sym] = syminfo.to_dict()
+            filters = {}
+            for entry in syminfo.filters:
+                ftype = entry.pop('filterType')
+                filters[ftype] = entry
 
             # XXX: after manually inspecting the response format we
             # just directly pick out the info we need
-            si['price_tick_size'] = float(syminfo.filters[0]['tickSize'])
-            si['lot_tick_size'] = float(syminfo.filters[2]['stepSize'])
+            si['price_tick_size'] = float(
+                filters['PRICE_FILTER']['tickSize']
+            )
+            si['lot_tick_size'] = float(
+                filters['LOT_SIZE']['stepSize']
+            )
             si['asset_type'] = 'crypto'
 
         symbol = symbols[0]

--- a/piker/data/_web_bs.py
+++ b/piker/data/_web_bs.py
@@ -26,6 +26,7 @@ import json
 
 import trio
 import trio_websocket
+from  wsproto.utilities import LocalProtocolError
 from trio_websocket._impl import (
     ConnectionClosed,
     DisconnectionTimeout,
@@ -51,6 +52,7 @@ class NoBsWs:
         ConnectionRejected,
         HandshakeError,
         ConnectionTimeout,
+        LocalProtocolError,
     )
 
     def __init__(


### PR DESCRIPTION
Tired of "moar binance fixes" PR names, so went with a historical context instead 😉 

2 fixes:
- symbol info "filters" pre-parse to **not** rely on order and instead build a table of meta data we may need to pass to the data feed layer
  - in this case the tick and step sizes are needed to tell charting and order mode controls a  y-axis increment precision 
- handle ping-pong related ws state errors by simply resetting the connection (an issue that is infrequent but does exhibit on long overnight runs with binance feeds)

 