### PR TITLE
Multi symbol input (support)

### DIFF
--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -1037,12 +1037,11 @@ async def allocate_persistent_feed(
 
     flume = Flume(
         symbol=symbol,
-        _hist_shm_token=hist_shm.token,
-        _rt_shm_token=rt_shm.token,
         first_quote=first_quote,
+        _rt_shm_token=rt_shm.token,
+        _hist_shm_token=hist_shm.token,
         izero_hist=izero_hist,
         izero_rt=izero_rt,
-        # throttle_rate=tick_throttle,
     )
 
     # for ambiguous names we simply apply the retreived

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -896,7 +896,7 @@ class ChartPlotWidget(pg.PlotWidget):
         # registry of overlay curve names
         self._flows: dict[str, Flow] = {}
 
-        self._feeds: dict[Symbol, Feed] = {}
+        self.feed: Feed | None = None
 
         self._labels = {}  # registry of underlying graphics
         self._ysticks = {}  # registry of underlying graphics
@@ -917,20 +917,18 @@ class ChartPlotWidget(pg.PlotWidget):
         self._on_screen: bool = False
 
     def resume_all_feeds(self):
-        ...
-        # try:
-        #     for feed in self._feeds.values():
-        #         for flume in feed.flumes.values():
-        #             self.linked.godwidget._root_n.start_soon(flume.resume)
-        # except RuntimeError:
-        #     # TODO: cancel the qtractor runtime here?
-        #     raise
+        feed = self.feed
+        if feed:
+            try:
+                self.linked.godwidget._root_n.start_soon(feed.resume)
+            except RuntimeError:
+                # TODO: cancel the qtractor runtime here?
+                raise
 
     def pause_all_feeds(self):
-        ...
-        # for feed in self._feeds.values():
-        #     for flume in feed.flumes.values():
-        #         self.linked.godwidget._root_n.start_soon(flume.pause)
+        feed = self.feed
+        if feed:
+            self.linked.godwidget._root_n.start_soon(feed.pause)
 
     @property
     def view(self) -> ChartView:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1224,7 +1224,6 @@ class ChartPlotWidget(pg.PlotWidget):
             graphics = BarItems(
                 linked=self.linked,
                 plotitem=pi,
-                # pen_color=self.pen_color,
                 color=color,
                 name=name,
                 **graphics_kwargs,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -580,9 +580,8 @@ def graphics_update_cycle(
         profiler('view incremented')
 
     ticks_frame = quote.get('ticks', ())
-
-    frames_by_type: dict[str, dict] = {}
-    lasts = {}
+    # frames_by_type: dict[str, dict] = {}
+    # lasts = {}
 
     # build tick-type "frames" of tick sequences since
     # likely the tick arrival rate is higher then our
@@ -616,22 +615,22 @@ def graphics_update_cycle(
         log.debug('Skipping prepend graphics cycle: frame not in view')
         return
 
-    for tick in ticks_frame:
-        price = tick.get('price')
-        ticktype = tick.get('type')
+    # for tick in ticks_frame:
+    #     price = tick.get('price')
+    #     ticktype = tick.get('type')
 
-        # if ticktype == 'n/a' or price == -1:
-        #     # okkk..
-        #     continue
+    #     # if ticktype == 'n/a' or price == -1:
+    #     #     # okkk..
+    #     #     continue
 
-        # keys are entered in olded-event-inserted-first order
-        # since we iterate ``ticks_frame`` in standard order
-        # above. in other words the order of the keys is the order
-        # of tick events by type from the provider feed.
-        frames_by_type.setdefault(ticktype, []).append(tick)
+    #     # keys are entered in olded-event-inserted-first order
+    #     # since we iterate ``ticks_frame`` in standard order
+    #     # above. in other words the order of the keys is the order
+    #     # of tick events by type from the provider feed.
+    #     frames_by_type.setdefault(ticktype, []).append(tick)
 
-        # overwrites so the last tick per type is the entry
-        lasts[ticktype] = tick
+    #     # overwrites so the last tick per type is the entry
+    #     lasts[ticktype] = tick
 
     # from pprint import pformat
     # frame_counts = {
@@ -675,11 +674,18 @@ def graphics_update_cycle(
     # NOTE: we always update the "last" datum
     # since the current range should at least be updated
     # to it's max/min on the last pixel.
+    typs: set[str] = set()
 
-    for typ, tick in lasts.items():
-
+    # for typ, tick in lasts.items():
+    for tick in ticks_frame:
+        typ = tick.get('type')
         price = tick.get('price')
         size = tick.get('size')
+
+        if typ in typs:
+            continue
+
+        typs.add(typ)
 
         # compute max and min prices (including bid/ask) from
         # tick frames to determine the y-range for chart

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -625,14 +625,14 @@ def graphics_update_cycle(
         chart.update_graphics_from_flow(
             fqsn,
             # chart.name,
-            do_append=do_append,
+            # do_append=do_append,
         )
         main_flow.draw_last(array_key=fqsn)
 
         hist_chart.update_graphics_from_flow(
             fqsn,
             # chart.name,
-            do_append=do_append,
+            # do_append=do_append,
         )
 
     # NOTE: we always update the "last" datum
@@ -882,7 +882,7 @@ def graphics_update_cycle(
                     curve_name,
                     array_key=curve_name,
                     # do_append=uppx < update_uppx,
-                    do_append=do_append,
+                    # do_append=do_append,
                 )
                 # is this even doing anything?
                 # (pretty sure it's the real-time
@@ -1118,7 +1118,10 @@ async def display_symbol_data(
 
         # limit to at least display's FPS
         # avoiding needless Qt-in-guest-mode context switches
-        tick_throttle=round(_quote_throttle_rate/len(fqsns)),
+        tick_throttle=min(
+            round(_quote_throttle_rate/len(fqsns)),
+            22,
+        ),
 
     ) as feed:
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -1191,6 +1191,7 @@ async def display_symbol_data(
         hist_chart = hist_linked.plot_ohlc_main(
             symbol,
             hist_ohlcv,
+            flume,
             # in the case of history chart we explicitly set `False`
             # to avoid internal pane creation.
             # sidepane=False,
@@ -1204,6 +1205,7 @@ async def display_symbol_data(
         rt_chart = rt_linked.plot_ohlc_main(
             symbol,
             ohlcv,
+            flume,
             # in the case of history chart we explicitly set `False`
             # to avoid internal pane creation.
             sidepane=pp_pane,
@@ -1275,9 +1277,10 @@ async def display_symbol_data(
                 hist_pi.hideAxis('left')
                 hist_pi.hideAxis('bottom')
 
-                curve, _ = hist_chart.draw_curve(
-                    name=fqsn,
-                    shm=hist_ohlcv,
+                flow = hist_chart.draw_curve(
+                    fqsn,
+                    hist_ohlcv,
+                    flume,
                     array_key=fqsn,
                     overlay=hist_pi,
                     pi=hist_pi,
@@ -1307,9 +1310,10 @@ async def display_symbol_data(
                 rt_pi.hideAxis('left')
                 rt_pi.hideAxis('bottom')
 
-                curve, _ = rt_chart.draw_curve(
-                    name=fqsn,
-                    shm=ohlcv,
+                flow = rt_chart.draw_curve(
+                    fqsn,
+                    ohlcv,
+                    flume,
                     array_key=fqsn,
                     overlay=rt_pi,
                     pi=rt_pi,

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -99,7 +99,7 @@ class BarItems(pg.GraphicsObject):
         linked: LinkedSplits,
         plotitem: 'pg.PlotItem',  # noqa
         color: str = 'bracket',
-        last_bar_color: str = 'bracket',
+        last_bar_color: str = 'original',
 
         name: Optional[str] = None,
 

--- a/piker/ui/_position.py
+++ b/piker/ui/_position.py
@@ -41,7 +41,11 @@ from ._anchors import (
     pp_tight_and_right,  # wanna keep it straight in the long run
     gpath_pin,
 )
-from ..calc import humanize, pnl, puterize
+from ..calc import (
+    humanize,
+    pnl,
+    puterize,
+)
 from ..clearing._allocate import Allocator
 from ..pp import Position
 from ..data._normalize import iterticks
@@ -105,6 +109,7 @@ async def update_pnl_from_feed(
                 # period = now - last_tick
 
                 for sym, quote in quotes.items():
+                    # print(f'{key} PnL: sym:{sym}')
 
                     # TODO: uggggh we probably want a better state
                     # management then this sincce we want to enable
@@ -112,6 +117,10 @@ async def update_pnl_from_feed(
                     # real-time right?
                     if sym != key:
                         continue
+
+                    # watch out for wrong quote msg-data if you muck
+                    # with backend feed subs code..
+                    # assert sym == quote['fqsn']
 
                     for tick in iterticks(quote, types):
                         # print(f'{1/period} Hz')
@@ -125,14 +134,17 @@ async def update_pnl_from_feed(
 
                         else:
                             # compute and display pnl status
-                            # print(f'formatting PNL {sym}: {quote}')
-                            order_mode.pane.pnl_label.format(
-                                pnl=copysign(1, size) * pnl(
-                                    # live.ppu,
-                                    order_mode.current_pp.live_pp.ppu,
-                                    tick['price'],
-                                ),
-                            )
+                            pnl_val = (
+                                 copysign(1, size)
+                                 *
+                                 pnl(
+                                     # live.ppu,
+                                     order_mode.current_pp.live_pp.ppu,
+                                     tick['price'],
+                                 )
+                             )
+                            # print(f'formatting PNL {sym} => {pnl_val}')
+                            order_mode.pane.pnl_label.format(pnl=pnl_val)
 
                         # last_tick = time.time()
     finally:

--- a/piker/ui/_style.py
+++ b/piker/ui/_style.py
@@ -240,11 +240,11 @@ def hcolor(name: str) -> str:
         'gunmetal': '#91A3B0',
         'battleship': '#848482',
 
+        # default ohlc-bars/curve gray
+        'bracket': '#666666',  # like the logo
+
         # bluish
         'charcoal': '#36454F',
-
-        # default bars
-        'bracket': '#666666',  # like the logo
 
         # work well for filled polygons which want a 'bracket' feel
         # going light to dark

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -88,7 +88,7 @@ class Dialog(Struct):
     # TODO: use ``pydantic.UUID4`` field
     uuid: str
     order: Order
-    symbol: Symbol
+    symbol: str
     lines: list[LevelLine]
     last_status_close: Callable = lambda: None
     msgs: dict[str, dict] = {}
@@ -379,7 +379,7 @@ class OrderMode:
         dialog = Dialog(
             uuid=order.oid,
             order=order,
-            symbol=order.symbol,
+            symbol=order.symbol,  # XXX: always a str?
             lines=lines,
             last_status_close=self.multistatus.open_status(
                 f'submitting {order.exec_mode}-{order.action}',
@@ -964,8 +964,9 @@ async def process_trade_msg(
     oid = msg.oid
     dialog: Dialog = mode.dialogs.get(oid)
 
-    fqsn = dialog.symbol.front_fqsn()
-    flume = mode.feed.flumes[fqsn]
+    if dialog:
+        fqsn = dialog.symbol
+        flume = mode.feed.flumes[fqsn]
 
     match msg:
         case Status(


### PR DESCRIPTION
Again in support of the final product landing in #420...

This is the initial implementation of multiple symbol input support via the `piker chart <symbol> <symbol> ... <symbol>` cli and thus first draft support for multi-feed overlays on a single chart.

There is **much much much** more refinement and fixes coming in the patches leading up to #420 but this gets a more easily reviewable chunk of UI code changes up and a baseline working changeset for overlays onto master.

I won't go into too too much detail but more or less the shortcoming that are improved on later (and will land in future PRs leading to #420) vs. what exists **in this version**, include:
- symbol feeds are not synced in (epoch) time in terms of both historical series alignment (LHS) nor in terms of using the new `samplerd` daemon sample step updates nor the (RHS) "latest datums" alignment.
- L1 labels are still the original style and become very cluttered when you overlay more then 2 fqsns.
- curve drawing performance and thus general latency is fairly low and un-tuned
- curve y-range sorting is done via y-max/min in view **per symbol**, meaning there is **zero credence** given to overlaying curves in a way that makes them (easy to) sensibly compare by eye.