### PR TITLE
Axis sticky api, `PlotItem` is the new "chart"

### DIFF
--- a/piker/ui/_app.py
+++ b/piker/ui/_app.py
@@ -118,17 +118,10 @@ async def _async_main(
         # godwidget.hbox.addWidget(search)
         godwidget.search = search
 
-        symbols: list[str] = []
-
-        for sym in syms:
-            symbol, _, provider = sym.rpartition('.')
-            symbols.append(symbol)
-
         # this internally starts a ``display_symbol_data()`` task above
         order_mode_ready = await godwidget.load_symbols(
-            provider,
-            symbols,
-            loglevel
+            fqsns=syms,
+            loglevel=loglevel,
         )
 
         # spin up a search engine for the local cached symbol set

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -18,6 +18,7 @@
 Chart axes graphics and behavior.
 
 """
+from __future__ import annotations
 from functools import lru_cache
 from typing import Optional, Callable
 from math import floor
@@ -27,6 +28,7 @@ import pyqtgraph as pg
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import QPointF
 
+from . import _pg_overrides as pgo
 from ..data._source import float_digits
 from ._label import Label
 from ._style import DpiAwareFont, hcolor, _font
@@ -46,7 +48,7 @@ class Axis(pg.AxisItem):
     '''
     def __init__(
         self,
-        linkedsplits,
+        plotitem: pgo.PlotItem,
         typical_max_str: str = '100 000.000',
         text_color: str = 'bracket',
         lru_cache_tick_strings: bool = True,
@@ -61,27 +63,32 @@ class Axis(pg.AxisItem):
         # XXX: pretty sure this makes things slower
         # self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
 
-        self.linkedsplits = linkedsplits
+        self.pi = plotitem
         self._dpi_font = _font
 
         self.setTickFont(_font.font)
         font_size = self._dpi_font.font.pixelSize()
 
+        style_conf = {
+            'textFillLimits': [(0, 0.5)],
+            'tickFont': self._dpi_font.font,
+
+        }
+        text_offset = None
         if self.orientation in ('bottom',):
             text_offset = floor(0.25 * font_size)
 
         elif self.orientation in ('left', 'right'):
             text_offset = floor(font_size / 2)
 
-        self.setStyle(**{
-            'textFillLimits': [(0, 0.5)],
-            'tickFont': self._dpi_font.font,
+        if text_offset:
+            style_conf.update({
+                # offset of text *away from* axis line in px
+                # use approx. half the font pixel size (height)
+                'tickTextOffset': text_offset,
+            })
 
-            # offset of text *away from* axis line in px
-            # use approx. half the font pixel size (height)
-            'tickTextOffset': text_offset,
-        })
-
+        self.setStyle(**style_conf)
         self.setTickFont(_font.font)
 
         # NOTE: this is for surrounding "border"
@@ -101,6 +108,9 @@ class Axis(pg.AxisItem):
             self.tickStrings = lru_cache(
                 maxsize=2**20
             )(self.tickStrings)
+
+        # axis "sticky" labels
+        self._stickies: dict[str, YAxisLabel] = {}
 
     # NOTE: only overriden to cast tick values entries into tuples
     # for use with the lru caching.
@@ -138,6 +148,40 @@ class Axis(pg.AxisItem):
 
     def txt_offsets(self) -> tuple[int, int]:
         return tuple(self.style['tickTextOffset'])
+
+    def add_sticky(
+        self,
+        pi: pgo.PlotItem,
+        name: None | str = None,
+        digits: None | int = 2,
+        # axis_name: str = 'right',
+        bg_color='bracket',
+
+    ) -> YAxisLabel:
+
+        # if the sticky is for our symbol
+        # use the tick size precision for display
+        name = name or pi.name
+        digits = digits or 2
+
+        # TODO: ``._ysticks`` should really be an attr on each
+        # ``PlotItem`` no instead of the (containing because of
+        # overlays) widget?
+
+        # add y-axis "last" value label
+        sticky = self._stickies[name] = YAxisLabel(
+            pi=pi,
+            parent=self,
+            # TODO: pass this from symbol data
+            digits=digits,
+            opacity=1,
+            bg_color=bg_color,
+        )
+
+        pi.sigRangeChanged.connect(sticky.update_on_resize)
+        # pi.addItem(sticky)
+        # pi.addItem(last)
+        return sticky
 
 
 class PriceAxis(Axis):
@@ -255,7 +299,9 @@ class DynamicDateAxis(Axis):
 
     ) -> list[str]:
 
-        chart = self.linkedsplits.chart
+        # XX: ARGGGGG AG:LKSKDJF:LKJSDFD
+        chart = self.pi.chart_widget
+
         flow = chart._flows[chart.name]
         shm = flow.shm
         bars = shm.array
@@ -533,16 +579,15 @@ class YAxisLabel(AxisLabel):
 
     def __init__(
         self,
-        chart,
+        pi: pgo.PlotItem,
         *args,
         **kwargs
     ) -> None:
 
         super().__init__(*args, **kwargs)
 
-        self._chart = chart
-
-        chart.sigRangeChanged.connect(self.update_on_resize)
+        self._pi = pi
+        pi.sigRangeChanged.connect(self.update_on_resize)
 
         self._last_datum = (None, None)
 
@@ -612,7 +657,7 @@ class YAxisLabel(AxisLabel):
             self._last_datum = (index, value)
 
         self.update_label(
-            self._chart.mapFromView(QPointF(index, value)),
+            self._pi.mapFromView(QPointF(index, value)),
             value
         )
 

--- a/piker/ui/_axes.py
+++ b/piker/ui/_axes.py
@@ -522,7 +522,7 @@ class XAxisLabel(AxisLabel):
 
 
 class YAxisLabel(AxisLabel):
-    _y_margin = 4
+    _y_margin: int = 4
 
     text_flags = (
         QtCore.Qt.AlignLeft
@@ -546,6 +546,7 @@ class YAxisLabel(AxisLabel):
 
         self._last_datum = (None, None)
 
+        self.x_offset = 0
         # pull text offset from axis from parent axis
         if getattr(self._parent, 'txt_offsets', False):
             self.x_offset, y_offset = self._parent.txt_offsets()
@@ -564,7 +565,8 @@ class YAxisLabel(AxisLabel):
         value: float,  # data for text
 
         # on odd dimension and/or adds nice black line
-        x_offset: Optional[int] = None
+        x_offset: int = 0,
+
     ) -> None:
 
         # this is read inside ``.paint()``

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -485,7 +485,6 @@ class LinkedSplits(QWidget):
         if ds:
             return _display.graphics_update_cycle(
                 ds,
-                ds.quotes,
                 **kwargs,
             )
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -45,7 +45,6 @@ import trio
 from ._axes import (
     DynamicDateAxis,
     PriceAxis,
-    YAxisLabel,
 )
 from ._cursor import (
     Cursor,
@@ -168,18 +167,18 @@ class GodWidget(QWidget):
     #     self.strategy_box = StrategyBoxWidget(self)
     #     self.toolbar_layout.addWidget(self.strategy_box)
 
-    def set_chart_symbol(
+    def set_chart_symbols(
         self,
-        symbol_key: str,  # of form <fqsn>.<providername>
+        group_key: tuple[str],  # of form <fqsn>.<providername>
         all_linked: tuple[LinkedSplits, LinkedSplits],  # type: ignore
 
     ) -> None:
         # re-sort org cache symbol list in LIFO order
         cache = self._chart_cache
-        cache.pop(symbol_key, None)
-        cache[symbol_key] = all_linked
+        cache.pop(group_key, None)
+        cache[group_key] = all_linked
 
-    def get_chart_symbol(
+    def get_chart_symbols(
         self,
         symbol_key: str,
 
@@ -188,8 +187,7 @@ class GodWidget(QWidget):
 
     async def load_symbols(
         self,
-        providername: str,
-        symbol_keys: list[str],
+        fqsns: list[str],
         loglevel: str,
         reset: bool = False,
 
@@ -200,20 +198,11 @@ class GodWidget(QWidget):
         Expects a ``numpy`` structured array containing all the ohlcv fields.
 
         '''
-        fqsns: list[str] = []
-
-        # our symbol key style is always lower case
-        for key in list(map(str.lower, symbol_keys)):
-
-            # fully qualified symbol name (SNS i guess is what we're making?)
-            fqsn = '.'.join([key, providername])
-            fqsns.append(fqsn)
-
         # NOTE: for now we use the first symbol in the set as the "key"
         # for the overlay of feeds on the chart.
-        group_key = fqsns[0]
+        group_key: tuple[str] = tuple(fqsns)
 
-        all_linked = self.get_chart_symbol(group_key)
+        all_linked = self.get_chart_symbols(group_key)
         order_mode_started = trio.Event()
 
         if not self.vbox.isEmpty():
@@ -245,7 +234,6 @@ class GodWidget(QWidget):
             self._root_n.start_soon(
                 display_symbol_data,
                 self,
-                providername,
                 fqsns,
                 loglevel,
                 order_mode_started,
@@ -253,8 +241,8 @@ class GodWidget(QWidget):
 
             # self.vbox.addWidget(hist_charts)
             self.vbox.addWidget(rt_charts)
-            self.set_chart_symbol(
-                fqsn,
+            self.set_chart_symbols(
+                group_key,
                 (hist_charts, rt_charts),
             )
 
@@ -568,12 +556,10 @@ class LinkedSplits(QWidget):
         # be no distinction since we will have multiple symbols per
         # view as part of "aggregate feeds".
         self.chart = self.add_plot(
-
-            name=symbol.key,
+            name=symbol.fqsn,
             shm=shm,
             style=style,
             _is_main=True,
-
             sidepane=sidepane,
         )
         # add crosshair graphic
@@ -615,12 +601,13 @@ class LinkedSplits(QWidget):
         # TODO: we gotta possibly assign this back
         # to the last subplot on removal of some last subplot
         xaxis = DynamicDateAxis(
+            None,
             orientation='bottom',
             linkedsplits=self
         )
         axes = {
-            'right': PriceAxis(linkedsplits=self, orientation='right'),
-            'left': PriceAxis(linkedsplits=self, orientation='left'),
+            'right': PriceAxis(None, orientation='right'),
+            'left': PriceAxis(None, orientation='left'),
             'bottom': xaxis,
         }
 
@@ -645,6 +632,11 @@ class LinkedSplits(QWidget):
             axisItems=axes,
             **cpw_kwargs,
         )
+        # TODO: wow i can't believe how confusing garbage all this axes
+        # stuff iss..
+        for axis in axes.values():
+            axis.pi = cpw.plotItem
+
         cpw.hideAxis('left')
         cpw.hideAxis('bottom')
 
@@ -860,7 +852,12 @@ class ChartPlotWidget(pg.PlotWidget):
         # source of our custom interactions
         self.cv = cv = self.mk_vb(name)
 
-        pi = pgo.PlotItem(viewBox=cv, **kwargs)
+        pi = pgo.PlotItem(
+            viewBox=cv,
+            name=name,
+            **kwargs,
+        )
+        pi.chart_widget = self
         super().__init__(
             background=hcolor(view_color),
             viewBox=cv,
@@ -913,18 +910,20 @@ class ChartPlotWidget(pg.PlotWidget):
         self._on_screen: bool = False
 
     def resume_all_feeds(self):
-        try:
-            for feed in self._feeds.values():
-                for flume in feed.flumes.values():
-                    self.linked.godwidget._root_n.start_soon(feed.resume)
-        except RuntimeError:
-            # TODO: cancel the qtractor runtime here?
-            raise
+        ...
+        # try:
+        #     for feed in self._feeds.values():
+        #         for flume in feed.flumes.values():
+        #             self.linked.godwidget._root_n.start_soon(flume.resume)
+        # except RuntimeError:
+        #     # TODO: cancel the qtractor runtime here?
+        #     raise
 
     def pause_all_feeds(self):
-        for feed in self._feeds.values():
-            for flume in feed.flumes.values():
-                self.linked.godwidget._root_n.start_soon(feed.pause)
+        ...
+        # for feed in self._feeds.values():
+        #     for flume in feed.flumes.values():
+        #         self.linked.godwidget._root_n.start_soon(flume.pause)
 
     @property
     def view(self) -> ChartView:
@@ -1116,43 +1115,6 @@ class ChartPlotWidget(pg.PlotWidget):
             padding=0,
         )
 
-    def draw_ohlc(
-        self,
-        name: str,
-        shm: ShmArray,
-
-        array_key: Optional[str] = None,
-
-    ) -> (pg.GraphicsObject, str):
-        '''
-        Draw OHLC datums to chart.
-
-        '''
-        graphics = BarItems(
-            self.linked,
-            self.plotItem,
-            pen_color=self.pen_color,
-            name=name,
-        )
-
-        # adds all bar/candle graphics objects for each data point in
-        # the np array buffer to be drawn on next render cycle
-        self.plotItem.addItem(graphics)
-
-        data_key = array_key or name
-
-        self._flows[data_key] = Flow(
-            name=name,
-            plot=self.plotItem,
-            _shm=shm,
-            is_ohlc=True,
-            graphics=graphics,
-        )
-
-        self._add_sticky(name, bg_color='davies')
-
-        return graphics, data_key
-
     def overlay_plotitem(
         self,
         name: str,
@@ -1172,8 +1134,8 @@ class ChartPlotWidget(pg.PlotWidget):
             raise ValueError(f'``axis_side``` must be in {allowed_sides}')
 
         yaxis = PriceAxis(
+            plotitem=None,
             orientation=axis_side,
-            linkedsplits=self.linked,
             **axis_kwargs,
         )
 
@@ -1188,6 +1150,8 @@ class ChartPlotWidget(pg.PlotWidget):
             },
             default_axes=[],
         )
+        yaxis.pi = pi
+        pi.chart_widget = self
         pi.hideButtons()
 
         # compose this new plot's graphics with the current chart's
@@ -1231,43 +1195,60 @@ class ChartPlotWidget(pg.PlotWidget):
         add_label: bool = True,
         pi: Optional[pg.PlotItem] = None,
         step_mode: bool = False,
+        is_ohlc: bool = False,
+        add_sticky: None | str = 'right',
 
-        **pdi_kwargs,
+        **graphics_kwargs,
 
-    ) -> (pg.PlotDataItem, str):
+    ) -> tuple[
+        pg.GraphicsObject,
+        str,
+    ]:
         '''
         Draw a "curve" (line plot graphics) for the provided data in
         the input shm array ``shm``.
 
         '''
         color = color or self.pen_color or 'default_light'
-        pdi_kwargs.update({
-            'color': color
-        })
+        # graphics_kwargs.update({
+        #     'color': color
+        # })
 
         data_key = array_key or name
 
-        curve_type = {
-            None: Curve,
-            'step': StepCurve,
-            # TODO:
-            # 'bars': BarsItems
-        }['step' if step_mode else None]
-
-        curve = curve_type(
-            name=name,
-            **pdi_kwargs,
-        )
-
         pi = pi or self.plotItem
+
+        if is_ohlc:
+            graphics = BarItems(
+                linked=self.linked,
+                plotitem=pi,
+                # pen_color=self.pen_color,
+                color=color,
+                name=name,
+                **graphics_kwargs,
+            )
+
+        else:
+            curve_type = {
+                None: Curve,
+                'step': StepCurve,
+                # TODO:
+                # 'bars': BarsItems
+            }['step' if step_mode else None]
+
+            graphics = curve_type(
+                name=name,
+                color=color,
+                **graphics_kwargs,
+            )
 
         self._flows[data_key] = Flow(
             name=name,
             plot=pi,
             _shm=shm,
-            is_ohlc=False,
+            is_ohlc=is_ohlc,
             # register curve graphics with this flow
-            graphics=curve,
+            graphics=graphics,
         )
 
         # TODO: this probably needs its own method?
@@ -1278,12 +1259,41 @@ class ChartPlotWidget(pg.PlotWidget):
                             f'{overlay} must be from `.plotitem_overlay()`'
                         )
                 pi = overlay
-        else:
-            # anchor_at = ('top', 'left')
 
-            # TODO: something instead of stickies for overlays
-            # (we need something that avoids clutter on x-axis).
-            self._add_sticky(name, bg_color=color)
+        if add_sticky:
+            axis = pi.getAxis(add_sticky)
+            if pi.name not in axis._stickies:
+
+                if pi is not self.plotItem:
+                    overlay = self.pi_overlay
+                    assert pi in overlay.overlays
+                    overlay_axis = overlay.get_axis(
+                        pi,
+                        add_sticky,
+                    )
+                    assert overlay_axis is axis
+
+                # TODO: UGH! just make this not here! we should
+                # be making the sticky from code which has access
+                # to the ``Symbol`` instance..
+
+                # if the sticky is for our symbol
+                # use the tick size precision for display
+                name = name or pi.name
+                sym = self.linked.symbol
+                digits = None
+                if name == sym.key:
+                    digits = sym.tick_size_digits
+
+                # anchor_at = ('top', 'left')
+
+                # TODO: something instead of stickies for overlays
+                # (we need something that avoids clutter on x-axis).
+                axis.add_sticky(
+                    pi=pi,
+                    bg_color=color,
+                    digits=digits,
+                )
 
         # NOTE: this is more or less the RENDER call that tells Qt to
         # start showing the generated graphics-curves. This is kind of
@@ -1294,38 +1304,30 @@ class ChartPlotWidget(pg.PlotWidget):
         # the next render cycle; just note a lot of the real-time
         # updates are implicit and require a bit of digging to
         # understand.
-        pi.addItem(curve)
+        pi.addItem(graphics)
 
-        return curve, data_key
+        return graphics, data_key
 
-    # TODO: make this a ctx mngr
-    def _add_sticky(
+    def draw_ohlc(
         self,
-
         name: str,
-        bg_color='bracket',
+        shm: ShmArray,
 
-    ) -> YAxisLabel:
+        array_key: Optional[str] = None,
+        **draw_curve_kwargs,
 
-        # if the sticky is for our symbol
-        # use the tick size precision for display
-        sym = self.linked.symbol
-        if name == sym.key:
-            digits = sym.tick_size_digits
-        else:
-            digits = 2
+    ) -> (pg.GraphicsObject, str):
+        '''
+        Draw OHLC datums to chart.
 
-        # add y-axis "last" value label
-        last = self._ysticks[name] = YAxisLabel(
-            chart=self,
-            # parent=self.getAxis('right'),
-            parent=self.pi_overlay.get_axis(self.plotItem, 'right'),
-            # TODO: pass this from symbol data
-            digits=digits,
-            opacity=1,
-            bg_color=bg_color,
+        '''
+        return self.draw_curve(
+            name=name,
+            shm=shm,
+            array_key=array_key,
+            is_ohlc=True,
+            **draw_curve_kwargs,
         )
-        return last
 
     def update_graphics_from_flow(
         self,

--- a/piker/ui/_cursor.py
+++ b/piker/ui/_cursor.py
@@ -418,7 +418,7 @@ class Cursor(pg.GraphicsObject):
         hl.hide()
 
         yl = YAxisLabel(
-            chart=plot,
+            pi=plot.plotItem,
             # parent=plot.getAxis('right'),
             parent=plot.pi_overlay.get_axis(plot.plotItem, 'right'),
             digits=digits or self.digits,

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -110,7 +110,8 @@ def update_fsp_chart(
     # sub-charts reference it under different 'named charts'.
 
     # read from last calculated value and update any label
-    last_val_sticky = chart._ysticks.get(graphics_name)
+    last_val_sticky = chart.plotItem.getAxis(
+        'right')._stickies.get(chart.name)
     if last_val_sticky:
         last = last_row[array_key]
         last_val_sticky.update_from_data(-1, last)
@@ -685,7 +686,8 @@ async def open_vlm_displays(
         assert chart.name != linked.chart.name
 
         # sticky only on sub-charts atm
-        last_val_sticky = chart._ysticks[chart.name]
+        last_val_sticky = chart.plotItem.getAxis(
+            'right')._stickies.get(chart.name)
 
         # read from last calculated value
         value = shm.array['volume'][-1]

--- a/piker/ui/_l1.py
+++ b/piker/ui/_l1.py
@@ -26,6 +26,7 @@ from PyQt5.QtCore import QPointF
 
 from ._axes import YAxisLabel
 from ._style import hcolor
+from ._pg_overrides import PlotItem
 
 
 class LevelLabel(YAxisLabel):
@@ -132,7 +133,7 @@ class LevelLabel(YAxisLabel):
         level = self.fields['level']
 
         # map "level" to local coords
-        abs_xy = self._chart.mapFromView(QPointF(0, level))
+        abs_xy = self._pi.mapFromView(QPointF(0, level))
 
         self.update_label(
             abs_xy,
@@ -149,7 +150,7 @@ class LevelLabel(YAxisLabel):
         h, w = self.set_label_str(fields)
 
         if self._adjust_to_l1:
-            self._x_offset = self._chart._max_l1_line_len
+            self._x_offset = self._pi.chart_widget._max_l1_line_len
 
         self.setPos(QPointF(
             self._h_shift * (w + self._x_offset),
@@ -236,10 +237,10 @@ class L1Label(LevelLabel):
         # Set a global "max L1 label length" so we can
         # look it up on order lines and adjust their
         # labels not to overlap with it.
-        chart = self._chart
+        chart = self._pi.chart_widget
         chart._max_l1_line_len: float = max(
             chart._max_l1_line_len,
-            w
+            w,
         )
 
         return h, w
@@ -251,17 +252,17 @@ class L1Labels:
     """
     def __init__(
         self,
-        chart: 'ChartPlotWidget',  # noqa
+        plotitem: PlotItem,
         digits: int = 2,
         size_digits: int = 3,
         font_size: str = 'small',
     ) -> None:
 
-        self.chart = chart
+        chart = self.chart = plotitem.chart_widget
 
-        raxis = chart.getAxis('right')
+        raxis = plotitem.getAxis('right')
         kwargs = {
-            'chart': chart,
+            'chart': plotitem,
             'parent': raxis,
 
             'opacity': 1,

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -98,7 +98,7 @@ class BarItems(pg.GraphicsObject):
         self,
         linked: LinkedSplits,
         plotitem: 'pg.PlotItem',  # noqa
-        pen_color: str = 'bracket',
+        color: str = 'bracket',
         last_bar_color: str = 'bracket',
 
         name: Optional[str] = None,
@@ -108,8 +108,8 @@ class BarItems(pg.GraphicsObject):
         self.linked = linked
         # XXX: for the mega-lulz increasing width here increases draw
         # latency...  so probably don't do it until we figure that out.
-        self._color = pen_color
-        self.bars_pen = pg.mkPen(hcolor(pen_color), width=1)
+        self._color = color
+        self.bars_pen = pg.mkPen(hcolor(color), width=1)
         self.last_bar_pen = pg.mkPen(hcolor(last_bar_color), width=2)
         self._name = name
 

--- a/piker/ui/_pg_overrides.py
+++ b/piker/ui/_pg_overrides.py
@@ -26,6 +26,8 @@ from typing import Optional
 
 import pyqtgraph as pg
 
+from ._axes import Axis
+
 
 def invertQTransform(tr):
     """Return a QTransform that is the inverse of *tr*.
@@ -62,6 +64,20 @@ class PlotItem(pg.PlotItem):
     Overrides for the core plot object mostly pertaining to overlayed
     multi-view management as it relates to multi-axis managment.
 
+    This object is the combination of a ``ViewBox`` and multiple
+    ``AxisItem``s and so far we've added additional functionality and
+    APIs for:
+    - removal of axes
+
+    ---
+
+    From ``pyqtgraph`` super type docs:
+    - Manage placement of ViewBox, AxisItems, and LabelItems
+    - Create and manage a list of PlotDataItems displayed inside the
+      ViewBox
+    - Implement a context menu with commonly used display and analysis
+      options
+
     '''
     def __init__(
         self,
@@ -86,6 +102,8 @@ class PlotItem(pg.PlotItem):
             enableMenu=enableMenu,
             kargs=kargs,
         )
+        self.name = name
+        self.chart_widget = None
         # self.setAxisItems(
         #     axisItems,
         #     default_axes=default_axes,
@@ -209,7 +227,12 @@ class PlotItem(pg.PlotItem):
                 # adding this is without it there's some weird
                 # ``ViewBox`` geometry bug.. where a gap for the
                 # 'bottom' axis is somehow left in?
-                axis = pg.AxisItem(orientation=name, parent=self)
+                # axis = pg.AxisItem(orientation=name, parent=self)
+                axis = Axis(
+                    self,
+                    orientation=name,
+                    parent=self,
+                )
 
             axis.linkToView(self.vb)
 


### PR DESCRIPTION
Prepares for further overlay and charting API reworking delivered in support of #420 by moving y-axis sticky label API to the `Axis` type and passing around our `PlotItem` override to the internals of our charting APIs allowing us to focus internal code round the `PlotItem` lower-level interface instead of our `ChartPlotWidget` widget..

This is mostly a preparatory set of internal hanges that shouldn't affect anything UI or public API related:

- use `PlotItem` more directly through out the widget methods
- access y-label stickies from the `Axis` tables
- adjust the search-results UI machinery to prepare for multi-symbol handling such that (eventually) we can pass a group of symbols for the overlaid set from CLI/API or through dynamic selection.


  