### PR TITLE
Update qt screen info script

### DIFF
--- a/snippets/qt_screen_info.py
+++ b/snippets/qt_screen_info.py
@@ -38,54 +38,41 @@ main_widget = QtWidgets.QWidget()
 window.setCentralWidget(main_widget)
 window.show()
 
+# TODO: move widget through multiple displays and auto-detect the pixel
+# ratio? (probably is gonna require calls to i3ipc on linux)..
 pxr = main_widget.devicePixelRatioF()
 
-# screen_num = app.desktop().screenNumber()
+# TODO: how to detect list of displays from API?
 # screen = app.screens()[screen_num]
 
+
+def ppscreeninfo(screen: 'QScreen') -> None:
+    # screen_num = app.desktop().screenNumber()
+    name = screen.name()
+    size = screen.size()
+    geo = screen.availableGeometry()
+    phydpi = screen.physicalDotsPerInch()
+    logdpi = screen.logicalDotsPerInch()
+    rr = screen.refreshRate()
+
+    print(
+        # f'screen number: {screen_num}\n',
+        f'screen: {name}\n'
+        f'  size: {size}\n'
+        f'  geometry: {geo}\n'
+        f'  logical dpi: {logdpi}\n'
+        f'  devicePixelRationF(): {pxr}\n'
+        f'  physical dpi: {phydpi}\n'
+        f'  refresh rate: {rr}\n'
+    )
+
+    print('-'*50 + '\n')
+
 screen = app.screenAt(main_widget.geometry().center())
-
-name = screen.name()
-size = screen.size()
-geo = screen.availableGeometry()
-phydpi = screen.physicalDotsPerInch()
-logdpi = screen.logicalDotsPerInch()
-rr = screen.refreshRate()
-
-print(
-    # f'screen number: {screen_num}\n',
-    f'screen: {name}\n'
-    f'  size: {size}\n'
-    f'  geometry: {geo}\n'
-    f'  logical dpi: {logdpi}\n'
-    f'  devicePixelRationF(): {pxr}\n'
-    f'  physical dpi: {phydpi}\n'
-    f'  refresh rate: {rr}\n'
-)
-
-print('-'*50 + '\n')
+ppscreeninfo(screen)
 
 screen = app.primaryScreen()
-
-name = screen.name()
-size = screen.size()
-geo = screen.availableGeometry()
-phydpi = screen.physicalDotsPerInch()
-logdpi = screen.logicalDotsPerInch()
-rr = screen.refreshRate()
-
-print(
-    # f'screen number: {screen_num}\n',
-    f'screen: {name}\n'
-    f'  size: {size}\n'
-    f'  geometry: {geo}\n'
-    f'  logical dpi: {logdpi}\n'
-    f'  devicePixelRationF(): {pxr}\n'
-    f'  physical dpi: {phydpi}\n'
-    f'  refresh rate: {rr}\n'
-)
-
-print('-'*50 + '\n')
+ppscreeninfo(screen)
 
 # app-wide font
 font = QtGui.QFont("Hack")

--- a/snippets/qt_screen_info.py
+++ b/snippets/qt_screen_info.py
@@ -16,11 +16,15 @@ DPI and info helper script for display metrics.
 
 from pyqtgraph import (
     QtGui,
-    QtWidgets,
 )
 from PyQt5.QtCore import (
-     Qt,
-     QCoreApplication,
+    Qt,
+    QCoreApplication,
+)
+from PyQt5.QtWidgets import (
+    QWidget,
+    QMainWindow,
+    QApplication,
 )
 
 # Proper high DPI scaling is available in Qt >= 5.6.0. This attibute
@@ -32,9 +36,9 @@ if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
     QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
 
-app = QtWidgets.QApplication([])
-window = QtWidgets.QMainWindow()
-main_widget = QtWidgets.QWidget()
+app = QApplication([])
+window = QMainWindow()
+main_widget = QWidget()
 window.setCentralWidget(main_widget)
 window.show()
 
@@ -46,7 +50,7 @@ pxr = main_widget.devicePixelRatioF()
 # screen = app.screens()[screen_num]
 
 
-def ppscreeninfo(screen: 'QScreen') -> None:
+def ppscreeninfo(screen: QtGui.QScreen) -> None:
     # screen_num = app.desktop().screenNumber()
     name = screen.name()
     size = screen.size()
@@ -67,6 +71,7 @@ def ppscreeninfo(screen: 'QScreen') -> None:
     )
 
     print('-'*50 + '\n')
+
 
 screen = app.screenAt(main_widget.geometry().center())
 ppscreeninfo(screen)

--- a/snippets/qt_screen_info.py
+++ b/snippets/qt_screen_info.py
@@ -1,22 +1,26 @@
 """
-Resource list for mucking with DPIs on multiple screens:
-
-- https://stackoverflow.com/questions/42141354/convert-pixel-size-to-point-size-for-fonts-on-multiple-platforms
-- https://stackoverflow.com/questions/25761556/qt5-font-rendering-different-on-various-platforms/25929628#25929628
-- https://doc.qt.io/qt-5/highdpi.html
-- https://stackoverflow.com/questions/20464814/changing-dpi-scaling-size-of-display-make-qt-applications-font-size-get-rendere
-- https://stackoverflow.com/a/20465247
-- https://doc.qt.io/archives/qt-4.8/qfontmetrics.html#width
-- https://forum.qt.io/topic/54136/how-do-i-get-the-qscreen-my-widget-is-on-qapplication-desktop-screen-returns-a-qwidget-and-qobject_cast-qscreen-returns-null/3
-- https://forum.qt.io/topic/43625/point-sizes-are-they-reliable/4
-- https://stackoverflow.com/questions/16561879/what-is-the-difference-between-logicaldpix-and-physicaldpix-in-qt
-- https://doc.qt.io/qt-5/qguiapplication.html#screenAt
-
+DPI and info helper script for display metrics.
 """
 
-from pyqtgraph import QtGui
+# Resource list for mucking with DPIs on multiple screens:
+# https://stackoverflow.com/questions/42141354/convert-pixel-size-to-point-size-for-fonts-on-multiple-platforms
+# https://stackoverflow.com/questions/25761556/qt5-font-rendering-different-on-various-platforms/25929628#25929628
+# https://doc.qt.io/qt-5/highdpi.html
+# https://stackoverflow.com/questions/20464814/changing-dpi-scaling-size-of-display-make-qt-applications-font-size-get-rendere
+# https://stackoverflow.com/a/20465247
+# https://doc.qt.io/archives/qt-4.8/qfontmetrics.html#width
+# https://forum.qt.io/topic/54136/how-do-i-get-the-qscreen-my-widget-is-on-qapplication-desktop-screen-returns-a-qwidget-and-qobject_cast-qscreen-returns-null/3
+# https://forum.qt.io/topic/43625/point-sizes-are-they-reliable/4
+# https://stackoverflow.com/questions/16561879/what-is-the-difference-between-logicaldpix-and-physicaldpix-in-qt
+# https://doc.qt.io/qt-5/qguiapplication.html#screenAt
+
+from pyqtgraph import (
+    QtGui,
+    QtWidgets,
+)
 from PyQt5.QtCore import (
-     Qt, QCoreApplication
+     Qt,
+     QCoreApplication,
 )
 
 # Proper high DPI scaling is available in Qt >= 5.6.0. This attibute
@@ -28,9 +32,9 @@ if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
     QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
 
-app = QtGui.QApplication([])
-window = QtGui.QMainWindow()
-main_widget = QtGui.QWidget()
+app = QtWidgets.QApplication([])
+window = QtWidgets.QMainWindow()
+main_widget = QtWidgets.QWidget()
 window.setCentralWidget(main_widget)
 window.show()
 
@@ -46,18 +50,20 @@ size = screen.size()
 geo = screen.availableGeometry()
 phydpi = screen.physicalDotsPerInch()
 logdpi = screen.logicalDotsPerInch()
+rr = screen.refreshRate()
 
 print(
     # f'screen number: {screen_num}\n',
-    f'screen name: {name}\n'
-    f'screen size: {size}\n'
-    f'screen geometry: {geo}\n\n'
-    f'devicePixelRationF(): {pxr}\n'
-    f'physical dpi: {phydpi}\n'
-    f'logical dpi: {logdpi}\n'
+    f'screen: {name}\n'
+    f'  size: {size}\n'
+    f'  geometry: {geo}\n'
+    f'  logical dpi: {logdpi}\n'
+    f'  devicePixelRationF(): {pxr}\n'
+    f'  physical dpi: {phydpi}\n'
+    f'  refresh rate: {rr}\n'
 )
 
-print('-'*50)
+print('-'*50 + '\n')
 
 screen = app.primaryScreen()
 
@@ -66,17 +72,20 @@ size = screen.size()
 geo = screen.availableGeometry()
 phydpi = screen.physicalDotsPerInch()
 logdpi = screen.logicalDotsPerInch()
+rr = screen.refreshRate()
 
 print(
     # f'screen number: {screen_num}\n',
-    f'screen name: {name}\n'
-    f'screen size: {size}\n'
-    f'screen geometry: {geo}\n\n'
-    f'devicePixelRationF(): {pxr}\n'
-    f'physical dpi: {phydpi}\n'
-    f'logical dpi: {logdpi}\n'
+    f'screen: {name}\n'
+    f'  size: {size}\n'
+    f'  geometry: {geo}\n'
+    f'  logical dpi: {logdpi}\n'
+    f'  devicePixelRationF(): {pxr}\n'
+    f'  physical dpi: {phydpi}\n'
+    f'  refresh rate: {rr}\n'
 )
 
+print('-'*50 + '\n')
 
 # app-wide font
 font = QtGui.QFont("Hack")


### PR DESCRIPTION
Brings script imports up to date with latest `PyQt5` schema as well as adds a bunch of extra info dumping and formatting for tinkering with further attempts at a generalized DPI sizing subsystem.

---
As per an issue i recently worked through with a noob piker, for systems that aren't quite lo-DPI and still require slight downscaling it would be good to figure out if we can drop the `'lo'` section from the [`.ui._style._font_sizes`](https://github.com/pikers/piker/blob/master/piker/ui/_style.py#L41) table..
