### PR TITLE
Dark clearing repairs

### DIFF
--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -173,6 +173,7 @@ async def clear_dark_triggers(
     # TODO:
     # - numba all this!
     # - this stream may eventually contain multiple symbols
+    quote_stream._raise_on_lag = False
     async for quotes in quote_stream:
         # start = time.time()
         for sym, quote in quotes.items():

--- a/piker/clearing/_ems.py
+++ b/piker/clearing/_ems.py
@@ -46,6 +46,7 @@ from ..data._normalize import iterticks
 from ..data._source import (
     unpack_fqsn,
     mk_fqsn,
+    float_digits,
 )
 from ..data.feed import (
     Feed,
@@ -1249,6 +1250,7 @@ async def process_client_order_cmds(
 
                 spread_slap: float = 5
                 min_tick = flume.symbol.tick_size
+                min_tick_digits = float_digits(min_tick)
 
                 if action == 'buy':
                     tickfilter = ('ask', 'last', 'trade')
@@ -1257,12 +1259,18 @@ async def process_client_order_cmds(
                     # TODO: we probably need to scale this based
                     # on some near term historical spread
                     # measure?
-                    abs_diff_away = spread_slap * min_tick
+                    abs_diff_away = round(
+                        spread_slap * min_tick,
+                        ndigits=min_tick_digits,
+                    )
 
                 elif action == 'sell':
                     tickfilter = ('bid', 'last', 'trade')
                     percent_away = -0.005
-                    abs_diff_away = -spread_slap * min_tick
+                    abs_diff_away = round(
+                        -spread_slap * min_tick,
+                        ndigits=min_tick_digits,
+                    )
 
                 else:  # alert
                     tickfilter = ('trade', 'utrade', 'last')


### PR DESCRIPTION
Includes some substantial fixes to ensure dark triggered orders work as well as adds some resilience to the dark clearing loop via new support for lag ignores in tractor, namely:
- https://github.com/goodboy/tractor/pull/343 adds improved bcast support with a new `._raise_on_lag` flag that can be used to avoid `Lagged` errors by slow tasks: https://github.com/goodboy/tractor/pull/343/files#diff-3545aec32a303122be541890ed73ee3569f9c8f437d1daebd665ff455ce129eaR174
- **NOTE**: this PR landing requires the above dev branch in `tractor`

---
Details of each improvement:
- 35b097469b8e4921f55785c90db522f1e8435878 fixes an issue where we could have dark triggered live submissions be rejected by the backend because the pricing / tick level precision was too high; now we always `round()` to the min tick digits reported by the symbol's info before live order request.
- 7ef81113813339556e58b75d2e7e06b09805260e adds clears table `datetime` sorted iteration in the `.pp.py` apis which is handy for position processing in general.
- 51f4afbd88ddbca2bb18630dab670fefc8e402c1 sets the above mentioned `tractor.trionics.BroadcastReceiver._raise_on_lag: bool` flag to avoid the dark clearing loop ever crashing due to latency.