### PR TITLE
NixOS development envoirment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ loaded with::
 
     nix-shell develop.nix
 
-this will setup the required python envoirment to run piker, make sure to
+this will setup the required python environment to run piker, make sure to
 run::
 
     pip install -r requirements.txt -e .

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,19 @@ for a development install::
     source ./env/bin/activate
     pip install -r requirements.txt -e .
 
+install for nixos
+*****************
+for users of `NixOS` we offer a development shell envoirment that can be
+loaded with::
+
+    nix-shell develop.nix
+
+this will setup the required python envoirment to run piker, make sure to
+run::
+
+    pip install -r requirements.txt -e .
+
+once after loading the shell
 
 install for tinas
 *****************

--- a/develop.nix
+++ b/develop.nix
@@ -22,5 +22,11 @@ stdenv.mkDerivation {
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${R}/lib/R/lib:${readline}/lib
 
     export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+
+    if [ ! -d "venv" ]; then
+        virtualenv venv
+    fi
+
+    source venv/bin/activate
   '';
 }

--- a/develop.nix
+++ b/develop.nix
@@ -1,0 +1,26 @@
+with (import <nixpkgs> {});
+with python310Packages;
+stdenv.mkDerivation {
+  name = "pip-env";
+  buildInputs = [
+    # System requirements.
+    readline
+
+    # Python requirements (enough to get a virtualenv going).
+    python310Full
+    virtualenv
+    setuptools
+    pyqt5
+    pip
+  ];
+  src = null;
+  shellHook = ''
+    # Allow the use of wheels.
+    SOURCE_DATE_EPOCH=$(date +%s)
+
+    # Augment the dynamic linker path
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${R}/lib/R/lib:${readline}/lib
+
+    export QT_QPA_PLATFORM_PLUGIN_PATH="${qt5.qtbase.bin}/lib/qt-${qt5.qtbase.version}/plugins";
+  '';
+}


### PR DESCRIPTION
Add development shell environment file for devs on NixOS.

To load shell run:

`nix-shell develop.nix`

The shell will create a `virtualenv` and load it automaticaly, once inside proceed with the regular piker development install:

`pip install -e . -r requirements.txt`

In case you get a filesystem error about not enough space try increasing the `tmpfs` partition size, if using `systemd` can be done by `logind` config by adding the following to the system's `.nix` configuration:

```
  services.logind.extraConfig = ''
    RuntimeDirectorySize=50%
  '';
```

This will increase `tmpfs` partition size to 50% of ram, which should be alright for most cases (4GB of ram+).