### PR TITLE
`binance`: use built-in `anext()` add note about new ws ep URL, fix agen streaming within `NoBsWs` usage

### DIFF
--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -531,17 +531,19 @@ async def stream_quotes(
 
         async with open_autorecon_ws(
             'wss://stream.binance.com/ws',
+            # XXX: see api docs which show diff addr?
+            # https://developers.binance.com/docs/binance-trading-api/websocket_api#general-api-information
+            # 'wss://ws-api.binance.com:443/ws-api/v3',
             fixture=subscribe,
         ) as ws:
 
             # pull a first quote and deliver
             msg_gen = stream_messages(ws)
 
-            typ, quote = await msg_gen.__anext__()
+            typ, quote = await anext(msg_gen)
 
             while typ != 'trade':
-                # TODO: use ``anext()`` when it lands in 3.10!
-                typ, quote = await msg_gen.__anext__()
+                typ, quote = await anext(msg_gen)
 
             task_status.started((init_msgs,  quote))
 

--- a/piker/brokers/binance.py
+++ b/piker/brokers/binance.py
@@ -26,7 +26,7 @@ from typing import (
 )
 import time
 
-from async_generator import aclosing
+from trio_util import trio_async_generator
 import trio
 from trio_typing import TaskStatus
 import pendulum
@@ -318,7 +318,10 @@ class AggTrade(Struct):
     M: bool  # Ignore
 
 
-async def stream_messages(ws: NoBsWs) -> AsyncGenerator[NoBsWs, dict]:
+@trio_async_generator
+async def stream_messages(
+    ws: NoBsWs,
+) -> AsyncGenerator[NoBsWs, dict]:
 
     timeouts = 0
     while True:
@@ -540,7 +543,7 @@ async def stream_quotes(
             ) as ws,
 
             # avoid stream-gen closure from breaking trio..
-            aclosing(stream_messages(ws)) as msg_gen,
+            stream_messages(ws) as msg_gen,
         ):
             typ, quote = await anext(msg_gen)
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         # async
         'trio',
         'trio-websocket',
+        'trio-util',
         'async_generator',
 
         # from github currently (see requirements.txt)


### PR DESCRIPTION
Not sure why this ain't workin for me (but maybe someone else can test
to verify?) but I tried updating the latest documented WS endpoint and
it doesn't seem to ever work 😂 

Further this starts using the new built-in `anext()` routines instead of
the dunders we had to use prior.

---
**ALSO** ~updates the streamer async-gen with an `aclosing()` which is
super critical to avoid `trio` crashes on re-connection logic!~

**INSTEAD** uses `@trio_util.trio_async_generator` which *actually*
solves the underlying issue of allowing an agen to work through multiple
cancel scopes as is needed by our `NoBsWs` reconnection logic.. **=> in [609b91e](https://github.com/pikers/piker/pull/473/commits/609b91e848740ab92a41a2666d1ca2c2f3c9ef9a)**
