### PR TITLE
Fix price label precision as `MktPair.price_tick_digits`

### DIFF
--- a/piker/ui/_chart.py
+++ b/piker/ui/_chart.py
@@ -1235,10 +1235,10 @@ class ChartPlotWidget(pg.PlotWidget):
                 # if the sticky is for our symbol
                 # use the tick size precision for display
                 name = name or pi.name
-                sym = self.linked.mkt
-                digits = None
-                if name == sym.key:
-                    digits = sym.tick_size_digits
+                mkt: MktPair = self.linked.mkt
+                digits: int | None = None
+                if name in mkt.fqme:
+                    digits = mkt.price_tick_digits
 
                 # anchor_at = ('top', 'left')
 


### PR DESCRIPTION
A hot fix after #489 that wasn't caught (since we don't have UI tests yet..) 😂 

Was only really borked for higher-precision but lower priced assets (like TLOS or peeneez) which have a `MktPair.price_tick_digits >= 2`.

The issue was using the wrong attr, the `size_tick_digits`..