### PR TITLE
Overlays interaction latency tuning

### DIFF
--- a/piker/_daemon.py
+++ b/piker/_daemon.py
@@ -257,7 +257,7 @@ async def open_piker_runtime(
     # and spawn the service tree distributed per that.
     start_method: str = 'trio',
 
-    tractor_kwargs: dict = {},
+    **tractor_kwargs,
 
 ) -> tuple[
     tractor.Actor,

--- a/piker/_profile.py
+++ b/piker/_profile.py
@@ -152,9 +152,14 @@ class Profiler(object):
             # don't do anything
             return cls._disabledProfiler
 
-        # create an actual profiling object
         cls._depth += 1
         obj = super(Profiler, cls).__new__(cls)
+        obj._msgs = []
+
+        # create an actual profiling object
+        if cls._depth < 1:
+            cls._msgs = []
+
         obj._name = msg or func_qualname
         obj._delayed = delayed
         obj._markCount = 0
@@ -174,8 +179,12 @@ class Profiler(object):
 
         self._markCount += 1
         newTime = perf_counter()
+        tot_ms = (newTime - self._firstTime) * 1000
         ms = (newTime - self._lastTime) * 1000
-        self._newMsg("  %s: %0.4f ms", msg, ms)
+        self._newMsg(
+            f"  {msg}: {ms:0.4f}, tot:{tot_ms:0.4f}"
+        )
+
         self._lastTime = newTime
 
     def mark(self, msg=None):

--- a/piker/data/_formatters.py
+++ b/piker/data/_formatters.py
@@ -332,6 +332,9 @@ class IncrementalFormatter(msgspec.Struct):
             array = in_view
             profiler(f'{self.viz.name} view range slice {view_range}')
 
+        # TODO: we need to check if the last-datum-in-view is true and
+        # if so only slice to the 2nd last datumonly slice to the 2nd
+        # last datum.
         # hist = array[:slice_to_head]
 
         # XXX: WOA WTF TRACTOR DEBUGGING BUGGG
@@ -628,7 +631,7 @@ class OHLCBarsFmtr(IncrementalFormatter):
 
         '''
         x, y, c = path_arrays_from_ohlc(
-            array,
+            array[:-1],
             start,
             bar_w=self.index_step_size,
             bar_gap=w * self.index_step_size,

--- a/piker/data/_formatters.py
+++ b/piker/data/_formatters.py
@@ -180,8 +180,6 @@ class IncrementalFormatter(msgspec.Struct):
             # set us in a zero-to-append state
             nd_stop = self.xy_nd_stop = src_stop
 
-            align_index = array[self.index_field]
-
         # compute the length diffs between the first/last index entry in
         # the input data and the last indexes we have on record from the
         # last time we updated the curve index.
@@ -376,11 +374,6 @@ class IncrementalFormatter(msgspec.Struct):
         # update the last "in view data range"
         if len(x_1d):
             self._last_ivdr = x_1d[0], x_1d[-1]
-            if (
-                self.index_field == 'time'
-                and (x_1d[-1] == 0.5).any()
-            ):
-                breakpoint()
 
         profiler('.format_to_1d()')
 
@@ -503,14 +496,22 @@ class IncrementalFormatter(msgspec.Struct):
         # NOTE: we don't include the very last datum which is filled in
         # normally by another graphics object.
         x_1d = array[self.index_field][:-1]
-        if (
-            self.index_field == 'time'
-            and x_1d.any()
-            and (x_1d[-1] == 0.5).any()
-        ):
-            breakpoint()
-
         y_1d = array[array_key][:-1]
+
+        # name = self.viz.name
+        # if 'trade_rate' == name:
+        #     s = 4
+        #     x_nd = list(self.x_nd[self.xy_slice][-s:-1])
+        #     y_nd = list(self.y_nd[self.xy_slice][-s:-1])
+        #     print(
+        #         f'{name}:\n'
+        #         f'XY data:\n'
+        #         f'x: {x_nd}\n'
+        #         f'y: {y_nd}\n\n'
+        #         f'x_1d: {list(x_1d[-s:])}\n'
+        #         f'y_1d: {list(y_1d[-s:])}\n\n'
+
+        #     )
         return (
             x_1d,
             y_1d,
@@ -825,13 +826,6 @@ class StepCurveFmtr(IncrementalFormatter):
         # flatten to 1d
         x_1d = x_step_iv.reshape(x_step_iv.size)
         y_1d = y_step_iv.reshape(y_step_iv.size)
-
-        if (
-            self.index_field == 'time'
-            and x_1d.any()
-            and (x_1d == 0.5).any()
-        ):
-            breakpoint()
 
         # debugging
         # if y_1d.any():

--- a/piker/data/_formatters.py
+++ b/piker/data/_formatters.py
@@ -55,6 +55,10 @@ class IncrementalFormatter(msgspec.Struct):
     shm: ShmArray
     viz: Viz
 
+    # the value to be multiplied any any index into the x/y_1d arrays
+    # given the input index is based on the original source data array.
+    flat_index_ratio: float = 1
+
     @property
     def index_field(self) -> 'str':
         '''
@@ -92,8 +96,8 @@ class IncrementalFormatter(msgspec.Struct):
     xy_nd_stop: int | None = None
 
     # TODO: eventually incrementally update 1d-pre-graphics path data?
-    # x_1d: Optional[np.ndarray] = None
-    # y_1d: Optional[np.ndarray] = None
+    x_1d: np.ndarray | None = None
+    y_1d: np.ndarray | None = None
 
     # incremental view-change state(s) tracking
     _last_vr: tuple[float, float] | None = None
@@ -106,32 +110,6 @@ class IncrementalFormatter(msgspec.Struct):
 
         '''
         return self.viz.index_step()
-
-    def __repr__(self) -> str:
-        msg = (
-            f'{type(self)}: ->\n\n'
-            f'fqsn={self.viz.name}\n'
-            f'shm_name={self.shm.token["shm_name"]}\n\n'
-
-            f'last_vr={self._last_vr}\n'
-            f'last_ivdr={self._last_ivdr}\n\n'
-
-            f'xy_slice={self.xy_slice}\n'
-            # f'xy_nd_stop={self.xy_nd_stop}\n\n'
-        )
-
-        x_nd_len = 0
-        y_nd_len = 0
-        if self.x_nd is not None:
-            x_nd_len = len(self.x_nd)
-            y_nd_len = len(self.y_nd)
-
-        msg += (
-            f'x_nd_len={x_nd_len}\n'
-            f'y_nd_len={y_nd_len}\n'
-        )
-
-        return msg
 
     def diff(
         self,
@@ -354,6 +332,11 @@ class IncrementalFormatter(msgspec.Struct):
             array_key,
             view_range,
         )
+        # cache/save last 1d outputs for use by other
+        # readers (eg. `Viz.draw_last_datum()` in the
+        # only-draw-last-uppx case).
+        self.x_1d = x_1d
+        self.y_1d = y_1d
 
         # app_tres = None
         # if append_len:
@@ -536,6 +519,7 @@ class OHLCBarsFmtr(IncrementalFormatter):
     fields: list[str] = field(
         default_factory=lambda: ['open', 'high', 'low', 'close']
     )
+    flat_index_ratio: float = 4
 
     def allocate_xy_nd(
         self,

--- a/piker/data/_m4.py
+++ b/piker/data/_m4.py
@@ -91,6 +91,14 @@ def ds_m4(
         x_end = x[-1]  # x end value/highest in domain
         xrange = (x_end - x_start)
 
+    if xrange < 0:
+        log.error(f'-VE M4 X-RANGE: {x_start} -> {x_end}')
+        # XXX: broken x-range calc-case, likely the x-end points
+        # are wrong and have some default value set (such as
+        # x_end -> <some epoch float> while x_start -> 0.5).
+        breakpoint()
+        return None
+
     # XXX: always round up on the input pixels
     # lnx = len(x)
     # uppx *= max(4 / (1 + math.log(uppx, 2)), 1)

--- a/piker/data/_m4.py
+++ b/piker/data/_m4.py
@@ -96,7 +96,7 @@ def ds_m4(
         # XXX: broken x-range calc-case, likely the x-end points
         # are wrong and have some default value set (such as
         # x_end -> <some epoch float> while x_start -> 0.5).
-        breakpoint()
+        # breakpoint()
         return None
 
     # XXX: always round up on the input pixels

--- a/piker/data/_pathops.py
+++ b/piker/data/_pathops.py
@@ -63,20 +63,27 @@ def xy_downsample(
     # downsample whenever more then 1 pixels per datum can be shown.
     # always refresh data bounds until we get diffing
     # working properly, see above..
-    bins, x, y, ymn, ymx = ds_m4(
+    m4_out = ds_m4(
         x,
         y,
         uppx,
     )
 
-    # flatten output to 1d arrays suitable for path-graphics generation.
-    x = np.broadcast_to(x[:, None], y.shape)
-    x = (x + np.array(
-        [-x_spacer, 0, 0, x_spacer]
-    )).flatten()
-    y = y.flatten()
+    if m4_out is not None:
+        bins, x, y, ymn, ymx = m4_out
+        # flatten output to 1d arrays suitable for path-graphics generation.
+        x = np.broadcast_to(x[:, None], y.shape)
+        x = (x + np.array(
+            [-x_spacer, 0, 0, x_spacer]
+        )).flatten()
+        y = y.flatten()
 
-    return x, y, ymn, ymx
+        return x, y, ymn, ymx
+
+    # XXX: we accept a None output for the case where the input range
+    # to ``ds_m4()`` is bad (-ve) and we want to catch and debug
+    # that (seemingly super rare) circumstance..
+    return None
 
 
 @njit(

--- a/piker/data/_pathops.py
+++ b/piker/data/_pathops.py
@@ -297,10 +297,7 @@ def slice_from_time(
     stop_t: float,
     step: int | None = None,
 
-) -> tuple[
-    slice,
-    slice,
-]:
+) -> slice:
     '''
     Calculate array indices mapped from a time range and return them in
     a slice.

--- a/piker/data/feed.py
+++ b/piker/data/feed.py
@@ -207,7 +207,7 @@ def get_feed_bus(
 
 ) -> _FeedsBus:
     '''
-    Retreive broker-daemon-local data feeds bus from process global
+    Retrieve broker-daemon-local data feeds bus from process global
     scope. Serialize task access to lock.
 
     '''
@@ -250,6 +250,7 @@ async def start_backfill(
     shm: ShmArray,
     timeframe: float,
     sampler_stream: tractor.MsgStream,
+    feed_is_live: trio.Event,
 
     last_tsdb_dt: Optional[datetime] = None,
     storage: Optional[Storage] = None,
@@ -281,7 +282,14 @@ async def start_backfill(
             - pendulum.from_timestamp(times[-2])
         ).seconds
 
-        if step_size_s == 60:
+        # if the market is open (aka we have a live feed) but the
+        # history sample step index seems off we report the surrounding
+        # data and drop into a bp. this case shouldn't really ever
+        # happen if we're doing history retrieval correctly.
+        if (
+            step_size_s == 60
+            and feed_is_live.is_set()
+        ):
             inow = round(time.time())
             diff = inow - times[-1]
             if abs(diff) > 60:
@@ -499,6 +507,7 @@ async def basic_backfill(
     bfqsn: str,
     shms: dict[int, ShmArray],
     sampler_stream: tractor.MsgStream,
+    feed_is_live: trio.Event,
 
 ) -> None:
 
@@ -518,6 +527,7 @@ async def basic_backfill(
                     shm,
                     timeframe,
                     sampler_stream,
+                    feed_is_live,
                 )
             )
         except DataUnavailable:
@@ -534,6 +544,7 @@ async def tsdb_backfill(
     bfqsn: str,
     shms: dict[int, ShmArray],
     sampler_stream: tractor.MsgStream,
+    feed_is_live: trio.Event,
 
     task_status: TaskStatus[
         tuple[ShmArray, ShmArray]
@@ -568,6 +579,8 @@ async def tsdb_backfill(
                     shm,
                     timeframe,
                     sampler_stream,
+                    feed_is_live,
+
                     last_tsdb_dt=last_tsdb_dt,
                     tsdb_is_up=True,
                     storage=storage,
@@ -870,6 +883,7 @@ async def manage_history(
                         60: hist_shm,
                     },
                     sample_stream,
+                    feed_is_live,
                 )
 
                 # yield back after client connect with filled shm
@@ -904,6 +918,7 @@ async def manage_history(
                     60: hist_shm,
                 },
                 sample_stream,
+                feed_is_live,
             )
             task_status.started((
                 hist_zero_index,
@@ -1065,7 +1080,10 @@ async def allocate_persistent_feed(
     # seed the buffer with a history datum - this is most handy
     # for many backends which don't sample @ 1s OHLC but do have
     # slower data such as 1m OHLC.
-    if not len(rt_shm.array):
+    if (
+        not len(rt_shm.array)
+        and hist_shm.array.size
+    ):
         rt_shm.push(hist_shm.array[-3:-1])
         ohlckeys = ['open', 'high', 'low', 'close']
         rt_shm.array[ohlckeys][-2:] = hist_shm.array['close'][-1]
@@ -1075,6 +1093,9 @@ async def allocate_persistent_feed(
         ts = round(time.time())
         rt_shm.array['time'][0] = ts
         rt_shm.array['time'][1] = ts + 1
+
+    elif hist_shm.array.size == 0:
+        await tractor.breakpoint()
 
     # wait the spawning parent task to register its subscriber
     # send-stream entry before we start the sample loop.

--- a/piker/data/flows.py
+++ b/piker/data/flows.py
@@ -22,17 +22,11 @@ real-time data processing data-structures.
 
 """
 from __future__ import annotations
-from contextlib import asynccontextmanager as acm
-from functools import partial
 from typing import (
-    AsyncIterator,
     TYPE_CHECKING,
 )
 
 import tractor
-from tractor.trionics import (
-    maybe_open_context,
-)
 import pendulum
 import numpy as np
 
@@ -44,9 +38,6 @@ from ._sharedmem import (
     attach_shm_array,
     ShmArray,
     _Token,
-)
-from ._sampling import (
-    open_sample_stream,
 )
 # from .._profile import (
 #     Profiler,
@@ -150,26 +141,6 @@ class Flume(Struct):
 
     async def receive(self) -> dict:
         return await self.stream.receive()
-
-    @acm
-    async def index_stream(
-        self,
-        delay_s: float = 1,
-
-    ) -> AsyncIterator[int]:
-
-        if not self.feed:
-            raise RuntimeError('This flume is not part of any ``Feed``?')
-
-        # TODO: maybe a public (property) API for this in ``tractor``?
-        portal = self.stream._ctx._portal
-        assert portal
-
-        # XXX: this should be singleton on a host,
-        # a lone broker-daemon per provider should be
-        # created for all practical purposes
-        async with open_sample_stream(float(delay_s)) as stream:
-            yield stream
 
     def get_ds_info(
         self,

--- a/piker/pp.py
+++ b/piker/pp.py
@@ -54,7 +54,7 @@ def open_trade_ledger(
     broker: str,
     account: str,
 
-) -> str:
+) -> dict:
     '''
     Indempotently create and read in a trade log file from the
     ``<configuration_dir>/ledgers/`` directory.

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1152,8 +1152,6 @@ class ChartPlotWidget(pg.PlotWidget):
 
         if is_ohlc:
             graphics = BarItems(
-                linked=self.linked,
-                plotitem=pi,
                 color=color,
                 name=name,
                 **graphics_kwargs,

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -629,11 +629,13 @@ class LinkedSplits(QWidget):
         for axis in axes.values():
             axis.pi = cpw.plotItem
 
+
         cpw.hideAxis('left')
         cpw.hideAxis('bottom')
 
         if (
-            _xaxis_at == 'bottom' and (
+            _xaxis_at == 'bottom'
+            and (
                 self.xaxis_chart
                 or (
                     not self.subplots
@@ -641,6 +643,8 @@ class LinkedSplits(QWidget):
                 )
             )
         ):
+            # hide the previous x-axis chart's bottom axis since we're
+            # presumably being appended to the bottom subplot.
             if self.xaxis_chart:
                 self.xaxis_chart.hideAxis('bottom')
 
@@ -685,7 +689,12 @@ class LinkedSplits(QWidget):
         # link chart x-axis to main chart
         # this is 1/2 of where the `Link` in ``LinkedSplit``
         # comes from ;)
-        cpw.setXLink(self.chart)
+        cpw.cv.setXLink(self.chart)
+
+        # NOTE: above is the same as the following,
+        # link this subchart's axes to the main top level chart.
+        # if self.chart:
+        #     cpw.cv.linkView(0, self.chart.cv)
 
         add_label = False
         anchor_at = ('top', 'left')
@@ -797,7 +806,9 @@ class LinkedSplits(QWidget):
 # write our own wrapper around `PlotItem`..
 class ChartPlotWidget(pg.PlotWidget):
     '''
-    ``GraphicsView`` subtype containing a single ``PlotItem``.
+    ``GraphicsView`` subtype containing a ``.plotItem: PlotItem`` as well
+    as a `.pi_overlay: PlotItemOverlay`` which helps manage and overlay flow
+    graphics view multiple compose view boxes.
 
     - The added methods allow for plotting OHLC sequences from
       ``np.ndarray``s with appropriate field names.
@@ -1098,6 +1109,7 @@ class ChartPlotWidget(pg.PlotWidget):
         # view **to** this parent and likewise *from* the
         # main/parent chart back *to* the created overlay.
         cv.enable_auto_yrange(src_vb=self.view)
+
         # makes it so that interaction on the new overlay will reflect
         # back on the main chart (which overlay was added to).
         self.view.enable_auto_yrange(src_vb=cv)
@@ -1172,6 +1184,7 @@ class ChartPlotWidget(pg.PlotWidget):
             # register curve graphics with this viz
             graphics=graphics,
         )
+        pi.viz = viz
         assert isinstance(viz.shm, ShmArray)
 
         # TODO: this probably needs its own method?
@@ -1318,7 +1331,7 @@ class ChartPlotWidget(pg.PlotWidget):
                 self.default_view(do_ds=False)
                 self._on_screen = True
         else:
-            x_range, mxmn = res
+            x_range, read_slc, mxmn = res
 
         return mxmn
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -528,6 +528,8 @@ class LinkedSplits(QWidget):
 
         style: str = 'ohlc_bar',
 
+        **add_plot_kwargs,
+
     ) -> ChartPlotWidget:
         '''
         Start up and show main (price) chart and all linked subcharts.
@@ -552,6 +554,7 @@ class LinkedSplits(QWidget):
             style=style,
             _is_main=True,
             sidepane=sidepane,
+            **add_plot_kwargs,
         )
         # add crosshair graphic
         self.chart.addItem(self.cursor)
@@ -576,6 +579,7 @@ class LinkedSplits(QWidget):
         _is_main: bool = False,
 
         sidepane: Optional[QWidget] = None,
+        draw_kwargs: dict = {},
 
         **cpw_kwargs,
 
@@ -701,12 +705,12 @@ class LinkedSplits(QWidget):
         # draw curve graphics
         if style == 'ohlc_bar':
 
-            # graphics, data_key = cpw.draw_ohlc(
             viz = cpw.draw_ohlc(
                 name,
                 shm,
                 flume=flume,
-                array_key=array_key
+                array_key=array_key,
+                **draw_kwargs,
             )
             self.cursor.contents_labels.add_label(
                 cpw,
@@ -724,6 +728,7 @@ class LinkedSplits(QWidget):
                 flume,
                 array_key=array_key,
                 color='default_light',
+                **draw_kwargs,
             )
 
         elif style == 'step':
@@ -737,6 +742,7 @@ class LinkedSplits(QWidget):
                 step_mode=True,
                 color='davies',
                 fill_color='davies',
+                **draw_kwargs,
             )
 
         else:

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -629,7 +629,6 @@ class LinkedSplits(QWidget):
         for axis in axes.values():
             axis.pi = cpw.plotItem
 
-
         cpw.hideAxis('left')
         cpw.hideAxis('bottom')
 
@@ -742,6 +741,15 @@ class LinkedSplits(QWidget):
 
         else:
             raise ValueError(f"Chart style {style} is currently unsupported")
+
+        # NOTE: back-link the new sub-chart to trigger y-autoranging in
+        # the (ohlc parent) main chart for this linked set.
+        if self.chart:
+            main_viz = self.chart.get_viz(self.chart.name)
+            self.chart.view.enable_auto_yrange(
+                src_vb=cpw.view,
+                viz=main_viz,
+            )
 
         graphics = viz.graphics
         data_key = viz.name
@@ -1105,15 +1113,6 @@ class ChartPlotWidget(pg.PlotWidget):
             link_axes=(0,),
         )
 
-        # connect auto-yrange callbacks *from* this new
-        # view **to** this parent and likewise *from* the
-        # main/parent chart back *to* the created overlay.
-        cv.enable_auto_yrange(src_vb=self.view)
-
-        # makes it so that interaction on the new overlay will reflect
-        # back on the main chart (which overlay was added to).
-        self.view.enable_auto_yrange(src_vb=cv)
-
         # add axis title
         # TODO: do we want this API to still work?
         # raxis = pi.getAxis('right')
@@ -1184,6 +1183,15 @@ class ChartPlotWidget(pg.PlotWidget):
             # register curve graphics with this viz
             graphics=graphics,
         )
+
+        # connect auto-yrange callbacks *from* this new
+        # view **to** this parent and likewise *from* the
+        # main/parent chart back *to* the created overlay.
+        pi.vb.enable_auto_yrange(
+            src_vb=self.view,
+            viz=viz,
+        )
+
         pi.viz = viz
         assert isinstance(viz.shm, ShmArray)
 

--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -127,7 +127,10 @@ class GodWidget(QWidget):
         # self.init_strategy_ui()
         # self.vbox.addLayout(self.hbox)
 
-        self._chart_cache: dict[str, LinkedSplits] = {}
+        self._chart_cache: dict[
+            str,
+            tuple[LinkedSplits, LinkedSplits],
+        ] = {}
 
         self.hist_linked: Optional[LinkedSplits] = None
         self.rt_linked: Optional[LinkedSplits] = None
@@ -146,23 +149,6 @@ class GodWidget(QWidget):
     @property
     def linkedsplits(self) -> LinkedSplits:
         return self.rt_linked
-
-    # def init_timeframes_ui(self):
-    #     self.tf_layout = QHBoxLayout()
-    #     self.tf_layout.setSpacing(0)
-    #     self.tf_layout.setContentsMargins(0, 12, 0, 0)
-    #     time_frames = ('1M', '5M', '15M', '30M', '1H', '1D', '1W', 'MN')
-    #     btn_prefix = 'TF'
-
-    #     for tf in time_frames:
-    #         btn_name = ''.join([btn_prefix, tf])
-    #         btn = QtWidgets.QPushButton(tf)
-    #         # TODO:
-    #         btn.setEnabled(False)
-    #         setattr(self, btn_name, btn)
-    #         self.tf_layout.addWidget(btn)
-
-    #     self.toolbar_layout.addLayout(self.tf_layout)
 
     # XXX: strat loader/saver that we don't need yet.
     # def init_strategy_ui(self):

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -112,6 +112,7 @@ class Curve(FlowGraphic):
       updates don't trigger a full path redraw.
 
     '''
+    cache_mode: int = QGraphicsItem.DeviceCoordinateCache
 
     def __init__(
         self,
@@ -178,7 +179,7 @@ class Curve(FlowGraphic):
         # only thing drawn is the "last" line segment which can
         # have a weird artifact where it won't be fully drawn to its
         # endpoint (something we saw on trade rate curves)
-        self.setCacheMode(QGraphicsItem.DeviceCoordinateCache)
+        self.setCacheMode(self.cache_mode)
 
         # XXX-NOTE-XXX: graphics caching.
         # see explanation for different caching modes:
@@ -381,6 +382,9 @@ class Curve(FlowGraphic):
 # element such that the current datum in view can be shown
 # (via it's max / min) even when highly zoomed out.
 class FlattenedOHLC(Curve):
+
+    # avoids strange dragging/smearing artifacts when panning..
+    cache_mode: int = QGraphicsItem.NoCache
 
     def draw_last_datum(
         self,

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -60,11 +60,82 @@ class FlowGraphic(pg.GraphicsObject):
 
     '''
     # sub-type customization methods
-    declare_paintables: Optional[Callable] = None
-    sub_paint: Optional[Callable] = None
+    declare_paintables: Callable | None = None
+    sub_paint: Callable | None = None
 
-    # TODO: can we remove this?
-    # sub_br: Optional[Callable] = None
+    # XXX-NOTE-XXX: graphics caching B)
+    # see explanation for different caching modes:
+    # https://stackoverflow.com/a/39410081
+    cache_mode: int = QGraphicsItem.DeviceCoordinateCache
+    # XXX: WARNING item caching seems to only be useful
+    # if we don't re-generate the entire QPainterPath every time
+    # don't ever use this - it's a colossal nightmare of artefacts
+    # and is disastrous for performance.
+    # QGraphicsItem.ItemCoordinateCache
+    # TODO: still questions todo with coord-cacheing that we should
+    # probably talk to a core dev about:
+    # - if this makes trasform interactions slower (such as zooming)
+    #   and if so maybe if/when we implement a "history" mode for the
+    #   view we disable this in that mode?
+
+    def __init__(
+        self,
+        *args,
+        name: str | None = None,
+
+        # line styling
+        color: str = 'bracket',
+        last_step_color: str = 'original',
+        fill_color: Optional[str] = None,
+        style: str = 'solid',
+
+        **kwargs
+
+    ) -> None:
+
+        self._name = name
+
+        # primary graphics item used for history
+        self.path: QPainterPath = QPainterPath()
+
+        # additional path that can be optionally used for appends which
+        # tries to avoid triggering an update/redraw of the presumably
+        # larger historical ``.path`` above. the flag to enable
+        # this behaviour is found in `Renderer.render()`.
+        self.fast_path: QPainterPath | None = None
+
+        # TODO: evaluating the path capacity stuff and see
+        # if it really makes much diff pre-allocating it.
+        # self._last_cap: int = 0
+        # cap = path.capacity()
+        # if cap != self._last_cap:
+        #     print(f'NEW CAPACITY: {self._last_cap} -> {cap}')
+        #     self._last_cap = cap
+
+        # all history of curve is drawn in single px thickness
+        self._color: str = color
+        pen = pg.mkPen(hcolor(color), width=1)
+        pen.setStyle(_line_styles[style])
+
+        if 'dash' in style:
+            pen.setDashPattern([8, 3])
+
+        self._pen = pen
+        self._brush = pg.functions.mkBrush(
+            hcolor(fill_color or color)
+        )
+
+        # last segment is drawn in 2px thickness for emphasis
+        self.last_step_pen = pg.mkPen(
+            hcolor(last_step_color),
+            width=2,
+        )
+        self._last_line: QLineF = QLineF()
+
+        super().__init__(*args, **kwargs)
+
+        # apply cache mode
+        self.setCacheMode(self.cache_mode)
 
     def x_uppx(self) -> int:
 
@@ -112,82 +183,32 @@ class Curve(FlowGraphic):
       updates don't trigger a full path redraw.
 
     '''
-    cache_mode: int = QGraphicsItem.DeviceCoordinateCache
+    # TODO: can we remove this?
+    # sub_br: Optional[Callable] = None
 
     def __init__(
         self,
         *args,
 
-        step_mode: bool = False,
-        color: str = 'default_lightest',
-        fill_color: Optional[str] = None,
-        style: str = 'solid',
-        name: Optional[str] = None,
+        # color: str = 'default_lightest',
+        # fill_color: Optional[str] = None,
+        # style: str = 'solid',
 
         **kwargs
 
     ) -> None:
 
-        self._name = name
-
         # brutaaalll, see comments within..
         self.yData = None
         self.xData = None
-
-        # self._last_cap: int = 0
-        self.path: Optional[QPainterPath] = None
-
-        # additional path that can be optionally used for appends which
-        # tries to avoid triggering an update/redraw of the presumably
-        # larger historical ``.path`` above. the flag to enable
-        # this behaviour is found in `Renderer.render()`.
-        self.fast_path: QPainterPath | None = None
 
         # TODO: we can probably just dispense with the parent since
         # we're basically only using the pen setting now...
         super().__init__(*args, **kwargs)
 
-        # all history of curve is drawn in single px thickness
-        pen = pg.mkPen(hcolor(color))
-        pen.setStyle(_line_styles[style])
-
-        if 'dash' in style:
-            pen.setDashPattern([8, 3])
-
-        self._pen = pen
-
-        # last segment is drawn in 2px thickness for emphasis
-        # self.last_step_pen = pg.mkPen(hcolor(color), width=2)
-        self.last_step_pen = pg.mkPen(pen, width=2)
-
         self._last_line: QLineF = QLineF()
 
-        # flat-top style histogram-like discrete curve
-        # self._step_mode: bool = step_mode
-
         # self._fill = True
-        self._brush = pg.functions.mkBrush(hcolor(fill_color or color))
-
-        # NOTE: this setting seems to mostly prevent redraws on mouse
-        # interaction which is a huge boon for avg interaction latency.
-
-        # TODO: one question still remaining is if this makes trasform
-        # interactions slower (such as zooming) and if so maybe if/when
-        # we implement a "history" mode for the view we disable this in
-        # that mode?
-        # don't enable caching by default for the case where the
-        # only thing drawn is the "last" line segment which can
-        # have a weird artifact where it won't be fully drawn to its
-        # endpoint (something we saw on trade rate curves)
-        self.setCacheMode(self.cache_mode)
-
-        # XXX-NOTE-XXX: graphics caching.
-        # see explanation for different caching modes:
-        # https://stackoverflow.com/a/39410081 seems to only be useful
-        # if we don't re-generate the entire QPainterPath every time
-        # don't ever use this - it's a colossal nightmare of artefacts
-        # and is disastrous for performance.
-        # self.setCacheMode(QtWidgets.QGraphicsItem.ItemCoordinateCache)
 
         # allow sub-type customization
         declare = self.declare_paintables
@@ -318,14 +339,10 @@ class Curve(FlowGraphic):
 
         p.setPen(self.last_step_pen)
         p.drawLine(self._last_line)
-        profiler('.drawLine()')
-        p.setPen(self._pen)
+        profiler('last datum `.drawLine()`')
 
+        p.setPen(self._pen)
         path = self.path
-        # cap = path.capacity()
-        # if cap != self._last_cap:
-        #     print(f'NEW CAPACITY: {self._last_cap} -> {cap}')
-        #     self._last_cap = cap
 
         if path:
             p.drawPath(path)
@@ -370,7 +387,7 @@ class Curve(FlowGraphic):
             # from last datum to current such that
             # the end of line touches the "beginning"
             # of the current datum step span.
-            x_2last , y[-2],
+            x_2last, y[-2],
             x_last, y[-1],
         )
 

--- a/piker/ui/_curve.py
+++ b/piker/ui/_curve.py
@@ -85,7 +85,7 @@ class FlowGraphic(pg.GraphicsObject):
 
         # line styling
         color: str = 'bracket',
-        last_step_color: str = 'original',
+        last_step_color: str | None = None,
         fill_color: Optional[str] = None,
         style: str = 'solid',
 
@@ -126,10 +126,17 @@ class FlowGraphic(pg.GraphicsObject):
         )
 
         # last segment is drawn in 2px thickness for emphasis
-        self.last_step_pen = pg.mkPen(
-            hcolor(last_step_color),
-            width=2,
-        )
+        if last_step_color:
+            self.last_step_pen = pg.mkPen(
+                hcolor(last_step_color),
+                width=2,
+            )
+        else:
+            self.last_step_pen = pg.mkPen(
+                self._pen,
+                width=2,
+            )
+
         self._last_line: QLineF = QLineF()
 
         super().__init__(*args, **kwargs)

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -388,9 +388,11 @@ class Viz(msgspec.Struct):  # , frozen=True):
                         f'{self.name} CACHED maxmin\n'
                         f'{ixrng} -> {cached_result}'
                     )
+                read_slc, mxmn = cached_result
                 return (
                     ixrng,
-                    cached_result,
+                    read_slc,
+                    mxmn,
                 )
 
         # get relative slice indexes into array
@@ -451,10 +453,11 @@ class Viz(msgspec.Struct):  # , frozen=True):
 
         # cache result for input range
         assert mxmn
-        self._mxmns[ixrng] = mxmn
+        self._mxmns[ixrng] = (read_slc, mxmn)
         profiler(f'yrange mxmn cacheing: {x_range} -> {mxmn}')
         return (
             ixrng,
+            read_slc,
             mxmn,
         )
 
@@ -1026,11 +1029,9 @@ class Viz(msgspec.Struct):  # , frozen=True):
         )
 
         if do_ds:
+            # view.interaction_graphics_update_cycle()
             view.maybe_downsample_graphics()
             view._set_yrange()
-
-            # caller should do this!
-            # self.linked.graphics_cycle()
 
     def incr_info(
         self,

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -1180,7 +1180,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
         i_last_append = varz['i_last_append']
         append_diff: int = i_step - i_last_append
 
-        do_px_step = append_diff >= uppx
+        do_px_step = (append_diff * self.index_step()) >= uppx
         do_rt_update = (uppx < update_uppx)
 
         if (

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -658,7 +658,11 @@ class Viz(msgspec.Struct):  # , frozen=True):
 
         **kwargs,
 
-    ) -> pg.GraphicsObject:
+    ) -> tuple[
+        bool,
+        tuple[int, int],
+        pg.GraphicsObject,
+    ]:
         '''
         Read latest datums from shm and render to (incrementally)
         render to graphics.
@@ -688,8 +692,9 @@ class Viz(msgspec.Struct):  # , frozen=True):
             not in_view.size
             or not render
         ):
-            # print('exiting early')
+            # print(f'{self.name} not in view (exiting early)')
             return (
+                False,
                 (ivl, ivr),
                 graphics,
             )
@@ -810,6 +815,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
         if not out:
             log.warning(f'{self.name} failed to render!?')
             return (
+                False,
                 (ivl, ivr),
                 graphics,
             )
@@ -865,6 +871,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
         self._in_ds = r._in_ds
 
         return (
+            True,
             (ivl, ivr),
             graphics,
         )
@@ -1053,7 +1060,9 @@ class Viz(msgspec.Struct):  # , frozen=True):
                 l_reset = r_reset - rl_diff
 
             else:
-                raise RuntimeError(f'Unknown view state {vl} -> {vr}')
+                log.warning(f'Unknown view state {vl} -> {vr}')
+                # return
+                # raise RuntimeError(f'Unknown view state {vl} -> {vr}')
 
         else:
             # maintain the l->r view distance

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -342,7 +342,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
         '''
         name = self.name
         profiler = Profiler(
-            msg=f'{name} -> `{str(self)}.maxmin()`',
+            msg=f'`Viz[{name}].maxmin()`',
             disabled=not pg_profile_enabled(),
             ms_threshold=4,
             delayed=True,
@@ -857,15 +857,15 @@ class Viz(msgspec.Struct):  # , frozen=True):
         #     array_key,
         #     index_field=self.index_field,
         # )
-        graphics.update()
-        profiler('.update()')
-
         # TODO: does this actuallly help us in any way (prolly should
         # look at the source / ask ogi). I think it avoid artifacts on
         # wheel-scroll downsampling curve updates?
         # TODO: is this ever better?
-        # graphics.prepareGeometryChange()
-        # profiler('.prepareGeometryChange()')
+        graphics.prepareGeometryChange()
+        profiler('.prepareGeometryChange()')
+
+        graphics.update()
+        profiler('.update()')
 
         # track downsampled state
         self._in_ds = r._in_ds

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -19,6 +19,10 @@ Data vizualization APIs
 
 '''
 from __future__ import annotations
+from math import (
+    ceil,
+    floor,
+)
 from typing import (
     Optional,
     Literal,
@@ -456,13 +460,13 @@ class Viz(msgspec.Struct):  # , frozen=True):
             array = self.shm.array
 
         index = array[index_field]
-        first = round(index[0])
-        last = round(index[-1])
+        first = floor(index[0])
+        last = ceil(index[-1])
 
         # first and last datums in view determined by
         # l / r view range.
-        leftmost = round(l)
-        rightmost = round(r)
+        leftmost = floor(l)
+        rightmost = ceil(r)
 
         # invalid view state
         if (

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -1086,8 +1086,46 @@ class Viz(msgspec.Struct):  # , frozen=True):
         is_1m: bool = False,
 
     ) -> tuple:
+        '''
+        Return a slew of graphics related data-flow metrics to do with
+        incrementally updating a data view.
 
-        _, _, _, r = self.bars_range()  # most recent right datum index in-view
+        Output  info includes,
+        ----------------------
+
+        uppx: float
+            x-domain units-per-pixel.
+
+        liv: bool
+            telling if the "last datum" is in vie"last datum" is in
+            view.
+
+        do_px_step: bool
+            recent data append(s) are enough that the next physical
+            pixel-column should be used for drawing.
+
+        i_diff_t: float
+            the difference between the last globally recorded time stamp
+            aand the current one.
+
+        append_diff: int
+           diff between last recorded "append index" (the index at whic
+           `do_px_step` was last returned `True`) and the current index.
+
+        do_rt_update: bool
+            `True` only when the uppx is less then some threshold
+            defined by `update_uppx`.
+
+        should_tread: bool
+            determines the first step, globally across all callers, that
+            the a set of data views should be "treaded", shifted in the
+            x-domain such that the last datum in view is always in the
+            same spot in non-view/scene (aka GUI coord) terms.
+
+
+        '''
+        # get most recent right datum index in-view
+        l, start, datum_start, datum_stop, stop, r = self.datums_range()
         lasts = self.shm.array[-1]
         i_step = lasts['index']  # last index-specific step.
         i_step_t = lasts['time']  # last time step.
@@ -1136,7 +1174,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
         # is such that a datum(s) update to graphics wouldn't span
         # to a new pixel, we don't update yet.
         i_last_append = varz['i_last_append']
-        append_diff = i_step - i_last_append
+        append_diff: int = i_step - i_last_append
 
         do_px_step = append_diff >= uppx
         do_rt_update = (uppx < update_uppx)

--- a/piker/ui/_dataviz.py
+++ b/piker/ui/_dataviz.py
@@ -1061,7 +1061,7 @@ class Viz(msgspec.Struct):  # , frozen=True):
 
             else:
                 log.warning(f'Unknown view state {vl} -> {vr}')
-                # return
+                return
                 # raise RuntimeError(f'Unknown view state {vl} -> {vr}')
 
         else:

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -453,7 +453,8 @@ async def graphics_update_loop(
                 # and quote_rate >= _quote_throttle_rate * 2
                 and quote_rate >= display_rate
             ):
-                log.warning(f'High quote rate {symbol.key}: {quote_rate}')
+                pass
+                # log.warning(f'High quote rate {symbol.key}: {quote_rate}')
 
             last_quote_s = time.time()
 
@@ -499,9 +500,9 @@ def graphics_update_cycle(
 
     profiler = Profiler(
         msg=f'Graphics loop cycle for: `{ds.fqsn}`',
-        delayed=True,
         disabled=not pg_profile_enabled(),
         ms_threshold=ms_slower_then,
+        delayed=True,
         # ms_threshold=4,
     )
 
@@ -1325,7 +1326,7 @@ async def display_symbol_data(
                     is_ohlc=True,
 
                     color=bg_chart_color,
-                    last_bar_color=bg_last_bar_color,
+                    last_step_color=bg_last_bar_color,
                 )
 
                 # ensure the last datum graphic is generated
@@ -1362,7 +1363,7 @@ async def display_symbol_data(
                     is_ohlc=True,
 
                     color=bg_chart_color,
-                    last_bar_color=bg_last_bar_color,
+                    last_step_color=bg_last_bar_color,
                 )
                 rt_pi.vb.maxmin = partial(
                     rt_chart.maxmin,

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -783,25 +783,25 @@ def graphics_update_cycle(
                 array_key=curve_name,
             )
 
-        # even if we're downsampled bigly
-        # draw the last datum in the final
-        # px column to give the user the mx/mn
-        # range of that set.
-        if (
-            curve_name != fqsn
-            and liv
-            # and not do_px_step
-            # and not do_rt_update
-        ):
-            viz.draw_last(
-                array_key=curve_name,
+            # even if we're downsampled bigly
+            # draw the last datum in the final
+            # px column to give the user the mx/mn
+            # range of that set.
+            if (
+                curve_name != fqsn
+                and liv
+                # and not do_px_step
+                # and not do_rt_update
+            ):
+                viz.draw_last(
+                    array_key=curve_name,
 
-                # TODO: XXX this is currently broken for the
-                # `FlattenedOHLC` case since we aren't returning the
-                # full x/y uppx's worth of src-data from
-                # `draw_last_datum()` ..
-                only_last_uppx=True,
-            )
+                    # TODO: XXX this is currently broken for the
+                    # `FlattenedOHLC` case since we aren't returning the
+                    # full x/y uppx's worth of src-data from
+                    # `draw_last_datum()` ..
+                    only_last_uppx=True,
+                )
 
     profiler('overlays updates')
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -43,7 +43,10 @@ from ..data.types import Struct
 from ..data._sharedmem import (
     ShmArray,
 )
-from ..data._sampling import _tick_groups
+from ..data._sampling import (
+    _tick_groups,
+    open_sample_stream,
+)
 from ._axes import YAxisLabel
 from ._chart import (
     ChartPlotWidget,
@@ -194,7 +197,7 @@ async def increment_history_view(
     #   wakeups/ctx switches verus logic checks (as normal)
     # - we need increment logic that only does the view shift
     #   call when the uppx permits/needs it
-    async with hist_viz.flume.index_stream(int(1)) as istream:
+    async with open_sample_stream(1.) as istream:
         async for msg in istream:
 
             # l3 = ds.viz.shm.array[-3:]

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -992,32 +992,6 @@ async def link_views_with_region(
     # region.sigRegionChangeFinished.connect(update_pi_from_region)
 
 
-# force 0 to always be in view
-def multi_maxmin(
-    chart: ChartPlotWidget,
-    names: list[str],
-
-) -> tuple[float, float]:
-    '''
-    Viz "group" maxmin loop; assumes all named vizs
-    are in the same co-domain and thus can be sorted
-    as one set.
-
-    Iterates all the named vizs and calls the chart
-    api to find their range values and return.
-
-    TODO: really we should probably have a more built-in API
-    for this?
-
-    '''
-    mx = 0
-    for name in names:
-        ymn, ymx = chart.maxmin(name=name)
-        mx = max(mx, ymx)
-
-        return 0, mx
-
-
 _quote_throttle_rate: int = 60 - 6
 
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -463,7 +463,7 @@ def graphics_update_cycle(
     #   state-tracking ``chart_maxmin()`` routine from above?
 
     chart = ds.chart
-    hist_chart = ds.godwidget.hist_linked.chart
+    hist_chart = ds.hist_chart
 
     flume = ds.flume
     sym = flume.symbol

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -214,7 +214,7 @@ async def increment_history_view(
             (
                 uppx,
                 liv,
-                do_append,
+                do_px_step,
                 i_diff_t,
                 append_diff,
                 do_rt_update,
@@ -226,7 +226,7 @@ async def increment_history_view(
             )
 
             if (
-                do_append
+                do_px_step
                 and liv
             ):
                 hist_viz.plot.vb._set_yrange(viz=hist_viz)
@@ -465,11 +465,11 @@ def graphics_update_cycle(
 
     chart = ds.chart
     hist_chart = ds.hist_chart
-
     flume = ds.flume
     sym = flume.symbol
     fqsn = sym.fqsn
     main_viz = chart._vizs[fqsn]
+    hist_viz = hist_chart._vizs[fqsn]
     index_field = main_viz.index_field
 
     profiler = Profiler(
@@ -493,7 +493,7 @@ def graphics_update_cycle(
     (
         uppx,
         liv,
-        do_append,
+        do_px_step,
         i_diff_t,
         append_diff,
         do_rt_update,
@@ -501,7 +501,7 @@ def graphics_update_cycle(
     ) = main_viz.incr_info(ds=ds)
 
     # TODO: we should only run mxmn when we know
-    # an update is due via ``do_append`` above.
+    # an update is due via ``do_px_step`` above.
     (
         mx_in_view,
         mn_in_view,
@@ -519,18 +519,16 @@ def graphics_update_cycle(
     # update ohlc sampled price bars
     if (
         do_rt_update
-        or do_append
+        or do_px_step
         or trigger_all
     ):
-        chart.update_graphics_from_flow(
-            fqsn,
-            # do_append=do_append,
-        )
-        main_viz.draw_last(array_key=fqsn)
+        main_viz.update_graphics(array_key=fqsn)
+        hist_viz.draw_last(array_key=fqsn)
 
-        hist_chart.update_graphics_from_flow(
-            fqsn,
-            # do_append=do_append,
+    else:
+        main_viz.draw_last(
+            array_key=fqsn,
+            only_last_uppx=True,
         )
 
     # don't real-time "shift" the curve to the
@@ -538,7 +536,7 @@ def graphics_update_cycle(
     if (
         (
             should_tread
-            and do_append
+            and do_px_step
             and liv
         )
         or trigger_all
@@ -592,7 +590,7 @@ def graphics_update_cycle(
 
             if wap_in_history:
                 # update vwap overlay line
-                chart.update_graphics_from_flow('bar_wap')
+                chart.get_viz('bar_wap').update_graphics()
 
         # L1 book label-line updates
         if typ in ('last',):
@@ -629,7 +627,8 @@ def graphics_update_cycle(
         ):
             l1.bid_label.update_fields({'level': price, 'size': size})
 
-    # check for y-autorange re-size
+    # Y-autoranging: adjust y-axis limits based on state tracking
+    # of previous "last" L1 values which are in view.
     lmx = varz['last_mx']
     lmn = varz['last_mn']
     mx_diff = mx - lmx
@@ -639,6 +638,8 @@ def graphics_update_cycle(
         mx_diff
         or mn_diff
     ):
+        # complain about out-of-range outliers which can show up
+        # in certain annoying feeds (like ib)..
         if (
             abs(mx_diff) > .25 * lmx
             or
@@ -653,7 +654,8 @@ def graphics_update_cycle(
                 f'mx_diff: {mx_diff}\n'
                 f'mn_diff: {mn_diff}\n'
             )
-        # fast chart resize case
+
+        # FAST CHART resize case
         elif (
             liv
             and not chart._static_yrange == 'axis'
@@ -665,7 +667,7 @@ def graphics_update_cycle(
             ):
                 yr = (mn, mx)
                 # print(
-                #     f'updating y-range due to mxmn\n'
+                #     f'MAIN VIZ yrange update\n'
                 #     f'{fqsn}: {yr}'
                 # )
 
@@ -679,8 +681,7 @@ def graphics_update_cycle(
                     yrange=yr
                 )
 
-        # check if slow chart needs a resize
-        hist_viz = hist_chart._vizs[fqsn]
+        # SLOW CHART resize case
         (
             _,
             hist_liv,
@@ -696,15 +697,16 @@ def graphics_update_cycle(
         if hist_liv:
             hist_viz.plot.vb._set_yrange(viz=hist_viz)
 
-    # XXX: update this every draw cycle to make
+    # XXX: update this every draw cycle to ensure y-axis auto-ranging
+    # only adjusts when the in-view data co-domain actually expands or
+    # contracts.
     varz['last_mx'], varz['last_mn'] = mx, mn
 
-    # run synchronous update on all linked viz
-    # TODO: should the "main" (aka source) viz be special?
+    # run synchronous update on all `Viz` overlays
     for curve_name, viz in chart._vizs.items():
+
         # update any overlayed fsp flows
         if (
-            # curve_name != chart.data_key
             curve_name != fqsn
             and not viz.is_ohlc
         ):
@@ -719,20 +721,27 @@ def graphics_update_cycle(
         # px column to give the user the mx/mn
         # range of that set.
         if (
-            liv
-            # and not do_append
+            curve_name != fqsn
+            and liv
+            # and not do_px_step
             # and not do_rt_update
         ):
             viz.draw_last(
                 array_key=curve_name,
+
+                # TODO: XXX this is currently broken for the
+                # `FlattenedOHLC` case since we aren't returning the
+                # full x/y uppx's worth of src-data from
+                # `draw_last_datum()` ..
                 only_last_uppx=True,
             )
 
     # volume chart logic..
     # TODO: can we unify this with the above loop?
     if vlm_chart:
-        # print(f"DOING VLM {fqsn}")
         vlm_vizs = vlm_chart._vizs
+
+        main_vlm_viz = vlm_vizs['volume']
 
         # always update y-label
         ds.vlm_sticky.update_from_data(
@@ -745,19 +754,20 @@ def graphics_update_cycle(
         if (
             (
                 do_rt_update
-                or do_append
+                or do_px_step
                 and liv
             )
             or trigger_all
         ):
             # TODO: make it so this doesn't have to be called
             # once the $vlm is up?
-            vlm_chart.update_graphics_from_flow(
-                'volume',
+            main_vlm_viz.update_graphics(
+
                 # UGGGh, see ``maxmin()`` impl in `._fsp` for
                 # the overlayed plotitems... we need a better
                 # bay to invoke a maxmin per overlay..
                 render=False,
+
                 # XXX: ^^^^ THIS IS SUPER IMPORTANT! ^^^^
                 # without this, since we disable the
                 # 'volume' (units) chart after the $vlm starts
@@ -766,7 +776,7 @@ def graphics_update_cycle(
                 # connected to update accompanying overlay
                 # graphics..
             )
-            profiler('`vlm_chart.update_graphics_from_flow()`')
+            profiler('`main_vlm_viz.update_graphics()`')
 
             if (
                 mx_vlm_in_view != varz['last_mx_vlm']
@@ -774,50 +784,49 @@ def graphics_update_cycle(
                 vlm_yr = (0, mx_vlm_in_view * 1.375)
                 vlm_chart.view._set_yrange(yrange=vlm_yr)
                 profiler('`vlm_chart.view._set_yrange()`')
-                # print(f'mx vlm: {last_mx_vlm} -> {mx_vlm_in_view}')
                 varz['last_mx_vlm'] = mx_vlm_in_view
 
         # update all downstream FSPs
         for curve_name, viz in vlm_vizs.items():
 
+            if curve_name == 'volume':
+                continue
+
             if (
-                curve_name not in {'volume', fqsn}
-                and viz.render
+                viz.render
                 and (
                     liv and do_rt_update
-                    or do_append
+                    or do_px_step
                 )
-                # and not viz.is_ohlc
-                # and curve_name != fqsn
+                and curve_name not in {fqsn,}
             ):
                 update_fsp_chart(
                     viz,
                     curve_name,
                     array_key=curve_name,
-                    # do_append=uppx < update_uppx,
-                    # do_append=do_append,
                 )
                 # is this even doing anything?
                 # (pretty sure it's the real-time
                 # resizing from last quote?)
                 fvb = viz.plot.vb
+
+                # XXX: without this we get completely
+                # mangled/empty vlm display subchart..
                 fvb._set_yrange(
                     viz=viz,
                 )
 
+            # even if we're downsampled bigly
+            # draw the last datum in the final
+            # px column to give the user the mx/mn
+            # range of that set.
             elif (
-                curve_name != 'volume'
-                and not do_append
+                not do_px_step
                 and liv
                 and uppx >= 1
-                # even if we're downsampled bigly
-                # draw the last datum in the final
-                # px column to give the user the mx/mn
-                # range of that set.
             ):
                 # always update the last datum-element
                 # graphic for all vizs
-                # print(f'drawing last {viz.name}')
                 viz.draw_last(array_key=curve_name)
 
 
@@ -1145,7 +1154,6 @@ async def display_symbol_data(
         # for zoom-interaction purposes.
         hist_chart.get_viz(fqsn).draw_last(
             array_key=fqsn,
-            # only_last_uppx=True,
         )
         pis.setdefault(fqsn, [None, None])[1] = hist_chart.plotItem
 
@@ -1249,7 +1257,6 @@ async def display_symbol_data(
                 # for zoom-interaction purposes.
                 viz.draw_last(
                     array_key=fqsn,
-                    # only_last_uppx=True,
                 )
 
                 hist_pi.vb.maxmin = partial(

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -557,7 +557,7 @@ def graphics_update_cycle(
         (liv and do_px_step)
         or trigger_all
     ):
-        i_read_range, _ = main_viz.update_graphics()
+        _, i_read_range, _ = main_viz.update_graphics()
         profiler('`Viz.update_graphics()` call')
 
         (

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -90,7 +90,6 @@ log = get_logger(__name__)
 def chart_maxmin(
     chart: ChartPlotWidget,
     fqsn: str,
-    # ohlcv_shm: ShmArray,
     vlm_chart: ChartPlotWidget | None = None,
 
 ) -> tuple[
@@ -106,13 +105,18 @@ def chart_maxmin(
 
     '''
     main_viz = chart.get_viz(chart.name)
-    last_bars_range = main_viz.bars_range()
-    out = chart.maxmin(name=fqsn)
+    out = main_viz.maxmin()
 
     if out is None:
-        return (last_bars_range, 0, 0, 0)
+        return (0, 0, 0)
 
-    mn, mx = out
+    (
+        ixrng,
+        read_slc,
+        mxmn,
+    ) = out
+
+    mn, mx = mxmn
 
     mx_vlm_in_view = 0
 
@@ -125,10 +129,9 @@ def chart_maxmin(
             _, mx_vlm_in_view = out
 
     return (
-        last_bars_range,
         mx,
         max(mn, 0),  # presuming price can't be negative?
-        mx_vlm_in_view,
+        mx_vlm_in_view,  # vlm max
     )
 
 
@@ -226,7 +229,7 @@ async def increment_history_view(
                 do_append
                 and liv
             ):
-                hist_viz.plot.vb._set_yrange()
+                hist_viz.plot.vb._set_yrange(viz=hist_viz)
 
             # check if tread-in-place x-shift is needed
             if should_tread:
@@ -313,9 +316,7 @@ async def graphics_update_loop(
             fqsn,
             vlm_chart,
         )
-        last_bars_range: tuple[float, float]
         (
-            last_bars_range,
             last_mx,
             last_mn,
             last_mx_vlm,
@@ -502,12 +503,11 @@ def graphics_update_cycle(
     # TODO: we should only run mxmn when we know
     # an update is due via ``do_append`` above.
     (
-        brange,
         mx_in_view,
         mn_in_view,
         mx_vlm_in_view,
     ) = ds.maxmin()
-    l, lbar, rbar, r = brange
+
     mx = mx_in_view + tick_margin
     mn = mn_in_view - tick_margin
     profiler('`ds.maxmin()` call')
@@ -524,14 +524,12 @@ def graphics_update_cycle(
     ):
         chart.update_graphics_from_flow(
             fqsn,
-            # chart.name,
             # do_append=do_append,
         )
         main_viz.draw_last(array_key=fqsn)
 
         hist_chart.update_graphics_from_flow(
             fqsn,
-            # chart.name,
             # do_append=do_append,
         )
 
@@ -546,7 +544,7 @@ def graphics_update_cycle(
         or trigger_all
     ):
         chart.increment_view(datums=append_diff)
-        main_viz.plot.vb._set_yrange()
+        main_viz.plot.vb._set_yrange(viz=main_viz)
 
         # NOTE: since vlm and ohlc charts are axis linked now we don't
         # need the double increment request?
@@ -696,7 +694,7 @@ def graphics_update_cycle(
             is_1m=True,
         )
         if hist_liv:
-            hist_viz.plot.vb._set_yrange()
+            hist_viz.plot.vb._set_yrange(viz=hist_viz)
 
     # XXX: update this every draw cycle to make
     varz['last_mx'], varz['last_mn'] = mx, mn
@@ -711,7 +709,6 @@ def graphics_update_cycle(
             and not viz.is_ohlc
         ):
             update_fsp_chart(
-                chart,
                 viz,
                 curve_name,
                 array_key=curve_name,
@@ -794,7 +791,6 @@ def graphics_update_cycle(
                 # and curve_name != fqsn
             ):
                 update_fsp_chart(
-                    vlm_chart,
                     viz,
                     curve_name,
                     array_key=curve_name,
@@ -806,7 +802,7 @@ def graphics_update_cycle(
                 # resizing from last quote?)
                 fvb = viz.plot.vb
                 fvb._set_yrange(
-                    name=curve_name,
+                    viz=viz,
                 )
 
             elif (

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -1223,6 +1223,9 @@ async def display_symbol_data(
             #         add_label=False,
             #     )
 
+            godwidget.resize_all()
+            await trio.sleep(0)
+
             for fqsn, flume in fitems[1:]:
                 # get a new color from the palette
                 bg_chart_color, bg_last_bar_color = next(palette)
@@ -1382,9 +1385,11 @@ async def display_symbol_data(
                 # as final default UX touch.
                 rt_chart.default_view()
                 rt_chart.view.enable_auto_yrange()
+                await trio.sleep(0)
 
                 hist_chart.default_view()
                 hist_chart.view.enable_auto_yrange()
+                await trio.sleep(0)
 
                 godwidget.resize_all()
 

--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -122,7 +122,7 @@ def multi_maxmin(
     ) = out
 
     if profiler:
-        profiler('fast_viz.maxmin({read_slice})')
+        profiler(f'fast_viz.maxmin({read_slc})')
 
     mn, mx = yrange
 
@@ -143,7 +143,7 @@ def multi_maxmin(
             mx_vlm_in_view = mxmn[1]
 
         if profiler:
-            profiler('vlm_viz.maxmin({read_slc})')
+            profiler(f'vlm_viz.maxmin({read_slc})')
 
     return (
         mx,

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -685,33 +685,6 @@ async def open_vlm_displays(
             style='step',
         )
         vlm_viz = vlm_chart._vizs['volume']
-        # vlm_chart.view.enable_auto_yrange(
-        #     viz=vlm_viz,
-        # )
-
-        # force 0 to always be in view
-        def multi_maxmin(
-            names: list[str],
-
-        ) -> tuple[float, float]:
-            '''
-            Viz "group" maxmin loop; assumes all named flows
-            are in the same co-domain and thus can be sorted
-            as one set.
-
-            Iterates all the named flows and calls the chart
-            api to find their range values and return.
-
-            TODO: really we should probably have a more built-in API
-            for this?
-
-            '''
-            mx = 0
-            for name in names:
-                ymn, ymx = vlm_chart.maxmin(name=name)
-                mx = max(mx, ymx)
-
-            return 0, mx
 
         # TODO: fix the x-axis label issue where if you put
         # the axis on the left it's totally not lined up...
@@ -806,7 +779,7 @@ async def open_vlm_displays(
             dvlm_pi.hideAxis('bottom')
 
             # all to be overlayed curve names
-            fields = [
+            dvlm_fields = [
                'dolla_vlm',
                'dark_vlm',
             ]
@@ -818,16 +791,6 @@ async def open_vlm_displays(
                 'trade_rate',
                 'dark_trade_rate',
             ]
-
-            group_mxmn = partial(
-                multi_maxmin,
-                # keep both regular and dark vlm in view
-                names=fields,
-                # names=fields + dvlm_rate_fields,
-            )
-
-            # add custom auto range handler
-            # dvlm_pi.vb._maxmin = group_mxmn
 
             # add dvlm (step) curves to common view
             def chart_curves(
@@ -865,7 +828,7 @@ async def open_vlm_displays(
                     assert viz.plot is pi
 
             chart_curves(
-                fields,
+                dvlm_fields,
                 dvlm_pi,
                 dvlm_flume.rt_shm,
                 dvlm_flume,
@@ -925,12 +888,6 @@ async def open_vlm_displays(
                 },
 
             )
-            # add custom auto range handler
-            # tr_pi.vb.maxmin = partial(
-            #     multi_maxmin,
-            #     # keep both regular and dark vlm in view
-            #     names=trade_rate_fields,
-            # )
             tr_pi.hideAxis('bottom')
 
             chart_curves(

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -761,7 +761,7 @@ async def open_vlm_displays(
 
                 {  # fsp engine conf
                     'func_name': 'dolla_vlm',
-                    'zero_on_step': False,
+                    'zero_on_step': True,
                     'params': {
                         'price_func': {
                             'default_value': 'chl3',

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -734,7 +734,7 @@ async def open_vlm_displays(
 
         last_val_sticky.update_from_data(-1, value)
 
-        vlm_curve = vlm_chart.update_graphics_from_flow(
+        _, vlm_curve = vlm_chart.update_graphics_from_flow(
             'volume',
         )
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -78,7 +78,6 @@ def has_vlm(ohlcv: ShmArray) -> bool:
 
 
 def update_fsp_chart(
-    chart: ChartPlotWidget,
     viz,
     graphics_name: str,
     array_key: Optional[str],
@@ -101,18 +100,14 @@ def update_fsp_chart(
     # update graphics
     # NOTE: this does a length check internally which allows it
     # staying above the last row check below..
-    chart.update_graphics_from_flow(
-        graphics_name,
-        array_key=array_key or graphics_name,
-        **kwargs,
-    )
+    viz.update_graphics()
 
     # XXX: re: ``array_key``: fsp func names must be unique meaning we
     # can't have duplicates of the underlying data even if multiple
     # sub-charts reference it under different 'named charts'.
 
     # read from last calculated value and update any label
-    last_val_sticky = chart.plotItem.getAxis(
+    last_val_sticky = viz.plot.getAxis(
         'right')._stickies.get(graphics_name)
     if last_val_sticky:
         last = last_row[array_key]

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -707,7 +707,7 @@ async def open_vlm_displays(
 
         last_val_sticky.update_from_data(-1, value)
 
-        _, vlm_curve = vlm_chart.update_graphics_from_flow(
+        _, _, vlm_curve = vlm_chart.update_graphics_from_flow(
             'volume',
         )
 

--- a/piker/ui/_fsp.py
+++ b/piker/ui/_fsp.py
@@ -282,9 +282,10 @@ async def run_fsp_ui(
         # profiler(f'fsp:{name} chart created')
 
         # first UI update, usually from shm pushed history
+        viz = chart.get_viz(array_key)
         update_fsp_chart(
             chart,
-            chart.get_viz(array_key),
+            viz,
             name,
             array_key=array_key,
         )
@@ -311,7 +312,7 @@ async def run_fsp_ui(
         #     level_line(chart, 70, orient_v='bottom')
         #     level_line(chart, 80, orient_v='top')
 
-        chart.view._set_yrange()
+        chart.view._set_yrange(viz=viz)
         # done()  # status updates
 
         # profiler(f'fsp:{func_name} starting update loop')
@@ -665,7 +666,7 @@ async def open_vlm_displays(
         # built-in vlm which we plot ASAP since it's
         # usually data provided directly with OHLC history.
         shm = ohlcv
-        ohlc_chart = linked.chart
+        # ohlc_chart = linked.chart
 
         vlm_chart = linked.add_plot(
             name='volume',
@@ -683,13 +684,10 @@ async def open_vlm_displays(
             # the curve item internals are pretty convoluted.
             style='step',
         )
-        vlm_chart.view.enable_auto_yrange()
-
-        # back-link the volume chart to trigger y-autoranging
-        # in the ohlc (parent) chart.
-        ohlc_chart.view.enable_auto_yrange(
-            src_vb=vlm_chart.view,
-        )
+        vlm_viz = vlm_chart._vizs['volume']
+        # vlm_chart.view.enable_auto_yrange(
+        #     viz=vlm_viz,
+        # )
 
         # force 0 to always be in view
         def multi_maxmin(
@@ -741,7 +739,9 @@ async def open_vlm_displays(
         )
 
         # size view to data once at outset
-        vlm_chart.view._set_yrange()
+        vlm_chart.view._set_yrange(
+            viz=vlm_viz
+        )
 
         # add axis title
         axis = vlm_chart.getAxis('right')
@@ -827,7 +827,7 @@ async def open_vlm_displays(
             )
 
             # add custom auto range handler
-            dvlm_pi.vb._maxmin = group_mxmn
+            # dvlm_pi.vb._maxmin = group_mxmn
 
             # add dvlm (step) curves to common view
             def chart_curves(
@@ -926,11 +926,11 @@ async def open_vlm_displays(
 
             )
             # add custom auto range handler
-            tr_pi.vb.maxmin = partial(
-                multi_maxmin,
-                # keep both regular and dark vlm in view
-                names=trade_rate_fields,
-            )
+            # tr_pi.vb.maxmin = partial(
+            #     multi_maxmin,
+            #     # keep both regular and dark vlm in view
+            #     names=trade_rate_fields,
+            # )
             tr_pi.hideAxis('bottom')
 
             chart_curves(

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -45,6 +45,7 @@ from . import _event
 
 if TYPE_CHECKING:
     from ._chart import ChartPlotWidget
+    from ._dataviz import Viz
 
 
 log = get_logger(__name__)
@@ -728,6 +729,7 @@ class ChartView(ViewBox):
         *,
 
         yrange: Optional[tuple[float, float]] = None,
+        viz: Viz | None = None,
 
         # NOTE: this value pairs (more or less) with L1 label text
         # height offset from from the bid/ask lines.

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -21,7 +21,11 @@ Chart view box primitives
 from __future__ import annotations
 from contextlib import asynccontextmanager
 import time
-from typing import Optional, Callable
+from typing import (
+    Optional,
+    Callable,
+    TYPE_CHECKING,
+)
 
 import pyqtgraph as pg
 # from pyqtgraph.GraphicsScene import mouseEvents
@@ -38,6 +42,9 @@ from .._profile import pg_profile_enabled, ms_slower_then
 # from ._style import _min_points_to_show
 from ._editors import SelectRect
 from . import _event
+
+if TYPE_CHECKING:
+    from ._chart import ChartPlotWidget
 
 
 log = get_logger(__name__)
@@ -374,7 +381,7 @@ class ChartView(ViewBox):
         )
 
         self.linked = None
-        self._chart: 'ChartPlotWidget' = None  # noqa
+        self._chart: ChartPlotWidget | None = None  # noqa
 
         # add our selection box annotator
         self.select_box = SelectRect(self)
@@ -445,11 +452,11 @@ class ChartView(ViewBox):
             yield self
 
     @property
-    def chart(self) -> 'ChartPlotWidget':  # type: ignore # noqa
+    def chart(self) -> ChartPlotWidget:  # type: ignore # noqa
         return self._chart
 
     @chart.setter
-    def chart(self, chart: 'ChartPlotWidget') -> None:  # type: ignore # noqa
+    def chart(self, chart: ChartPlotWidget) -> None:  # type: ignore # noqa
         self._chart = chart
         self.select_box.chart = chart
         if self._maxmin is None:
@@ -783,11 +790,9 @@ class ChartView(ViewBox):
 
                 if yrange is None:
                     log.warning(f'No yrange provided for {name}!?')
-                    print(f"WTF NO YRANGE {name}")
                     return
 
             ylow, yhigh = yrange
-
             profiler(f'callback ._maxmin(): {yrange}')
 
             # view margins: stay within a % of the "true range"

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -467,7 +467,6 @@ class ChartView(ViewBox):
         self,
         ev,
         axis=None,
-        # relayed_from: ChartView = None,
     ):
         '''
         Override "center-point" location for scrolling.
@@ -482,7 +481,6 @@ class ChartView(ViewBox):
         if (
             not linked
         ):
-            # print(f'{self.name} not linked but relay from {relayed_from.name}')
             return
 
         if axis in (0, 1):
@@ -604,21 +602,8 @@ class ChartView(ViewBox):
         self,
         ev,
         axis: Optional[int] = None,
-        # relayed_from: ChartView = None,
 
     ) -> None:
-        # if relayed_from:
-        #     print(f'PAN: {self.name} -> RELAYED FROM: {relayed_from.name}')
-
-        # NOTE since in the overlay case axes are already
-        # "linked" any x-range change will already be mirrored
-        # in all overlaid ``PlotItems``, so we need to simply
-        # ignore the signal here since otherwise we get N-calls
-        # from N-overlays resulting in an "accelerated" feeling
-        # panning motion instead of the expect linear shift.
-        # if relayed_from:
-        #     return
-
         pos = ev.pos()
         lastPos = ev.lastPos()
         dif = pos - lastPos

--- a/piker/ui/_ohlc.py
+++ b/piker/ui/_ohlc.py
@@ -121,7 +121,7 @@ class BarItems(FlowGraphic):
 
         # XXX: causes this weird jitter bug when click-drag panning
         # where the path curve will awkwardly flicker back and forth?
-        # self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
+        self.setCacheMode(QtWidgets.QGraphicsItem.DeviceCoordinateCache)
 
         self.path = QPainterPath()
         self._last_bar_lines: tuple[QLineF, ...] | None = None

--- a/piker/ui/_render.py
+++ b/piker/ui/_render.py
@@ -211,17 +211,19 @@ class Renderer(msgspec.Struct):
 
             elif should_ds and uppx > 1:
 
-                x_1d, y_1d, ymn, ymx = xy_downsample(
+                ds_out = xy_downsample(
                     x_1d,
                     y_1d,
                     uppx,
                 )
-                self.viz.yrange = ymn, ymx
-                # print(f'{self.viz.name} post ds: ymn, ymx: {ymn},{ymx}')
+                if ds_out is not None:
+                    x_1d, y_1d, ymn, ymx = ds_out
+                    self.viz.yrange = ymn, ymx
+                    # print(f'{self.viz.name} post ds: ymn, ymx: {ymn},{ymx}')
 
-                reset = True
-                profiler(f'FULL PATH downsample redraw={should_ds}')
-                self._in_ds = True
+                    reset = True
+                    profiler(f'FULL PATH downsample redraw={should_ds}')
+                    self._in_ds = True
 
             path = self.draw_path(
                 x=x_1d,

--- a/piker/ui/_render.py
+++ b/piker/ui/_render.py
@@ -58,8 +58,8 @@ class Renderer(msgspec.Struct):
 
     # output graphics rendering, the main object
     # processed in ``QGraphicsObject.paint()``
-    path: Optional[QPainterPath] = None
-    fast_path: Optional[QPainterPath] = None
+    path: QPainterPath | None = None
+    fast_path: QPainterPath | None = None
 
     # XXX: just ideas..
     # called on the final data (transform) output to convert
@@ -81,7 +81,7 @@ class Renderer(msgspec.Struct):
         x: np.ndarray,
         y: np.ndarray,
         connect: str | np.ndarray = 'all',
-        path: Optional[QPainterPath] = None,
+        path: QPainterPath | None = None,
         redraw: bool = False,
 
     ) -> QPainterPath:
@@ -105,7 +105,7 @@ class Renderer(msgspec.Struct):
             # - https://doc.qt.io/qt-5/qpainterpath.html#reserve
             # - https://doc.qt.io/qt-5/qpainterpath.html#capacity
             # - https://doc.qt.io/qt-5/qpainterpath.html#clear
-            # XXX: right now this is based on had hoc checks on a
+            # XXX: right now this is based on ad-hoc checks on a
             # hidpi 3840x2160 4k monitor but we should optimize for
             # the target display(s) on the sys.
             # if no_path_yet:

--- a/piker/ui/_render.py
+++ b/piker/ui/_render.py
@@ -24,7 +24,6 @@ for fast incremental update.
 '''
 from __future__ import annotations
 from typing import (
-    Optional,
     TYPE_CHECKING,
 )
 
@@ -60,17 +59,6 @@ class Renderer(msgspec.Struct):
     # processed in ``QGraphicsObject.paint()``
     path: QPainterPath | None = None
     fast_path: QPainterPath | None = None
-
-    # XXX: just ideas..
-    # called on the final data (transform) output to convert
-    # to "graphical data form" a format that can be passed to
-    # the ``.draw()`` implementation.
-    # graphics_t: Optional[Callable[ShmArray, np.ndarray]] = None
-    # graphics_t_shm: Optional[ShmArray] = None
-
-    # path graphics update implementation methods
-    # prepend_fn: Optional[Callable[QPainterPath, QPainterPath]] = None
-    # append_fn: Optional[Callable[QPainterPath, QPainterPath]] = None
 
     # downsampling state
     _last_uppx: float = 0
@@ -218,7 +206,7 @@ class Renderer(msgspec.Struct):
         ):
             # print(f"{self.viz.name} -> REDRAWING BRUH")
             if new_sample_rate and showing_src_data:
-                log.info(f'DEDOWN -> {array_key}')
+                log.info(f'DE-downsampling -> {array_key}')
                 self._in_ds = False
 
             elif should_ds and uppx > 1:
@@ -269,10 +257,7 @@ class Renderer(msgspec.Struct):
             append_length > 0
             and do_append
         ):
-            print(f'{array_key} append len: {append_length}')
-            # new_x = x_1d[-append_length - 2:]  # slice_to_head]
-            # new_y = y_1d[-append_length - 2:]  # slice_to_head]
-            profiler('sliced append path')
+            profiler(f'sliced append path {append_length}')
             # (
             #     x_1d,
             #     y_1d,
@@ -300,22 +285,23 @@ class Renderer(msgspec.Struct):
             profiler('generated append qpath')
 
             if use_fpath:
-                # print(f'{self.viz.name}: FAST PATH')
                 # an attempt at trying to make append-updates faster..
                 if fast_path is None:
                     fast_path = append_path
                     # fast_path.reserve(int(6e3))
                 else:
+                    # print(
+                    #     f'{self.viz.name}: FAST PATH\n'
+                    #     f"append_path br: {append_path.boundingRect()}\n"
+                    #     f"path size: {size}\n"
+                    #     f"append_path len: {append_path.length()}\n"
+                    #     f"fast_path len: {fast_path.length()}\n"
+                    # )
+
                     fast_path.connectPath(append_path)
                     size = fast_path.capacity()
                     profiler(f'connected fast path w size: {size}')
 
-                    print(
-                        f"append_path br: {append_path.boundingRect()}\n"
-                        f"path size: {size}\n"
-                        f"append_path len: {append_path.length()}\n"
-                        f"fast_path len: {fast_path.length()}\n"
-                    )
                     # graphics.path.moveTo(new_x[0], new_y[0])
                     # path.connectPath(append_path)
 

--- a/piker/ui/_search.py
+++ b/piker/ui/_search.py
@@ -624,10 +624,10 @@ class SearchWidget(QtWidgets.QWidget):
         godw = self.godwidget
 
         # first entry in the cache is the current symbol(s)
-        fqsns = []
-
+        fqsns = set()
         for multi_fqsns in list(godw._chart_cache):
-            fqsns.extend(list(multi_fqsns))
+            for fqsn in set(multi_fqsns):
+                fqsns.add(fqsn)
 
         self.view.set_section_entries(
             'cache',


### PR DESCRIPTION
Like it sounds, improvements to speed up real-time update (displaying) and user interaction (mouse and keyboard ctls) for multi-feed overlay charts.

Obviously in support of #420 🏄🏼 

----
#### Lots of chart UI bug fixes included:
- query label fixes for epoch indexing
- fix duplicate search result entries when you load an fqsn already shown in an overlay chart

---

#### TLDR interaction perf;
- generally drop the display loop's "multi maxmin()" stuff instead delegating to the `Viz`
- ensure we use *only draw last uppx pixel column* style on updates when zoomed out enough
- [Only update last datum graphic(s) on clear ticks](https://github.com/pikers/piker/commit/5ed4e5c945446fbeff0f0d81b8561eaee6d4f219)
- always allocate throttle rate based on number of overlays with a max update per period capped at the detected display rate (eg. 4 symbols with 60Hz display is 60/4 = 15Hz per feed)
- add serious profiling to display loop and make it actually useful for digging into latency sources
- overlays API improvements
- use `Viz` update pipelines in the interaction handlers and display loop avoiding more-then-necessary x-domain time series reloading
- cache formatted xy 1d data for use in *last uppx pixel column* style updates to avoid recomputing max mins per bar
- generally delegate to the new `Viz` range calcing methods which were moved off the chart widget api and drop the whole `ChartView._maxmin()` overriding muck