### PR TITLE
Fix `loglevel` not getting propagated to `emsd`

### DIFF
--- a/piker/ui/_display.py
+++ b/piker/ui/_display.py
@@ -1437,7 +1437,8 @@ async def display_symbol_data(
                     feed,
                     godwidget,
                     fqsns[0],
-                    order_mode_started
+                    order_mode_started,
+                    loglevel=loglevel
                 ) as mode
             ):
 

--- a/piker/ui/order_mode.py
+++ b/piker/ui/order_mode.py
@@ -658,6 +658,7 @@ async def open_order_mode(
     godw: GodWidget,
     fqsn: str,
     started: trio.Event,
+    loglevel: str = 'info'
 
 ) -> None:
     '''Activate chart-trader order mode loop:
@@ -685,7 +686,7 @@ async def open_order_mode(
 
     # spawn EMS actor-service
     async with (
-        open_ems(fqsn) as (
+        open_ems(fqsn, loglevel=loglevel) as (
             book,
             trades_stream,
             position_msgs,


### PR DESCRIPTION
Quick one, while debugging decimal issues we realized no logs were getting printed from `emsd`, easy fix.