### PR TITLE
`msgspec` struct derivative updates

### DIFF
--- a/piker/data/types.py
+++ b/piker/data/types.py
@@ -18,7 +18,8 @@
 Built-in (extension) types.
 
 """
-import sys
+import builtins
+# import sys
 from pprint import pformat
 
 import msgspec
@@ -85,5 +86,11 @@ class Struct(
         self,
         # fields: list[str] | None = None,
     ) -> None:
-        for fname, ftype in self.__annotations__.items():
-            setattr(self, fname, ftype(getattr(self, fname)))
+        for fname, ftype_str in self.__annotations__.items():
+            ftype = getattr(builtins, ftype_str)
+            attr  = getattr(self, fname)
+            setattr(
+                self,
+                fname,
+                ftype(attr),
+            )

--- a/piker/data/types.py
+++ b/piker/data/types.py
@@ -1,5 +1,7 @@
 # piker: trading gear for hackers
-# Copyright (C) Guillermo Rodriguez (in stewardship for piker0)
+# Copyright (C) (in stewardship for pikers)
+#  - Tyler Goodlet
+#  - Guillermo Rodriguez
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -14,12 +16,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""
-Built-in (extension) types.
+'''
+Extensions to built-in or (heavily used but 3rd party) friend-lib
+types.
 
-"""
-import builtins
-# import sys
+'''
 from pprint import pformat
 
 from msgspec import (


### PR DESCRIPTION
Ran into some weird `.data.types.Struct.__annotations__` behavior while workin on #520 so ended up digging and finding the new `msgspec.structs` API(s) and instead re-implemented our type-casting methods using that.

More or less just a super simple delegation patch in the end 🥳 