### PR TITLE
`python3.11` support... ish.

### DIFF
--- a/piker/data/_sharedmem.py
+++ b/piker/data/_sharedmem.py
@@ -271,7 +271,7 @@ class ShmArray:
 
         # type that all field values will be cast to
         # in the returned view.
-        common_dtype: np.dtype = np.float,
+        common_dtype: np.dtype = float,
 
     ) -> np.ndarray:
 

--- a/piker/ui/_interaction.py
+++ b/piker/ui/_interaction.py
@@ -620,7 +620,7 @@ class ChartView(ViewBox):
         # Ignore axes if mouse is disabled
         mouseEnabled = np.array(
             self.state['mouseEnabled'],
-            dtype=np.float,
+            dtype=float,
         )
         mask = mouseEnabled.copy()
         if axis is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,6 @@
 # our async client for ``marketstore`` (the tsdb)
 -e git+https://github.com/pikers/anyio-marketstore.git@master#egg=anyio-marketstore
 
-
-# ``trimeter`` for asysnc history fetching
--e git+https://github.com/python-trio/trimeter.git@master#egg=trimeter
-
-
 # ``asyncvnc`` for sending interactions to ib-gw inside docker
 -e git+https://github.com/pikers/asyncvnc.git@main#egg=asyncvnc
 

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         'Intended Audience :: Financial and Insurance Industry',
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from setuptools import setup, find_packages
+from setuptools import (
+    setup,
+    find_packages,
+)
 
 with open('README.rst', encoding='utf-8') as f:
     readme = f.read()
@@ -57,13 +60,14 @@ setup(
         'async_generator',
 
         # from github currently (see requirements.txt)
-        # 'trimeter',  # not released yet..
+        # normally pinned to particular git hashes..
         # 'tractor',
-        # asyncvnc,
-        # 'cryptofeed',
+        # 'asyncvnc',
+        # 'pyqtgraph',
+        # anyio-marketstore  # mkts tsdb client
 
         # brokers
-        'asks',
+        'asks',  # for non-ws rest apis
         'ib_insync',
 
         # numerics
@@ -78,9 +82,6 @@ setup(
         # 'pyqtgraph',  from our fork see reqs.txt
         'qdarkstyle >= 3.0.2',  # themeing
         'fuzzywuzzy[speedup]',  # fuzzy search
-
-        # tsdbs
-        # anyio-marketstore  # from gh see reqs.txt
     ],
     extras_require={
         'tsdb': [


### PR DESCRIPTION
python 3.11 just landed on arch 🏄🏼 

Everything seems to be running fine for me with the small `numpy.float` removal 💥 

Please give it a shot if you've got a copy of the new cpython interpreter 😎 

----
#### wut's new bby!
https://docs.python.org/3/whatsnew/3.11.html