### PR TITLE
Explicitly write `pps.toml` on exit for `ib` and `kraken`

### DIFF
--- a/piker/brokers/ib/broker.py
+++ b/piker/brokers/ib/broker.py
@@ -480,10 +480,17 @@ async def trades_dialogue(
                 # open ledger and pptable wrapper for each
                 # detected account.
                 ledger = ledgers[acctid] = lstack.enter_context(
-                    open_trade_ledger('ib', acctid)
+                    open_trade_ledger(
+                        'ib',
+                        acctid,
+                    )
                 )
                 table = tables[acctid] = lstack.enter_context(
-                    open_pps('ib', acctid)
+                    open_pps(
+                        'ib',
+                        acctid,
+                        write_on_exit=True,
+                    )
                 )
 
             for account, proxy in proxies.items():

--- a/piker/brokers/kraken/api.py
+++ b/piker/brokers/kraken/api.py
@@ -221,7 +221,7 @@ class Client:
 
     async def get_trades(
         self,
-        fetch_limit: int = 10,
+        fetch_limit: int | None = None,
 
     ) -> dict[str, Any]:
         '''
@@ -233,7 +233,10 @@ class Client:
         trades_by_id: dict[str, Any] = {}
 
         for i in itertools.count():
-            if i >= fetch_limit:
+            if (
+                fetch_limit
+                and i >= fetch_limit
+            ):
                 break
 
             # increment 'ofs' pagination offset
@@ -246,7 +249,8 @@ class Client:
             by_id = resp['result']['trades']
             trades_by_id.update(by_id)
 
-            # we can get up to 50 results per query
+            # can get up to 50 results per query, see:
+            # https://docs.kraken.com/rest/#tag/User-Data/operation/getTradeHistory
             if (
                 len(by_id) < 50
             ):

--- a/piker/brokers/kraken/broker.py
+++ b/piker/brokers/kraken/broker.py
@@ -470,6 +470,7 @@ async def trades_dialogue(
             open_pps(
                 'kraken',
                 acctid,
+                write_on_exit=True,
             ) as table,
 
             open_trade_ledger(
@@ -627,7 +628,7 @@ async def trades_dialogue(
                                         cost_scalar=1,
                                     )
                                     log.info(
-                                        'Updated {dst} from transfers:\n'
+                                        f'Updated {dst} from transfers:\n'
                                         f'{pformat(updated)}'
                                     )
 
@@ -1212,23 +1213,3 @@ def norm_trade_records(
         )
 
     return records
-
-
-@cm
-def open_ledger(
-    acctid: str,
-    trade_entries: list[dict[str, Any]],
-
-) -> set[Transaction]:
-    '''
-    Write recent session's trades to the user's (local) ledger file.
-
-    '''
-    with open_trade_ledger(
-        'kraken',
-        acctid,
-    ) as ledger:
-        yield ledger
-
-        # update on exit
-        ledger.update(trade_entries)


### PR DESCRIPTION
As per the default setting change to `.pp.open_pps()` to not write the TOML file on close, this adjusts the `ib` and `kraken` backends to set the write flag explicitly and indeed update the pps file on teardown.

Further, this includes the removal of the trades history record-limit since there seems to be no particular reason to halt on the last 10 transactions, though eventually we should probably expose this through the `brokers.toml`?