### PR TITLE
Update nix dev env to 3.11.1

### DIFF
--- a/develop.nix
+++ b/develop.nix
@@ -1,5 +1,5 @@
 with (import <nixpkgs> {});
-with python310Packages;
+with python311Packages;
 stdenv.mkDerivation {
   name = "pip-env";
   buildInputs = [
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     readline
 
     # Python requirements (enough to get a virtualenv going).
-    python310Full
+    python311
     virtualenv
     setuptools
     pyqt5


### PR DESCRIPTION
Can't really merge this yet cause `numba` hasnt updated its max version requirement to allow `3.11.1`, and nix package `python311` is hardcoded to `3.11.1`

:clown_face: 