### PR TITLE
Backward compat support for `Transaction.sym: Symbol`

### DIFF
--- a/piker/brokers/ib/feed.py
+++ b/piker/brokers/ib/feed.py
@@ -770,7 +770,7 @@ async def stream_quotes(
 
             syminfo['price_tick_size'] = max(syminfo['minTick'], min_tick)
 
-            # for "traditional" assets, volume is normally discreet, not
+            # for "legacy" assets, volume is normally discreet, not
             # a float
             syminfo['lot_tick_size'] = 0.0
 

--- a/piker/brokers/kraken/broker.py
+++ b/piker/brokers/kraken/broker.py
@@ -48,6 +48,7 @@ from piker.pp import (
     open_trade_ledger,
     open_pps,
 )
+from piker.data._source import Symbol
 from piker.clearing._messages import (
     Order,
     Status,
@@ -1196,10 +1197,21 @@ def norm_trade_records(
         }[record['type']]
 
         # we normalize to kraken's `altname` always..
-        bsuid = norm_sym = Client.normalize_symbol(record['pair'])
+        bsuid, pair_info = Client.normalize_symbol(record['pair'])
+        fqsn = f'{bsuid}.kraken'
+
+        mktpair = Symbol.from_fqsn(
+            fqsn,
+            info={
+                'lot_size_digits': pair_info.lot_decimals,
+                'tick_size_digits': pair_info.pair_decimals,
+                'asset_type': 'crypto',
+            },
+        )
 
         records[tid] = Transaction(
-            fqsn=f'{norm_sym}.kraken',
+            fqsn=fqsn,
+            sym=mktpair,
             tid=tid,
             size=size,
             price=float(record['price']),


### PR DESCRIPTION
Like it sounds makes #470 still work on existing `pps.toml` files in the wild 😉 

Further this ports the `kraken` and `ib` backends to correctly provide the precision info for transaction sizes where possible by pulling the info from the market info available either from ledger or API records.

---
Additionally, this includes a draft implementation for a `.data._source.Symbol` replacement: `MktPair`.

It's not used at all but gives us a guide for how we could majorly simplify the interface and provide a much clearer defined market addressing system especially as it pertains to refining our schema as documented in #467.