### PR TITLE
Pps precision hotfixes

### DIFF
--- a/piker/brokers/kraken/feed.py
+++ b/piker/brokers/kraken/feed.py
@@ -453,7 +453,7 @@ async def open_symbol_search(
                     score_cutoff=50,
                 )
                 # repack in dict form
-                await stream.send(
-                    {item[0]['altname']: item[0]
-                     for item in matches}
-                )
+                await stream.send({
+                    pair[0].altname: pair[0]
+                    for pair in matches
+                })

--- a/piker/pp.py
+++ b/piker/pp.py
@@ -199,8 +199,16 @@ class Position(Struct):
         sym_info = s.broker_info[broker]
 
         d['asset_type'] = sym_info['asset_type']
-        d['price_tick_size'] = sym_info['price_tick_size']
-        d['lot_tick_size'] = sym_info['lot_tick_size']
+        d['price_tick_size'] = (
+            sym_info.get('price_tick_size')
+            or
+            s.tick_size
+        )
+        d['lot_tick_size'] = (
+            sym_info.get('lot_tick_size')
+            or
+            s.lot_tick_size
+        )
 
         if self.expiry is None:
             d.pop('expiry', None)


### PR DESCRIPTION
2 fixes broken by #470 and the sub-PR #477:

- [x] for `ib` positions backport, read precision fields from the `Symbol` directly first, then failover to the `.broker_info: dict`
- [x] in `kraken` we adjusted the internal pair info caching to store a table of `Pair`s not `dict`.. so adjust the search result processing to match!